### PR TITLE
Turning off warning about deprecated declarations

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -842,7 +842,7 @@ def configureCompilerOptions(self):
         if re.match(solarisRegex, sys_platform):
             self.env.append_value('LIB_SOCKET', 'socket')
 
-        warningFlags = '-Wall'
+        warningFlags = '-Wall -Wno-deprecated-declarations'
         if Options.options.warningsAsErrors:
             warningFlags += ' -Wfatal-errors'
 


### PR DESCRIPTION
Otherwise, with gcc and C++11 support we get warnings about auto_ptr being deprecated, which is true, but we need to continue to use it until we can require a C++11 compiler.