### PR TITLE
Updating jenkins files to reflect Git ID rather than SVN ID in file path

### DIFF
--- a/build/scripts/jenkins.py
+++ b/build/scripts/jenkins.py
@@ -66,8 +66,12 @@ elif '-vc10' in os.environ.get('JOB_NAME'):
     config_options += ["--msvc_version=msvc 10.0,msvc 10.0Exp"]
 
 print 'Job: %s' % os.environ.get('JOB_NAME', '')
-commit_id = os.environ.get('GIT_COMMIT', '')
-print "Revision: %s" % commit_id[-8:]
+if os.environ.has_key('GIT_COMMIT')
+    commit_id = os.environ.get('GIT_COMMIT', '')
+    commit_id = commit_id[-8:]
+elif os.environ.has_key('SVN_REVISION')
+    commit_id = os.environ.get('SVN_REVISION')
+print "Revision: %s" % commit_id
 print "LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH','')
 
 install_path = installPath(package_name)

--- a/build/scripts/jenkins.py
+++ b/build/scripts/jenkins.py
@@ -66,7 +66,8 @@ elif '-vc10' in os.environ.get('JOB_NAME'):
     config_options += ["--msvc_version=msvc 10.0,msvc 10.0Exp"]
 
 print 'Job: %s' % os.environ.get('JOB_NAME', '')
-print "Revision: %s" % os.environ.get('GIT_COMMIT', '')
+str commit_id = os.environ.get('GIT_COMMIT', '')
+print "Revision: %s" % commit_id[-8:]
 print "LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH','')
 
 install_path = installPath(package_name)

--- a/build/scripts/jenkins.py
+++ b/build/scripts/jenkins.py
@@ -66,7 +66,7 @@ elif '-vc10' in os.environ.get('JOB_NAME'):
     config_options += ["--msvc_version=msvc 10.0,msvc 10.0Exp"]
 
 print 'Job: %s' % os.environ.get('JOB_NAME', '')
-print "Revision: %s" % os.environ.get('SVN_REVISION', '')
+print "Revision: %s" % os.environ.get('GIT_COMMIT', '')
 print "LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH','')
 
 install_path = installPath(package_name)

--- a/build/scripts/jenkins.py
+++ b/build/scripts/jenkins.py
@@ -66,8 +66,7 @@ elif '-vc10' in os.environ.get('JOB_NAME'):
     config_options += ["--msvc_version=msvc 10.0,msvc 10.0Exp"]
 
 print 'Job: %s' % os.environ.get('JOB_NAME', '')
-str commit_id = "%s" % os.environ.get('GIT_COMMIT', '')
-print "Revision: %s" % commit_id[-8:]
+print "Revision: %s" % os.environ.get('GIT_COMMIT', '')
 print "LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH','')
 
 install_path = installPath(package_name)

--- a/build/scripts/jenkins.py
+++ b/build/scripts/jenkins.py
@@ -66,7 +66,7 @@ elif '-vc10' in os.environ.get('JOB_NAME'):
     config_options += ["--msvc_version=msvc 10.0,msvc 10.0Exp"]
 
 print 'Job: %s' % os.environ.get('JOB_NAME', '')
-str commit_id = os.environ.get('GIT_COMMIT', '')
+str commit_id = "%s" % os.environ.get('GIT_COMMIT', '')
 print "Revision: %s" % commit_id[-8:]
 print "LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH','')
 

--- a/build/scripts/jenkins.py
+++ b/build/scripts/jenkins.py
@@ -66,7 +66,8 @@ elif '-vc10' in os.environ.get('JOB_NAME'):
     config_options += ["--msvc_version=msvc 10.0,msvc 10.0Exp"]
 
 print 'Job: %s' % os.environ.get('JOB_NAME', '')
-print "Revision: %s" % os.environ.get('GIT_COMMIT', '')
+commit_id = os.environ.get('GIT_COMMIT', '')
+print "Revision: %s" % commit_id[-8:]
 print "LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH','')
 
 install_path = installPath(package_name)

--- a/build/scripts/makeInstallPath.py
+++ b/build/scripts/makeInstallPath.py
@@ -28,5 +28,7 @@ def installPath(package_name):
         commit_id = commit_id[-8:]
     elif os.environ.has_key('SVN_REVISION')
         commit_id = os.environ.get('SVN_REVISION')
-    install_path = "%s-%s-r%s" % (package_name,install_suffix, commit_id) 
+    install_path = "%s-%s-r%s" % (package_name,install_suffix, commit_id)
+    if os.environ.has_key('SVN_REVISION')
+        install_path = join('..', install_path)
     return install_path

--- a/build/scripts/makeInstallPath.py
+++ b/build/scripts/makeInstallPath.py
@@ -21,7 +21,12 @@ def installPath(package_name):
         install_suffix += '-vc9'
     elif '-vc10' in os.environ.get('JOB_NAME'):
         install_suffix += '-vc10'
-     
-    commit_id = os.environ.get('GIT_COMMIT', '')
-    install_path = "%s-%s-r%s" % (package_name,install_suffix, commit_id[-8:]) 
+    
+    
+    if os.environ.has_key('GIT_COMMIT')
+        commit_id = os.environ.get('GIT_COMMIT', '')
+        commit_id = commit_id[-8:]
+    elif os.environ.has_key('SVN_REVISION')
+        commit_id = os.environ.get('SVN_REVISION')
+    install_path = "%s-%s-r%s" % (package_name,install_suffix, commit_id) 
     return install_path

--- a/build/scripts/makeInstallPath.py
+++ b/build/scripts/makeInstallPath.py
@@ -24,6 +24,4 @@ def installPath(package_name):
      
     commit_id = os.environ.get('GIT_COMMIT', '')
     install_path = "%s-%s-r%s" % (package_name,install_suffix, commit_id[-8:]) 
-    #install_path = "%s-%s-r%s" % (package_name,install_suffix,os.environ.get('SVN_REVISION', ''))
-    #install_path = join('..', install_path)
     return install_path

--- a/build/scripts/makeInstallPath.py
+++ b/build/scripts/makeInstallPath.py
@@ -21,8 +21,9 @@ def installPath(package_name):
         install_suffix += '-vc9'
     elif '-vc10' in os.environ.get('JOB_NAME'):
         install_suffix += '-vc10'
-        
-    install_path = "%s-%s-r%s" % (package_name,install_suffix,os.environ.get('GIT_COMMIT', '')) 
+     
+    commit_id = os.environ.get('GIT_COMMIT', '')
+    install_path = "%s-%s-r%s" % (package_name,install_suffix, commit_id[-8:]) 
     #install_path = "%s-%s-r%s" % (package_name,install_suffix,os.environ.get('SVN_REVISION', ''))
     #install_path = join('..', install_path)
     return install_path

--- a/build/scripts/makeInstallPath.py
+++ b/build/scripts/makeInstallPath.py
@@ -21,7 +21,8 @@ def installPath(package_name):
         install_suffix += '-vc9'
     elif '-vc10' in os.environ.get('JOB_NAME'):
         install_suffix += '-vc10'
-    
-    install_path = "%s-%s-r%s" % (package_name,install_suffix,os.environ.get('SVN_REVISION', ''))
-    install_path = join('..', install_path)
+        
+    install_path = "%s-%s-r%s" % (package_name,install_suffix,os.environ.get('GIT_COMMIT', '')) 
+    #install_path = "%s-%s-r%s" % (package_name,install_suffix,os.environ.get('SVN_REVISION', ''))
+    #install_path = join('..', install_path)
     return install_path


### PR DESCRIPTION
The Git Commit IDs are shortened to the last eight characters of the ID