### PR TITLE
Conf/ functionality for Java modules

### DIFF
--- a/build/javatool.py
+++ b/build/javatool.py
@@ -201,6 +201,13 @@ def java_module(bld, **modArgs):
 
            lib.install_path = installPath or '${PREFIX}/lib'
 
+       confDir = path.make_node('conf')
+       if os.path.exists(confDir.abspath()) :
+           jar.targets_to_add.append(
+               bld(features='install_tgt', dir=confDir, pattern='**',
+                   install_path='${PREFIX}/conf/%s/' % modArgs['name'],
+                   copy_to_source_dir=True))
+
        return jar
 
 # Tell waf to ignore any build.xml files, the 'ant' feature will take care of them.


### PR DESCRIPTION
This adds the same "automatic copy" for conf/ directories in the java modules. I tested this works in Nitro's java layer. I'm using this on FSG to copy my user manuals to the installation folder for each PIMA plugin.