### PR TITLE
bytesToWrite now is calculated against a size_t.

### DIFF
--- a/modules/c++/sys/source/FileWin32.cpp
+++ b/modules/c++/sys/source/FileWin32.cpp
@@ -91,15 +91,15 @@ void sys::File::readInto(char *buffer, Size_T size)
 
 void sys::File::writeFrom(const char *buffer, Size_T size)
 {
-    static const DWORD MAX_WRITE_SIZE = std::numeric_limits<DWORD>::max();
+    static const size_t MAX_WRITE_SIZE = std::numeric_limits<DWORD>::max();
     size_t bytesRemaining = size;
     size_t bytesWritten = 0;
 
     while (bytesWritten < size)
     {
         // Determine how many bytes to write
-        const DWORD bytesToWrite =
-            std::min<DWORD>(MAX_WRITE_SIZE, bytesRemaining);
+        const DWORD bytesToWrite = static_cast<DWORD>(
+            std::min<size_t>(MAX_WRITE_SIZE, bytesRemaining));
 
         // Write the data
         DWORD bytesThisWrite = 0;

--- a/modules/c++/sys/source/FileWin32.cpp
+++ b/modules/c++/sys/source/FileWin32.cpp
@@ -64,7 +64,7 @@ void sys::File::readInto(char *buffer, Size_T size)
     {
         // Determine how many bytes to read
         const DWORD bytesToRead = static_cast<DWORD>(
-                std::min<size_t>(MAX_READ_SIZE, bytesRemaining));
+                std::min(MAX_READ_SIZE, bytesRemaining));
 
         // Read from file
         DWORD bytesThisRead = 0;
@@ -99,7 +99,7 @@ void sys::File::writeFrom(const char *buffer, Size_T size)
     {
         // Determine how many bytes to write
         const DWORD bytesToWrite = static_cast<DWORD>(
-            std::min<size_t>(MAX_WRITE_SIZE, bytesRemaining));
+            std::min(MAX_WRITE_SIZE, bytesRemaining));
 
         // Write the data
         DWORD bytesThisWrite = 0;


### PR DESCRIPTION
Same issue as reader, but with the writer. The bytesToWrite needs to be calculated using a size_t instead of a DWORD.