### PR TITLE
Types row col sqrt fix for windows

### DIFF
--- a/modules/c++/types/include/types/RowCol.h
+++ b/modules/c++/types/include/types/RowCol.h
@@ -223,8 +223,8 @@ template<typename T> struct RowCol
         //  this is more explicit
         return static_cast<T>(
             std::sqrt(static_cast<double>(row * row) + 
-                      static_cast<double>(col * col)));    }
-
+                      static_cast<double>(col * col)));
+    }
 };
 
 template <>

--- a/modules/c++/types/include/types/RowCol.h
+++ b/modules/c++/types/include/types/RowCol.h
@@ -219,11 +219,14 @@ template<typename T> struct RowCol
     }
     T normL2() const
     {
-        //! VC++ 2010 compiler get confused on the cast --
-        //  this is more explicit
+        //! Should be able to just use sqrt() here but VC++ 2010 compiler
+        //  appears to (incorrectly) be calling std::sqrt() in this scenario
+        //  and then complaining it can't find an overloading for some types
+        //  (like size_t)
+        //  So, cast to double and at that point we might as well just call
+        //  std::sqrt()
         return static_cast<T>(
-            std::sqrt(static_cast<double>(row * row) + 
-                      static_cast<double>(col * col)));
+            std::sqrt(static_cast<double>(row * row + col * col)));
     }
 };
 

--- a/modules/c++/types/include/types/RowCol.h
+++ b/modules/c++/types/include/types/RowCol.h
@@ -219,8 +219,11 @@ template<typename T> struct RowCol
     }
     T normL2() const
     {
-        return sqrt(row * row + col * col);
-    }
+        //! VC++ 2010 compiler get confused on the cast --
+        //  this is more explicit
+        return static_cast<T>(
+            std::sqrt(static_cast<double>(row * row) + 
+                      static_cast<double>(col * col)));    }
 
 };
 


### PR DESCRIPTION
Visual Studio 2010 was unable to resolve the sqrt for size_t or sys::SSize_T, so because this isn't heavily used and types doesn't depend on sys, we perform a cast to double to make the template we intend to use explicit. This is a little unfortunate.