### PR TITLE
Adding a typemap for Off_T

### DIFF
--- a/modules/python/sys/source/sys.i
+++ b/modules/python/sys/source/sys.i
@@ -19,3 +19,39 @@
 %typemap(typecheck) ssize_t {
   $1 = PyInt_Check($input) ? 1 : 0;
 }
+
+%typemap(in) off_t {
+  $1 = PyInt_AsSsize_t($input);
+}
+
+%typemap(out) off_t {
+  $result = PyInt_FromSsize_t($1);
+}
+
+%typemap(typecheck) off_t {
+  $1 = PyInt_Check($input) ? 1 : 0;
+}
+
+%typemap(in) __int64 {
+  $1 = PyInt_AsSsize_t($input);
+}
+
+%typemap(out) __int64 {
+  $result = PyInt_FromSsize_t($1);
+}
+
+%typemap(typecheck) __int64 {
+  $1 = PyInt_Check($input) ? 1 : 0;
+}
+
+%typemap(in) Int64_T {
+  $1 = PyInt_AsSsize_t($input);
+}
+
+%typemap(out) Int64_T {
+  $result = PyInt_FromSsize_t($1);
+}
+
+%typemap(typecheck) Int64_T {
+  $1 = PyInt_Check($input) ? 1 : 0;
+}


### PR DESCRIPTION
We need this for our bindings elsewhere. There are several sets of typemaps here because I suspect the one set would have trouble on windows. I'm not sure why but sys::Off_T does not actually match usages of sys::Off_T. 

Adding the typemaps didn't seem to change the cxx and py wrappers either.