### PR TITLE
Cpp11 switch

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -686,6 +686,8 @@ def options(opt):
                    default=False, help='Treat compiler warnings as errors')
     opt.add_option('--enable-debugging', action='store_true', dest='debugging',
                    help='Enable debugging')
+    opt.add_option('--enable-cpp11', action='store_true', default=False, dest='enablecpp11',
+                   help='Enable C++11 features')
     #TODO - get rid of enable64 - it's useless now
     opt.add_option('--enable-64bit', action='store_true', dest='enable64',
                    help='Enable 64bit builds')
@@ -813,7 +815,8 @@ def configureCompilerOptions(self):
             config['cxx']['optz_fastest']   = '-O3'
 
             gxxCompileFlags='-fPIC'
-            if cxxCompiler == 'g++' and gccHasCpp11():
+            if cxxCompiler == 'g++' and self.env['cpp11support'] and gccHasCpp11:
+                print 'why'
                 gxxCompileFlags+=' -std=c++11'
 
             self.env.append_value('CXXFLAGS', gxxCompileFlags.split())
@@ -1101,7 +1104,7 @@ def configure(self):
 
     if self.env['DETECTED_BUILD_PY']:
         return
-
+    
     sys_platform = getPlatform(default=Options.platform)
     winRegex = r'win32'
 
@@ -1181,7 +1184,7 @@ def configure(self):
         env.append_unique('LINKFLAGS', Options.options.linkflags.split())
     if Options.options._defs:
         env.append_unique('DEFINES', Options.options._defs.split(','))
-
+    env['cpp11support'] = Options.options.enablecpp11
     configureCompilerOptions(self)
 
     env['PLATFORM'] = sys_platform

--- a/build/build.py
+++ b/build/build.py
@@ -815,7 +815,8 @@ def configureCompilerOptions(self):
             config['cxx']['optz_fastest']   = '-O3'
 
             gxxCompileFlags='-fPIC'
-            if cxxCompiler == 'g++' and self.env['cpp11support'] and gccHasCpp11:
+            botherChecking = self.env['cpp11support'] or self.env['force_cpp11support']
+            if cxxCompiler == 'g++' and botherChecking and gccHasCpp11:
                 print 'why'
                 gxxCompileFlags+=' -std=c++11'
 

--- a/build/build.py
+++ b/build/build.py
@@ -815,9 +815,7 @@ def configureCompilerOptions(self):
             config['cxx']['optz_fastest']   = '-O3'
 
             gxxCompileFlags='-fPIC'
-            botherChecking = self.env['cpp11support'] or self.env['force_cpp11support']
-            if cxxCompiler == 'g++' and botherChecking and gccHasCpp11:
-                print 'why'
+            if cxxCompiler == 'g++' and self.env['cpp11support'] and gccHasCpp11():
                 gxxCompileFlags+=' -std=c++11'
 
             self.env.append_value('CXXFLAGS', gxxCompileFlags.split())
@@ -1185,7 +1183,9 @@ def configure(self):
         env.append_unique('LINKFLAGS', Options.options.linkflags.split())
     if Options.options._defs:
         env.append_unique('DEFINES', Options.options._defs.split(','))
-    env['cpp11support'] = Options.options.enablecpp11
+    #if its already defined in a wscript, don't touch.
+    if not env['cpp11support']:
+        env['cpp11support'] = Options.options.enablecpp11
     configureCompilerOptions(self)
 
     env['PLATFORM'] = sys_platform

--- a/build/build.py
+++ b/build/build.py
@@ -1504,7 +1504,7 @@ def gccHasCpp11():
         output = subprocess.check_output("g++ --help=c++", stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError:
         #If gcc is too old for --help=, then it is too old for C++11
-        return false
+        return False
     for line in output.split('\n'):
         if re.search(r'-std=c\+\+11', line):
             return True

--- a/modules/c++/sys/wscript
+++ b/modules/c++/sys/wscript
@@ -44,18 +44,11 @@ def configure(conf):
             }
             '''
 	cpp11_str = '''
-		#include <stdio.h>
+		#include <iostream>
 		int main()
 		{
-			#if __cplusplus >= 201103L
-			int x  = 1;
-			#else
-			int x = 0;
-			#endif
-			if(x) printf("cpp11=True\\n");
-			else printf("cpp11=False\\n");
-			return 0;
-			
+			int* s = nullptr;
+			std::cout << s;
 		}
 		'''
         #find out the size of some types, etc.
@@ -74,16 +67,7 @@ def configure(conf):
                 elif v == 'False':
                     v = False
             conf.define(k.upper(), v)
-	output11 = conf.check_cxx(fragment = cpp11_str, execute=1, msg='Checking for C++11 support', define_ret=True, mandatory=False)
-	t2 = Utils.str_to_dict(output11 or '')
-	for k, v in t2.iteritems():
-		v = v.strip()
-		if v == 'True':
-			v=True
-		elif v == 'False': 
-			v=False;
-		conf.define(k.upper(), v)
-        
+        conf.check_cxx(fragment = cpp11_str, execute=1, msg='Checking for C++11 support', define_name='__CPP11', mandatory=False)
     writeConfig(conf, sys_callback, NAME)
     
 def build(bld):

--- a/modules/c++/sys/wscript
+++ b/modules/c++/sys/wscript
@@ -67,7 +67,7 @@ def configure(conf):
                 elif v == 'False':
                     v = False
             conf.define(k.upper(), v)
-        conf.check_cxx(fragment = cpp11_str, execute=1, msg='Checking for C++11 support', define_name='__CPP11', mandatory=False)
+        conf.check_cxx(fragment = cpp11_str, execute=1, msg='Checking for C++11 support', define_name='__CODA_CPP11', mandatory=False)
     writeConfig(conf, sys_callback, NAME)
     
 def build(bld):


### PR DESCRIPTION
This allows c++11 usage to be determined at configure-time. There is also support for allowing wscripts to force c++11 usage via the 'force_cpp11support' parameter.