### PR TITLE
Logger should be noncopyable

### DIFF
--- a/modules/c++/logging/include/logging/Logger.h
+++ b/modules/c++/logging/include/logging/Logger.h
@@ -129,6 +129,16 @@ public:
     //! Removes all handlers
     void reset();
 
+private:
+    // Noncopyable
+    // NOTE: It isn't currently safe to copy a logger because mHandlers isn't
+    //       a deep copy and you end up with a double delete (it's not using
+    //       smart pointers :o( ).  If we really wanted to support a copy,
+    //       would need to decide if mHandlers should be deeply or shallowly
+    //       copied.
+    Logger(const Logger& );
+    Logger& operator=(const Logger& );
+
 protected:
     void handle(const LogRecord* record);
 


### PR DESCRIPTION
Logically a Logger should probably be noncopyable.  Old implementation resulted in a double delete when copying.