### PR TITLE
Added math.poly and math.linear functionality to support mcad_analysis

### DIFF
--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -969,11 +969,8 @@ public:
         }
         return perm;
     }
-    /*
-     * Find the square of the L2 norm
-     * Sum of squares of the vector elements
-     */
-     _T normSq() const
+    // Addition made 5-13-15:
+    _T normSq() const
     {
         size_t sz = mM * mN;
         _T acc(0);
@@ -982,15 +979,28 @@ public:
             acc += mRaw[i] * mRaw[i];
         }
         return (const _T)acc;
+
     }
+
     /*!
      *  Find the L2 norm of the matrix.
      *  \return The norm
      */
     _T norm() const
     {
+        /*
+        size_t sz = mM * mN;
+        _T acc(0);
+        for (size_t i = 0; i < sz; ++i)
+        {
+            acc += mRaw[i] * mRaw[i];
+        }
+        */
+        //return (_T)::sqrt((const _T)acc);
         return (_T)::sqrt(normSq());
     }
+
+
     /*!
      *  Scale the entire matrix inplace by the L2 norm value.
      *  \return A reference to this

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -969,8 +969,11 @@ public:
         }
         return perm;
     }
-    // Addition made 5-13-15:
-    _T normSq() const
+    /*
+     * Find the square of the L2 norm
+     * Sum of squares of the vector elements
+     */
+     _T normSq() const
     {
         size_t sz = mM * mN;
         _T acc(0);
@@ -979,28 +982,15 @@ public:
             acc += mRaw[i] * mRaw[i];
         }
         return (const _T)acc;
-
     }
-
     /*!
      *  Find the L2 norm of the matrix.
      *  \return The norm
      */
     _T norm() const
     {
-        /*
-        size_t sz = mM * mN;
-        _T acc(0);
-        for (size_t i = 0; i < sz; ++i)
-        {
-            acc += mRaw[i] * mRaw[i];
-        }
-        */
-        //return (_T)::sqrt((const _T)acc);
         return (_T)::sqrt(normSq());
     }
-
-
     /*!
      *  Scale the entire matrix inplace by the L2 norm value.
      *  \return A reference to this
@@ -1338,3 +1328,4 @@ template<typename _T>
 
 
 #endif
+

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -969,12 +969,11 @@ public:
         }
         return perm;
     }
-
-    /*!
-     *  Find the L2 norm of the matrix.
-     *  \return The norm
+    /*
+     * Find the square of the L2 norm
+     * Sum of squares of the vector elements
      */
-    _T norm() const
+     _T normSq() const
     {
         size_t sz = mM * mN;
         _T acc(0);
@@ -982,9 +981,16 @@ public:
         {
             acc += mRaw[i] * mRaw[i];
         }
-        return (_T)::sqrt((const _T)acc);
+        return (const _T)acc;
     }
-
+    /*!
+     *  Find the L2 norm of the matrix.
+     *  \return The norm
+     */
+    _T norm() const
+    {
+        return (_T)::sqrt(normSq());
+    }
     /*!
      *  Scale the entire matrix inplace by the L2 norm value.
      *  \return A reference to this

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -981,7 +981,7 @@ public:
         {
             acc += mRaw[i] * mRaw[i];
         }
-        return (const _T)acc;
+        return acc;
     }
     /*!
      *  Find the L2 norm of the matrix.
@@ -989,7 +989,7 @@ public:
      */
     _T norm() const
     {
-        return (_T)::sqrt(normSq());
+        return static_cast<_T>(std::sqrt(normSq()));
     }
     /*!
      *  Scale the entire matrix inplace by the L2 norm value.

--- a/modules/c++/math.linear/include/math/linear/MatrixMxN.h
+++ b/modules/c++/math.linear/include/math/linear/MatrixMxN.h
@@ -1079,7 +1079,7 @@ public:
                 acc += mRaw[i][j] * mRaw[i][j];
             }
         }
-        return static_cast<_T>(acc);
+        return acc;
     }
     /*!
      *  Find the L2 norm of the matrix.

--- a/modules/c++/math.linear/include/math/linear/MatrixMxN.h
+++ b/modules/c++/math.linear/include/math/linear/MatrixMxN.h
@@ -1065,11 +1065,11 @@ public:
         }
         return perm;
     }
-    /*!
-     *  Find the L2 norm of the matrix.
-     *  \return The norm
+    /*
+     * Find the square of the L2 norm
+     * Sum of squares of the vector elements
      */
-    _T norm() const
+    _T normSq() const
     {
         _T acc(0);
         for (size_t i = 0; i < _MD; ++i)
@@ -1079,7 +1079,15 @@ public:
                 acc += mRaw[i][j] * mRaw[i][j];
             }
         }
-        return static_cast<_T>(::sqrt(acc));
+        return static_cast<_T>(acc);
+    }
+    /*!
+     *  Find the L2 norm of the matrix.
+     *  \return The norm
+     */
+    _T norm() const
+    {
+        return static_cast<_T>(::sqrt(normSq()));
     }
 
     /*!

--- a/modules/c++/math.linear/include/math/linear/Vector.h
+++ b/modules/c++/math.linear/include/math/linear/Vector.h
@@ -232,16 +232,28 @@ public:
         }
         return acc;
     }
-
+    
+    _T angle(const Vector& v) const
+    {
+        _T val = ((*this * v) / norm()) / v.norm();
+        if (val > 1.0) val = 1.0;
+        if (val < -1.0) val = -1.0;
+        return (std::acos(val));
+    }
+    
+    _T normSq() const
+    {
+        return mRaw.normSq();
+    }
+    
     /*!
      * Euclidean, L2 norm
      */
     _T norm() const
     {
-
+     
         return mRaw.norm();
     }
-
     //!  Normalize a value
     void normalize()
     {

--- a/modules/c++/math.linear/include/math/linear/Vector.h
+++ b/modules/c++/math.linear/include/math/linear/Vector.h
@@ -23,6 +23,7 @@
 #define __MATH_LINEAR_VECTOR_H__
 
 #include "math/linear/Matrix2D.h"
+#include <cmath>
 
 namespace math
 {

--- a/modules/c++/math.linear/include/math/linear/Vector.h
+++ b/modules/c++/math.linear/include/math/linear/Vector.h
@@ -236,9 +236,7 @@ public:
     _T angle(const Vector& v) const
     {
         _T val = ((*this * v) / norm()) / v.norm();
-        if (val > 1.0) val = 1.0;
-        if (val < -1.0) val = -1.0;
-        return (std::acos(val));
+        return std::acos(std::max(-1.0, std::min(val, 1.0)));
     }
     
     _T normSq() const

--- a/modules/c++/math.linear/include/math/linear/Vector.h
+++ b/modules/c++/math.linear/include/math/linear/Vector.h
@@ -245,13 +245,11 @@ public:
     {
         return mRaw.normSq();
     }
-    
     /*!
      * Euclidean, L2 norm
      */
     _T norm() const
     {
-     
         return mRaw.norm();
     }
     //!  Normalize a value

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -23,7 +23,7 @@
 #define __MATH_LINEAR_VECTOR_N_H__
 
 #include "math/linear/MatrixMxN.h"
-#include <math.h>
+#include <cmath>
 
 namespace math
 {

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -219,15 +219,14 @@ public:
         return mRaw.normSq();
     }
     /*
-     * Angle between this VectorN and v
+     * Angle between this vector and v
      */
-    _T angle(Like_T v) const
+    _T angle(const Like_T& v) const
     {
-        _T val = dot(v) / norm()/ v.norm();
-        if (val > 1.0) val = 1.0;
-        if (val < -1.0) val = -1.0;
-        return (std::acos(val));
+        _T val = ((*this * v) / norm()) / v.norm();
+        return std::acos(std::max(-1.0, std::min(val, 1.0)));
     }
+    
     void normalize()
     {
         mRaw.normalize();

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -23,6 +23,7 @@
 #define __MATH_LINEAR_VECTOR_N_H__
 
 #include "math/linear/MatrixMxN.h"
+#include <math.h>
 
 namespace math
 {
@@ -202,6 +203,7 @@ public:
         const _T dotProduct = dot(vec) / (norm() * vec.norm());
         return std::max<_T>(std::min<_T>(dotProduct, 1.0), -1.0);
     }
+
     /*!
      * Euclidean, L2 norm
      */
@@ -209,20 +211,17 @@ public:
     {
         return mRaw.norm();
     }
-    /* 
-     * Euclidean, L2 norm squared
-     * Sum of the squares of the vector elements
-     */
+
+    // Addition made 5-13-15:
     _T normSq() const
     {
         return mRaw.normSq();
+
     }
-    /*
-    * Returns the angle to another VectorN
-    */
+    // Addition made 5-13-15:
     _T angle(Like_T v) const
     {
-        _T val = ((*this * v) / norm()) / v.norm();
+        _T val = dot(v) / norm()/ v.norm();
         if (val > 1.0) val = 1.0;
         if (val < -1.0) val = -1.0;
         return (std::acos(val));
@@ -366,8 +365,6 @@ template<size_t _ND, typename _T> VectorN<_ND, _T>
     return v;
 }
 
-}
-}
 
 template<size_t _MD, size_t _ND, typename _T> 
     math::linear::VectorN<_MD, _T>
@@ -384,7 +381,7 @@ template<size_t _ND, typename _T> math::linear::VectorN<_ND, _T>
 }
 
 
-template<size_t _ND, typename _T> 
+template<size_t _ND, typename _T>
     std::ostream& operator<<(std::ostream& os,
                              const math::linear::VectorN<_ND, _T>& v)
 {
@@ -395,5 +392,9 @@ template<size_t _ND, typename _T>
     return os;
     
 }
+} //linear
+} //math
+
+
 
 #endif

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -398,3 +398,4 @@ template<size_t _ND, typename _T>
 } //math
 
 #endif
+

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -202,7 +202,6 @@ public:
         const _T dotProduct = dot(vec) / (norm() * vec.norm());
         return std::max<_T>(std::min<_T>(dotProduct, 1.0), -1.0);
     }
-
     /*!
      * Euclidean, L2 norm
      */
@@ -210,7 +209,24 @@ public:
     {
         return mRaw.norm();
     }
-
+    /* 
+     * Euclidean, L2 norm squared
+     * Sum of the squares of the vector elements
+     */
+    _T normSq() const
+    {
+        return mRaw.normSq();
+    }
+    /*
+    * Returns the angle to another VectorN
+    */
+    _T angle(Like_T v) const
+    {
+        _T val = ((*this * v) / norm()) / v.norm();
+        if (val > 1.0) val = 1.0;
+        if (val < -1.0) val = -1.0;
+        return (std::acos(val));
+    }
     void normalize()
     {
         mRaw.normalize();

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -211,14 +211,16 @@ public:
     {
         return mRaw.norm();
     }
-
-    // Addition made 5-13-15:
+    /*
+     * Square of the Euclidean norm,
+     */
     _T normSq() const
     {
         return mRaw.normSq();
-
     }
-    // Addition made 5-13-15:
+    /*
+     * Angle between this VectorN and v
+     */
     _T angle(Like_T v) const
     {
         _T val = dot(v) / norm()/ v.norm();
@@ -394,7 +396,5 @@ template<size_t _ND, typename _T>
 }
 } //linear
 } //math
-
-
 
 #endif

--- a/modules/c++/math.poly/include/math/poly/OneD.h
+++ b/modules/c++/math.poly/include/math/poly/OneD.h
@@ -1,24 +1,4 @@
-/* =========================================================================
  * This file is part of math.poly-c++ 
- * =========================================================================
- * 
- * (C) Copyright 2004 - 2014, MDA Information Systems LLC
- *
- * math.poly-c++ is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation; either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
- * see <http://www.gnu.org/licenses/>.
- *
- */
 
 #ifndef __MATH_POLY_ONED_H__
 #define __MATH_POLY_ONED_H__
@@ -132,7 +112,6 @@ public:
     {
         return mCoef.empty();
     }
-
     /*!
      * Returns a scaled polynomial such that
      * P'(x) = P(x * scale)
@@ -193,30 +172,31 @@ public:
      * \param p The polynomial to copy from.
      */
     void copyFrom(const OneD<_T>& p);
-
     _T operator ()(double at) const;
     _T integrate(double start, double end) const;
     OneD<_T>derivative() const;
+    // Additions 5-14-15
+    _T velocity(double x) const;
+    _T acceleration(double x) const;
+
     _T& operator[](size_t i);
     _T operator[](size_t i) const;
-    template<typename _TT>
-    friend std::ostream& operator <<(std::ostream& out, const OneD<_TT>& p);
     OneD<_T>& operator *=(double cv);
     OneD<_T>operator *(double cv) const;
     template<typename _TT>
     friend OneD<_TT>operator *(double cv, const OneD<_TT>& p);
     OneD<_T>& operator *=(const OneD<_T>& p);
-    OneD<_T>operator *(const OneD<_T>& p) const;
+    OneD<_T>operator *(const math::poly::OneD<_T>& p) const;
     OneD<_T>& operator +=(const OneD<_T>& p);
     OneD<_T>operator +(const OneD<_T>& p) const;
     OneD<_T>& operator -=(const OneD<_T>& p);
     OneD<_T>operator -(const OneD<_T>& p) const;
     OneD<_T>& operator /=(double cv);
     OneD<_T>operator /(double cv) const;
-
     OneD<_T> power(size_t toThe) const;
 
-    template<typename Vector_T> bool operator==(const Vector_T& p) const
+    template<typename Vector_T>
+    bool operator==(const Vector_T& p) const
     {
         size_t sz = size();
         size_t psz = p.size();
@@ -255,8 +235,12 @@ public:
         return !(*this == p);
     }
 };
-
 } // poly
 } // math
+
+template<typename _TT>
+friend std::ostream& operator <<(std::ostream& out, const math::poly::OneD<_TT>& p);
+
+
 #include "math/poly/OneD.hpp"
 #endif

--- a/modules/c++/math.poly/include/math/poly/OneD.h
+++ b/modules/c++/math.poly/include/math/poly/OneD.h
@@ -132,6 +132,7 @@ public:
     {
         return mCoef.empty();
     }
+
     /*!
      * Returns a scaled polynomial such that
      * P'(x) = P(x * scale)
@@ -192,31 +193,33 @@ public:
      * \param p The polynomial to copy from.
      */
     void copyFrom(const OneD<_T>& p);
+
     _T operator ()(double at) const;
     _T integrate(double start, double end) const;
     OneD<_T>derivative() const;
-    // Additions 5-14-15
     _T velocity(double x) const;
     _T acceleration(double x) const;
-
     _T& operator[](size_t i);
     _T operator[](size_t i) const;
     OneD<_T>& operator *=(double cv);
     OneD<_T>operator *(double cv) const;
     template<typename _TT>
-    friend OneD<_TT>operator *(double cv, const OneD<_TT>& p);
+    friend std::ostream& operator <<(std::ostream& out, const OneD<_TT>& p);
+    template<typename _TT>
+    friend math::poly::OneD<_TT>operator *(double cv, const OneD<_TT>& p);
+
     OneD<_T>& operator *=(const OneD<_T>& p);
-    OneD<_T>operator *(const math::poly::OneD<_T>& p) const;
+    OneD<_T>operator *(const OneD<_T>& p) const;
     OneD<_T>& operator +=(const OneD<_T>& p);
     OneD<_T>operator +(const OneD<_T>& p) const;
     OneD<_T>& operator -=(const OneD<_T>& p);
     OneD<_T>operator -(const OneD<_T>& p) const;
     OneD<_T>& operator /=(double cv);
     OneD<_T>operator /(double cv) const;
+
     OneD<_T> power(size_t toThe) const;
 
-    template<typename Vector_T>
-    bool operator==(const Vector_T& p) const
+    template<typename Vector_T> bool operator==(const Vector_T& p) const
     {
         size_t sz = size();
         size_t psz = p.size();
@@ -255,12 +258,9 @@ public:
         return !(*this == p);
     }
 };
+
 } // poly
 } // math
-
-template<typename _TT>
-friend std::ostream& operator <<(std::ostream& out, const math::poly::OneD<_TT>& p);
-
 
 #include "math/poly/OneD.hpp"
 #endif

--- a/modules/c++/math.poly/include/math/poly/OneD.h
+++ b/modules/c++/math.poly/include/math/poly/OneD.h
@@ -1,4 +1,24 @@
+/* =========================================================================
  * This file is part of math.poly-c++ 
+ * =========================================================================
+ * 
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * math.poly-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this program; If not, 
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
 
 #ifndef __MATH_POLY_ONED_H__
 #define __MATH_POLY_ONED_H__

--- a/modules/c++/math.poly/include/math/poly/OneD.h
+++ b/modules/c++/math.poly/include/math/poly/OneD.h
@@ -206,7 +206,7 @@ public:
     OneD<_T>& operator *=(double cv);
     OneD<_T>operator *(double cv) const;
     template<typename _TT>
-    friend math::poly::OneD<_TT>operator *(double cv, const OneD<_TT>& p);
+    friend OneD<_TT>operator *(double cv, const OneD<_TT>& p);
     OneD<_T>& operator *=(const OneD<_T>& p);
     OneD<_T>operator *(const OneD<_T>& p) const;
     OneD<_T>& operator +=(const OneD<_T>& p);

--- a/modules/c++/math.poly/include/math/poly/OneD.h
+++ b/modules/c++/math.poly/include/math/poly/OneD.h
@@ -201,13 +201,12 @@ public:
     _T acceleration(double x) const;
     _T& operator[](size_t i);
     _T operator[](size_t i) const;
+    template<typename _TT>
+    friend std::ostream& operator <<(std::ostream& out, const OneD<_TT>& p);
     OneD<_T>& operator *=(double cv);
     OneD<_T>operator *(double cv) const;
     template<typename _TT>
-    friend std::ostream& operator <<(std::ostream& out, const OneD<_TT>& p);
-    template<typename _TT>
     friend math::poly::OneD<_TT>operator *(double cv, const OneD<_TT>& p);
-
     OneD<_T>& operator *=(const OneD<_T>& p);
     OneD<_T>operator *(const OneD<_T>& p) const;
     OneD<_T>& operator +=(const OneD<_T>& p);
@@ -261,6 +260,5 @@ public:
 
 } // poly
 } // math
-
 #include "math/poly/OneD.hpp"
 #endif

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -132,7 +132,16 @@ OneD<_T>::operator [] (size_t i) const
    return ret;
 }
 
-
+template<typename _T>
+std::ostream&
+operator << (std::ostream& out, const OneD<_T>& p)
+{
+   for (size_t i = 0 ; i < p.mCoef.size() ; i++)
+   {
+      out << p[i] << "*y^" << i << " ";
+   }
+   return out;
+}
 
 template<typename _T>
 OneD<_T>&
@@ -347,14 +356,5 @@ void OneD<_T>::copyFrom(const OneD<_T>& p)
 } // poly
 } // math
 
-template<typename _T>
-std::ostream&
-operator << (std::ostream& out, const math::poly::OneD<_T>& p)
-{
-   for (size_t i = 0 ; i < p.mCoef.size() ; i++)
-   {
-      out << p[i] << "*y^" << i << " ";
-   }
-   return out;
-}
+
 

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -80,7 +80,6 @@ OneD<_T>::derivative() const
     }
     return ret;
 }
-
 template<typename _T>
 _T
 OneD<_T>::velocity(double x) const
@@ -88,7 +87,6 @@ OneD<_T>::velocity(double x) const
    _T temp;
    return temp;
 }
-
 template<typename _T>
 _T
 OneD<_T>::acceleration(double x) const
@@ -97,8 +95,7 @@ OneD<_T>::acceleration(double x) const
     return temp;
 
 }
-} // poly
-} // math
+
 template<typename _T>
 _T& 
 math::poly::OneD<_T>::operator [] (size_t i)
@@ -135,18 +132,6 @@ math::poly::OneD<_T>::operator [] (size_t i) const
       throw except::IndexOutOfRangeException(Ctxt(msg));
    }
    return ret;
-}
-
-
-template<typename _T>
-std::ostream& 
-operator << (std::ostream& out, const math::poly::OneD<_T>& p)
-{
-   for (size_t i = 0 ; i < p.mCoef.size() ; i++)
-   {
-      out << p[i] << "*y^" << i << " ";
-   }
-   return out;
 }
 
 template<typename _T>
@@ -365,3 +350,17 @@ math::poly::OneD<_T>::copyFrom(const OneD<_T>& p)
     std::copy(p.mCoef.begin(), p.mCoef.begin() + numCopy, mCoef.begin());
 }
 
+
+} // poly
+} // math
+
+template<typename _T>
+std::ostream&
+operator << (std::ostream& out, const math::poly::OneD<_T>& p)
+{
+   for (size_t i = 0 ; i < p.mCoef.size() ; i++)
+   {
+      out << p[i] << "*y^" << i << " ";
+   }
+   return out;
+}

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -353,6 +353,7 @@ void OneD<_T>::copyFrom(const OneD<_T>& p)
     const size_t numCopy(std::min(size(), p.size()));
     std::copy(p.mCoef.begin(), p.mCoef.begin() + numCopy, mCoef.begin());
 }
+
 } // poly
 } // math
 

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -82,8 +82,26 @@ OneD<_T>::derivative() const
 }
 
 template<typename _T>
+_T
+OneD<_T>::velocity(double x) const
+{
+   _T temp;
+   return temp;
+}
+
+template<typename _T>
+_T
+OneD<_T>::acceleration(double x) const
+{
+    _T temp;
+    return temp;
+
+}
+} // poly
+} // math
+template<typename _T>
 _T& 
-OneD<_T>::operator [] (size_t i)
+math::poly::OneD<_T>::operator [] (size_t i)
 {
     if (i < mCoef.size())
     {
@@ -102,7 +120,7 @@ OneD<_T>::operator [] (size_t i)
 
 template<typename _T>
 _T 
-OneD<_T>::operator [] (size_t i) const
+math::poly::OneD<_T>::operator [] (size_t i) const
 {
    _T ret(0.0);
    if (i < mCoef.size())
@@ -119,9 +137,10 @@ OneD<_T>::operator [] (size_t i) const
    return ret;
 }
 
+
 template<typename _T>
 std::ostream& 
-operator << (std::ostream& out, const OneD<_T>& p)
+operator << (std::ostream& out, const math::poly::OneD<_T>& p)
 {
    for (size_t i = 0 ; i < p.mCoef.size() ; i++)
    {
@@ -131,8 +150,8 @@ operator << (std::ostream& out, const OneD<_T>& p)
 }
 
 template<typename _T>
-OneD<_T>& 
-OneD<_T>::operator *= (double cv) 
+math::poly::OneD<_T>&
+math::poly::OneD<_T>::operator *= (double cv)
 {
     for (size_t i = 0, sz = mCoef.size() ; i < sz; i++)
     {
@@ -142,8 +161,8 @@ OneD<_T>::operator *= (double cv)
 }
     
 template<typename _T>
-OneD<_T> 
-OneD<_T>::operator * (double cv) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::operator * (double cv) const
 {
     OneD<_T> ret(*this);
     ret *= cv;
@@ -151,15 +170,15 @@ OneD<_T>::operator * (double cv) const
 }
 
 template<typename _T>
-OneD<_T> 
-operator * (double cv, const OneD<_T>& p) 
+math::poly::OneD<_T>
+operator * (double cv, const math::poly::OneD<_T>& p)
 {
     return p*cv;
 }
 
 template<typename _T>
-OneD<_T>& 
-OneD<_T>::operator *= (const OneD<_T>& p) 
+math::poly::OneD<_T>&
+math::poly::OneD<_T>::operator *= (const OneD<_T>& p)
 {
    OneD<_T> tmp(order()+p.order());
    for (size_t i = 0, xsz = mCoef.size() ; i < xsz; i++)
@@ -174,8 +193,8 @@ OneD<_T>::operator *= (const OneD<_T>& p)
 }
     
 template<typename _T>
-OneD<_T> 
-OneD<_T>::operator * (const OneD<_T>& p) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::operator * (const OneD<_T>& p) const
 {
     OneD<_T> ret(*this);
     ret *= p;
@@ -183,8 +202,8 @@ OneD<_T>::operator * (const OneD<_T>& p) const
 }
 
 template<typename _T>
-OneD<_T>& 
-OneD<_T>::operator += (const OneD<_T>& p) 
+math::poly::OneD<_T>&
+math::poly::OneD<_T>::operator += (const OneD<_T>& p)
 {
     OneD<_T> tmp(std::max<size_t>(order(), p.order()));
     for (size_t i = 0, sz = mCoef.size() ; i < sz; i++)
@@ -200,8 +219,8 @@ OneD<_T>::operator += (const OneD<_T>& p)
 }
 
 template<typename _T>
-OneD<_T> 
-OneD<_T>::operator + (const OneD<_T>& p) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::operator + (const OneD<_T>& p) const
 {
     OneD<_T> ret(*this);
     ret += p;
@@ -209,8 +228,8 @@ OneD<_T>::operator + (const OneD<_T>& p) const
 }
     
 template<typename _T>
-OneD<_T>& 
-OneD<_T>::operator -= (const OneD<_T>& p) 
+math::poly::OneD<_T>&
+math::poly::OneD<_T>::operator -= (const OneD<_T>& p)
 {
    OneD<_T> tmp(std::max<size_t>(order(), p.order()));
    for (unsigned int i = 0, sz = mCoef.size() ; i < sz; i++)
@@ -226,8 +245,8 @@ OneD<_T>::operator -= (const OneD<_T>& p)
 }
 
 template<typename _T>
-OneD<_T> 
-OneD<_T>::operator - (const OneD<_T>& p) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::operator - (const OneD<_T>& p) const
 {
    OneD<_T> ret(*this);
    ret -= p;
@@ -235,8 +254,8 @@ OneD<_T>::operator - (const OneD<_T>& p) const
 }
 
 template<typename _T>
-OneD<_T>& 
-OneD<_T>::operator /= (double cv) 
+math::poly::OneD<_T>&
+math::poly::OneD<_T>::operator /= (double cv)
 {
     double recipCV = 1.0/cv;
     for (unsigned int i = 0, sz = mCoef.size() ; i < sz; i++)
@@ -247,8 +266,8 @@ OneD<_T>::operator /= (double cv)
 }
 
 template<typename _T>
-OneD<_T> 
-OneD<_T>::operator / (double cv) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::operator / (double cv) const
 {
     OneD<_T> ret(*this);
     ret *= (1.0/cv);
@@ -256,7 +275,8 @@ OneD<_T>::operator / (double cv) const
 }
 
 template<typename _T>
-OneD<_T> OneD<_T>::power(size_t toThe) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::power(size_t toThe) const
 {
     // If its 0, we have to give back a 1*x^0 poly, since
     // we want a 2D poly out
@@ -283,13 +303,14 @@ OneD<_T> OneD<_T>::power(size_t toThe) const
 }
 
 template<typename _T>
-OneD<_T> OneD<_T>::scaleVariable(double scale) const
+math::poly::OneD<_T> math::poly::OneD<_T>::scaleVariable(double scale) const
 {
     return ::math::poly::scaleVariable<OneD<_T> >(*this, scale);
 }
 
 template<typename _T>
-OneD<_T> OneD<_T>::truncateTo(size_t order) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::truncateTo(size_t order) const
 {
     order = std::min(this->order(), order);
 
@@ -302,7 +323,8 @@ OneD<_T> OneD<_T>::truncateTo(size_t order) const
 }
 
 template<typename _T>
-OneD<_T> OneD<_T>::truncateToNonZeros(double zeroEpsilon) const
+math::poly::OneD<_T>
+math::poly::OneD<_T>::truncateToNonZeros(double zeroEpsilon) const
 {
     zeroEpsilon = std::abs(zeroEpsilon);
     size_t newOrder(0);
@@ -321,7 +343,8 @@ OneD<_T> OneD<_T>::truncateToNonZeros(double zeroEpsilon) const
 }
 
 template<typename _T>
-OneD<_T> OneD<_T>::transformInput(const OneD<_T>& gx,
+math::poly::OneD<_T>
+math::poly::OneD<_T>::transformInput(const OneD<_T>& gx,
                                   double zeroEpsilon) const
 {
     OneD<_T> newP(order());
@@ -335,11 +358,10 @@ OneD<_T> OneD<_T>::transformInput(const OneD<_T>& gx,
 }
 
 template<typename _T>
-void OneD<_T>::copyFrom(const OneD<_T>& p)
+void
+math::poly::OneD<_T>::copyFrom(const OneD<_T>& p)
 {
     const size_t numCopy(std::min(size(), p.size()));
     std::copy(p.mCoef.begin(), p.mCoef.begin() + numCopy, mCoef.begin());
 }
 
-} // poly
-} // math

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -84,14 +84,14 @@ template<typename _T>
 _T
 OneD<_T>::velocity(double x) const
 {
-    _T vel = ((*this).derivative())(x);
+    _T vel = derivative()(x);
     return vel;
 }
 template<typename _T>
 _T
 OneD<_T>::acceleration(double x) const
 {
-    _T acc = ( ((*this).derivative()).derivative() )(x);
+    _T acc = ((derivative()).derivative())(x);
     return acc;
 }
 template<typename _T>

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -84,21 +84,19 @@ template<typename _T>
 _T
 OneD<_T>::velocity(double x) const
 {
-   _T temp;
-   return temp;
+    _T vel = ((*this).derivative())(x);
+    return vel;
 }
 template<typename _T>
 _T
 OneD<_T>::acceleration(double x) const
 {
-    _T temp;
-    return temp;
-
+    _T acc = ( ((*this).derivative()).derivative() )(x);
+    return acc;
 }
-
 template<typename _T>
 _T& 
-math::poly::OneD<_T>::operator [] (size_t i)
+OneD<_T>::operator [] (size_t i)
 {
     if (i < mCoef.size())
     {
@@ -117,7 +115,7 @@ math::poly::OneD<_T>::operator [] (size_t i)
 
 template<typename _T>
 _T 
-math::poly::OneD<_T>::operator [] (size_t i) const
+OneD<_T>::operator [] (size_t i) const
 {
    _T ret(0.0);
    if (i < mCoef.size())
@@ -134,9 +132,11 @@ math::poly::OneD<_T>::operator [] (size_t i) const
    return ret;
 }
 
+
+
 template<typename _T>
-math::poly::OneD<_T>&
-math::poly::OneD<_T>::operator *= (double cv)
+OneD<_T>&
+OneD<_T>::operator *= (double cv)
 {
     for (size_t i = 0, sz = mCoef.size() ; i < sz; i++)
     {
@@ -146,8 +146,8 @@ math::poly::OneD<_T>::operator *= (double cv)
 }
     
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::operator * (double cv) const
+OneD<_T>
+OneD<_T>::operator * (double cv) const
 {
     OneD<_T> ret(*this);
     ret *= cv;
@@ -155,15 +155,15 @@ math::poly::OneD<_T>::operator * (double cv) const
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-operator * (double cv, const math::poly::OneD<_T>& p)
+OneD<_T>
+operator * (double cv, const OneD<_T>& p)
 {
     return p*cv;
 }
 
 template<typename _T>
-math::poly::OneD<_T>&
-math::poly::OneD<_T>::operator *= (const OneD<_T>& p)
+OneD<_T>&
+OneD<_T>::operator *= (const OneD<_T>& p)
 {
    OneD<_T> tmp(order()+p.order());
    for (size_t i = 0, xsz = mCoef.size() ; i < xsz; i++)
@@ -178,8 +178,8 @@ math::poly::OneD<_T>::operator *= (const OneD<_T>& p)
 }
     
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::operator * (const OneD<_T>& p) const
+OneD<_T>
+OneD<_T>::operator * (const OneD<_T>& p) const
 {
     OneD<_T> ret(*this);
     ret *= p;
@@ -187,8 +187,8 @@ math::poly::OneD<_T>::operator * (const OneD<_T>& p) const
 }
 
 template<typename _T>
-math::poly::OneD<_T>&
-math::poly::OneD<_T>::operator += (const OneD<_T>& p)
+OneD<_T>&
+OneD<_T>::operator += (const OneD<_T>& p)
 {
     OneD<_T> tmp(std::max<size_t>(order(), p.order()));
     for (size_t i = 0, sz = mCoef.size() ; i < sz; i++)
@@ -204,8 +204,8 @@ math::poly::OneD<_T>::operator += (const OneD<_T>& p)
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::operator + (const OneD<_T>& p) const
+OneD<_T>
+OneD<_T>::operator + (const OneD<_T>& p) const
 {
     OneD<_T> ret(*this);
     ret += p;
@@ -213,8 +213,8 @@ math::poly::OneD<_T>::operator + (const OneD<_T>& p) const
 }
     
 template<typename _T>
-math::poly::OneD<_T>&
-math::poly::OneD<_T>::operator -= (const OneD<_T>& p)
+OneD<_T>&
+OneD<_T>::operator -= (const OneD<_T>& p)
 {
    OneD<_T> tmp(std::max<size_t>(order(), p.order()));
    for (unsigned int i = 0, sz = mCoef.size() ; i < sz; i++)
@@ -230,8 +230,8 @@ math::poly::OneD<_T>::operator -= (const OneD<_T>& p)
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::operator - (const OneD<_T>& p) const
+OneD<_T>
+OneD<_T>::operator - (const OneD<_T>& p) const
 {
    OneD<_T> ret(*this);
    ret -= p;
@@ -239,8 +239,8 @@ math::poly::OneD<_T>::operator - (const OneD<_T>& p) const
 }
 
 template<typename _T>
-math::poly::OneD<_T>&
-math::poly::OneD<_T>::operator /= (double cv)
+OneD<_T>&
+OneD<_T>::operator /= (double cv)
 {
     double recipCV = 1.0/cv;
     for (unsigned int i = 0, sz = mCoef.size() ; i < sz; i++)
@@ -251,8 +251,8 @@ math::poly::OneD<_T>::operator /= (double cv)
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::operator / (double cv) const
+OneD<_T>
+OneD<_T>::operator / (double cv) const
 {
     OneD<_T> ret(*this);
     ret *= (1.0/cv);
@@ -260,8 +260,7 @@ math::poly::OneD<_T>::operator / (double cv) const
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::power(size_t toThe) const
+OneD<_T> OneD<_T>::power(size_t toThe) const
 {
     // If its 0, we have to give back a 1*x^0 poly, since
     // we want a 2D poly out
@@ -288,14 +287,13 @@ math::poly::OneD<_T>::power(size_t toThe) const
 }
 
 template<typename _T>
-math::poly::OneD<_T> math::poly::OneD<_T>::scaleVariable(double scale) const
+OneD<_T> OneD<_T>::scaleVariable(double scale) const
 {
     return ::math::poly::scaleVariable<OneD<_T> >(*this, scale);
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::truncateTo(size_t order) const
+OneD<_T> OneD<_T>::truncateTo(size_t order) const
 {
     order = std::min(this->order(), order);
 
@@ -308,8 +306,7 @@ math::poly::OneD<_T>::truncateTo(size_t order) const
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::truncateToNonZeros(double zeroEpsilon) const
+OneD<_T> OneD<_T>::truncateToNonZeros(double zeroEpsilon) const
 {
     zeroEpsilon = std::abs(zeroEpsilon);
     size_t newOrder(0);
@@ -328,8 +325,7 @@ math::poly::OneD<_T>::truncateToNonZeros(double zeroEpsilon) const
 }
 
 template<typename _T>
-math::poly::OneD<_T>
-math::poly::OneD<_T>::transformInput(const OneD<_T>& gx,
+OneD<_T> OneD<_T>::transformInput(const OneD<_T>& gx,
                                   double zeroEpsilon) const
 {
     OneD<_T> newP(order());
@@ -343,14 +339,11 @@ math::poly::OneD<_T>::transformInput(const OneD<_T>& gx,
 }
 
 template<typename _T>
-void
-math::poly::OneD<_T>::copyFrom(const OneD<_T>& p)
+void OneD<_T>::copyFrom(const OneD<_T>& p)
 {
     const size_t numCopy(std::min(size(), p.size()));
     std::copy(p.mCoef.begin(), p.mCoef.begin() + numCopy, mCoef.begin());
 }
-
-
 } // poly
 } // math
 
@@ -364,3 +357,4 @@ operator << (std::ostream& out, const math::poly::OneD<_T>& p)
    }
    return out;
 }
+

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -84,15 +84,14 @@ template<typename _T>
 _T
 OneD<_T>::velocity(double x) const
 {
-    _T vel = derivative()(x);
-    return vel;
+    return derivative()(x);
 }
 template<typename _T>
 _T
 OneD<_T>::acceleration(double x) const
 {
-    _T acc = ((derivative()).derivative())(x);
-    return acc;
+    return derivative().derivative()(x);
+    
 }
 template<typename _T>
 _T& 

--- a/modules/c++/math.poly/include/math/poly/TwoD.h
+++ b/modules/c++/math.poly/include/math/poly/TwoD.h
@@ -77,7 +77,12 @@ public:
             }
         }
     }
-    TwoD(std::vector<OneD<_T> > v): mCoef(v) {}
+    
+    TwoD(const std::vector<OneD<_T> >& v): mCoef(v) 
+    {
+     
+    }
+    
     bool empty() const
     {
         return mCoef.empty();

--- a/modules/c++/math.poly/include/math/poly/TwoD.h
+++ b/modules/c++/math.poly/include/math/poly/TwoD.h
@@ -65,7 +65,7 @@ public:
 
     TwoD(size_t orderX, size_t orderY) : mCoef(orderX+1,OneD<_T>(orderY)) {}   
     
-    TwoD(std::vector<math::poly::OneD<double> v): mCoef(v) {}
+    TwoD(std::vector<OneD<_T> v): mCoef(v) {}
 
     template<typename Vector_T> TwoD(size_t orderX, size_t orderY,
                                      const Vector_T& coeffs)

--- a/modules/c++/math.poly/include/math/poly/TwoD.h
+++ b/modules/c++/math.poly/include/math/poly/TwoD.h
@@ -64,8 +64,6 @@ public:
     TwoD() {}
 
     TwoD(size_t orderX, size_t orderY) : mCoef(orderX+1,OneD<_T>(orderY)) {}   
-    
-    TwoD(std::vector<OneD<_T> v): mCoef(v) {}
 
     template<typename Vector_T> TwoD(size_t orderX, size_t orderY,
                                      const Vector_T& coeffs)
@@ -79,6 +77,7 @@ public:
             }
         }
     }
+    TwoD(std::vector<OneD<_T> > v): mCoef(v) {}
     bool empty() const
     {
         return mCoef.empty();

--- a/modules/c++/math.poly/include/math/poly/TwoD.h
+++ b/modules/c++/math.poly/include/math/poly/TwoD.h
@@ -64,6 +64,8 @@ public:
     TwoD() {}
 
     TwoD(size_t orderX, size_t orderY) : mCoef(orderX+1,OneD<_T>(orderY)) {}   
+    
+    TwoD(std::vector<math::poly::OneD<double> v): mCoef(v) {}
 
     template<typename Vector_T> TwoD(size_t orderX, size_t orderY,
                                      const Vector_T& coeffs)

--- a/modules/c++/math.poly/include/math/poly/TwoD.h
+++ b/modules/c++/math.poly/include/math/poly/TwoD.h
@@ -78,9 +78,9 @@ public:
         }
     }
     
-    TwoD(const std::vector<OneD<_T> >& v): mCoef(v) 
+    TwoD(const std::vector<OneD<_T> >& v) : 
+        mCoef(v) 
     {
-     
     }
     
     bool empty() const


### PR DESCRIPTION
Introduced angle and normSq functions to Vector and VectorN classes, introduced velocity and acceleration functions to OneD, and created a new constructor for TwoD to initialize coefficients with a std::vector<OneD<_T> >. These additions allow mcad_analysis files to now build with CODA instead of older source files that included these missing functionalities. 

Trac ticket #3