### PR TITLE
Added check for __init__.py installation

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1397,6 +1397,10 @@ def process_swig_linkage(tsk):
 @feature('python_package')
 def python_package(tg):
 
+    # make sure we actually need to install stuff
+    if not 'install' in tg.bld.cmd:
+        return
+
     # setup some paths
     # we'll create our __init__.py right in our build directory
     install_path = tg.install_path


### PR DESCRIPTION
There was a bug here where if you ran `./waf build` prior to installing a python module the `__init__.py` would not get installed correctly. Since the python interface doesn't really work without installation anyway I added a check to only run the `__init__.py` installation during install and that seems to have fixed it.