### PR TITLE
Long long swig fix

### DIFF
--- a/modules/c++/sio.lite/include/sio/lite/FileHeader.h
+++ b/modules/c++/sio.lite/include/sio/lite/FileHeader.h
@@ -152,7 +152,7 @@ public:
      * @param key The key to search for in our hash table
      * @return true if it exists
      */
-    bool userDataFieldExists( std::string key ) const;
+    bool userDataFieldExists(const std::string& key) const;
 
     /**
      *  Get all of the user data field names
@@ -170,7 +170,7 @@ public:
      *  Get the raw byte user data for a given user data ID.
      *  @return An array of user data for a given key
      */
-    std::vector<sys::byte>& getUserData( std::string key )
+    std::vector<sys::byte>& getUserData(const std::string& key)
         throw (except::NoSuchKeyException);
 
     /**

--- a/modules/c++/sio.lite/source/FileHeader.cpp
+++ b/modules/c++/sio.lite/source/FileHeader.cpp
@@ -81,7 +81,7 @@ long sio::lite::FileHeader::getLength() const
 }
 
 
-bool sio::lite::FileHeader::userDataFieldExists( std::string key ) const
+bool sio::lite::FileHeader::userDataFieldExists(const std::string& key) const
 {
     return userData.exists(key);
 }
@@ -94,7 +94,7 @@ void sio::lite::FileHeader::getAllUserDataFields(
         keys.push_back(p->first);
 }
 
-std::vector<sys::byte>& sio::lite::FileHeader::getUserData( std::string key )
+std::vector<sys::byte>& sio::lite::FileHeader::getUserData(const std::string& key)
     throw (except::NoSuchKeyException)
 {
     if (!userData.exists(key))

--- a/modules/python/sio.lite/source/generated/sio_lite.py
+++ b/modules/python/sio.lite/source/generated/sio_lite.py
@@ -886,7 +886,7 @@ class StreamReader(InputStream):
     def read(self, *args):
         """
         read(StreamReader self, sys::byte * b, size_t size) -> sys::SSize_T
-        read(StreamReader self, long long data, size_t size) -> sys::SSize_T
+        read(StreamReader self, long long data, long long size) -> sys::SSize_T
         """
         return _sio_lite.StreamReader_read(self, *args)
 

--- a/modules/python/sio.lite/source/generated/sio_lite.py
+++ b/modules/python/sio.lite/source/generated/sio_lite.py
@@ -742,7 +742,7 @@ class FileHeader(_object):
 
 
     def userDataFieldExists(self, key):
-        """userDataFieldExists(FileHeader self, std::string key) -> bool"""
+        """userDataFieldExists(FileHeader self, std::string const & key) -> bool"""
         return _sio_lite.FileHeader_userDataFieldExists(self, key)
 
 
@@ -757,7 +757,7 @@ class FileHeader(_object):
 
 
     def getUserData(self, key):
-        """getUserData(FileHeader self, std::string key) -> std::vector< sys::byte > &"""
+        """getUserData(FileHeader self, std::string const & key) -> std::vector< sys::byte > &"""
         return _sio_lite.FileHeader_getUserData(self, key)
 
 
@@ -816,7 +816,7 @@ class FileWriter(_object):
         write(FileWriter self, FileHeader header, void const * data)
         write(FileWriter self, int numLines, int numElements, int elementSize, int elementType, void const * data, int numBands=1)
         write(FileWriter self, int numLines, int numElements, int elementSize, int elementType, void const * data)
-        write(FileWriter self, FileHeader header, size_t data)
+        write(FileWriter self, FileHeader header, long long data)
         """
         return _sio_lite.FileWriter_write(self, *args)
 
@@ -886,7 +886,7 @@ class StreamReader(InputStream):
     def read(self, *args):
         """
         read(StreamReader self, sys::byte * b, size_t size) -> sys::SSize_T
-        read(StreamReader self, size_t data, size_t size) -> sys::SSize_T
+        read(StreamReader self, long long data, size_t size) -> sys::SSize_T
         """
         return _sio_lite.StreamReader_read(self, *args)
 

--- a/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
+++ b/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
@@ -3654,7 +3654,7 @@ SWIGINTERN void sio_lite_FileWriter_write__SWIG_6(sio::lite::FileWriter *self,si
         const void* buffer = reinterpret_cast<const void*>(data);
         self->write(header, buffer);
     }
-SWIGINTERN sys::SSize_T sio_lite_StreamReader_read__SWIG_1(sio::lite::StreamReader *self,long long data,size_t size){
+SWIGINTERN sys::SSize_T sio_lite_StreamReader_read__SWIG_1(sio::lite::StreamReader *self,long long data,long long size){
         sys::byte* buffer = reinterpret_cast<sys::byte*>(data);
         return self->read(buffer, size);
     }
@@ -9473,12 +9473,12 @@ SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(se
   PyObject *resultobj = 0;
   sio::lite::StreamReader *arg1 = (sio::lite::StreamReader *) 0 ;
   long long arg2 ;
-  size_t arg3 ;
+  long long arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   long long val2 ;
   int ecode2 = 0 ;
-  size_t val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -9496,11 +9496,11 @@ SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(se
     SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StreamReader_read" "', argument " "2"" of type '" "long long""'");
   } 
   arg2 = static_cast< long long >(val2);
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(obj2, &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StreamReader_read" "', argument " "3"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StreamReader_read" "', argument " "3"" of type '" "long long""'");
   } 
-  arg3 = static_cast< size_t >(val3);
+  arg3 = static_cast< long long >(val3);
   result = sio_lite_StreamReader_read__SWIG_1(arg1,arg2,arg3);
   {
     resultobj = PyInt_FromSsize_t(result);
@@ -9535,7 +9535,7 @@ SWIGINTERN PyObject *_wrap_StreamReader_read(PyObject *self, PyObject *args) {
       }
       if (_v) {
         {
-          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -9568,7 +9568,7 @@ fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'StreamReader_read'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    sio::lite::StreamReader::read(sys::byte *,size_t)\n"
-    "    sio::lite::StreamReader::read(long long,size_t)\n");
+    "    sio::lite::StreamReader::read(long long,long long)\n");
   return 0;
 }
 
@@ -10041,7 +10041,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"StreamReader_available", _wrap_StreamReader_available, METH_VARARGS, (char *)"StreamReader_available(StreamReader self) -> sys::Off_T"},
 	 { (char *)"StreamReader_read", _wrap_StreamReader_read, METH_VARARGS, (char *)"\n"
 		"read(sys::byte * b, size_t size) -> sys::SSize_T\n"
-		"StreamReader_read(StreamReader self, long long data, size_t size) -> sys::SSize_T\n"
+		"StreamReader_read(StreamReader self, long long data, long long size) -> sys::SSize_T\n"
 		""},
 	 { (char *)"StreamReader_swigregister", StreamReader_swigregister, METH_VARARGS, NULL},
 	 { (char *)"delete_FileReader", _wrap_delete_FileReader, METH_VARARGS, (char *)"delete_FileReader(FileReader self)"},

--- a/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
+++ b/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
@@ -3613,11 +3613,48 @@ SWIG_AsVal_bool (PyObject *obj, bool *val)
   return SWIG_OK;
 }
 
-SWIGINTERN void sio_lite_FileWriter_write__SWIG_6(sio::lite::FileWriter *self,sio::lite::FileHeader *header,size_t data){
+
+SWIGINTERN int
+SWIG_AsVal_long_SS_long (PyObject *obj, long long *val)
+{
+  int res = SWIG_TypeError;
+  if (PyLong_Check(obj)) {
+    long long v = PyLong_AsLongLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+    }
+  } else {
+    long v;
+    res = SWIG_AsVal_long (obj,&v);
+    if (SWIG_IsOK(res)) {
+      if (val) *val = v;
+      return res;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    const double mant_max = 1LL << DBL_MANT_DIG;
+    const double mant_min = -mant_max;
+    double d;
+    res = SWIG_AsVal_double (obj,&d);
+    if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, mant_min, mant_max)) {
+      if (val) *val = (long long)(d);
+      return SWIG_AddCast(res);
+    }
+    res = SWIG_TypeError;
+  }
+#endif
+  return res;
+}
+
+SWIGINTERN void sio_lite_FileWriter_write__SWIG_6(sio::lite::FileWriter *self,sio::lite::FileHeader *header,long long data){
         const void* buffer = reinterpret_cast<const void*>(data);
         self->write(header, buffer);
     }
-SWIGINTERN sys::SSize_T sio_lite_StreamReader_read__SWIG_1(sio::lite::StreamReader *self,size_t data,size_t size){
+SWIGINTERN sys::SSize_T sio_lite_StreamReader_read__SWIG_1(sio::lite::StreamReader *self,long long data,size_t size){
         sys::byte* buffer = reinterpret_cast<sys::byte*>(data);
         return self->read(buffer, size);
     }
@@ -7664,9 +7701,10 @@ fail:
 SWIGINTERN PyObject *_wrap_FileHeader_userDataFieldExists(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   sio::lite::FileHeader *arg1 = (sio::lite::FileHeader *) 0 ;
-  std::string arg2 ;
+  std::string *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   bool result;
@@ -7679,17 +7717,21 @@ SWIGINTERN PyObject *_wrap_FileHeader_userDataFieldExists(PyObject *SWIGUNUSEDPA
   arg1 = reinterpret_cast< sio::lite::FileHeader * >(argp1);
   {
     std::string *ptr = (std::string *)0;
-    int res = SWIG_AsPtr_std_string(obj1, &ptr);
-    if (!SWIG_IsOK(res) || !ptr) {
-      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "FileHeader_userDataFieldExists" "', argument " "2"" of type '" "std::string""'"); 
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FileHeader_userDataFieldExists" "', argument " "2"" of type '" "std::string const &""'"); 
     }
-    arg2 = *ptr;
-    if (SWIG_IsNewObj(res)) delete ptr;
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FileHeader_userDataFieldExists" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
   }
-  result = (bool)((sio::lite::FileHeader const *)arg1)->userDataFieldExists(arg2);
+  result = (bool)((sio::lite::FileHeader const *)arg1)->userDataFieldExists((std::string const &)*arg2);
   resultobj = SWIG_From_bool(static_cast< bool >(result));
+  if (SWIG_IsNewObj(res2)) delete arg2;
   return resultobj;
 fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
   return NULL;
 }
 
@@ -7752,9 +7794,10 @@ fail:
 SWIGINTERN PyObject *_wrap_FileHeader_getUserData(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   sio::lite::FileHeader *arg1 = (sio::lite::FileHeader *) 0 ;
-  std::string arg2 ;
+  std::string *arg2 = 0 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
+  int res2 = SWIG_OLDOBJ ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   std::vector< sys::byte > *result = 0 ;
@@ -7767,23 +7810,27 @@ SWIGINTERN PyObject *_wrap_FileHeader_getUserData(PyObject *SWIGUNUSEDPARM(self)
   arg1 = reinterpret_cast< sio::lite::FileHeader * >(argp1);
   {
     std::string *ptr = (std::string *)0;
-    int res = SWIG_AsPtr_std_string(obj1, &ptr);
-    if (!SWIG_IsOK(res) || !ptr) {
-      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "FileHeader_getUserData" "', argument " "2"" of type '" "std::string""'"); 
+    res2 = SWIG_AsPtr_std_string(obj1, &ptr);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FileHeader_getUserData" "', argument " "2"" of type '" "std::string const &""'"); 
     }
-    arg2 = *ptr;
-    if (SWIG_IsNewObj(res)) delete ptr;
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FileHeader_getUserData" "', argument " "2"" of type '" "std::string const &""'"); 
+    }
+    arg2 = ptr;
   }
   try {
-    result = (std::vector< sys::byte > *) &(arg1)->getUserData(arg2);
+    result = (std::vector< sys::byte > *) &(arg1)->getUserData((std::string const &)*arg2);
   }
   catch(except::NoSuchKeyException &_e) {
     SWIG_Python_Raise(SWIG_NewPointerObj((new except::NoSuchKeyException(static_cast< const except::NoSuchKeyException& >(_e))),SWIGTYPE_p_except__NoSuchKeyException,SWIG_POINTER_OWN), "except::NoSuchKeyException", SWIGTYPE_p_except__NoSuchKeyException); SWIG_fail;
   }
   
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_std__vectorT_char_t, 0 |  0 );
+  if (SWIG_IsNewObj(res2)) delete arg2;
   return resultobj;
 fail:
+  if (SWIG_IsNewObj(res2)) delete arg2;
   return NULL;
 }
 
@@ -8682,12 +8729,12 @@ SWIGINTERN PyObject *_wrap_FileWriter_write__SWIG_6(PyObject *SWIGUNUSEDPARM(sel
   PyObject *resultobj = 0;
   sio::lite::FileWriter *arg1 = (sio::lite::FileWriter *) 0 ;
   sio::lite::FileHeader *arg2 = (sio::lite::FileHeader *) 0 ;
-  size_t arg3 ;
+  long long arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 = 0 ;
   int res2 = 0 ;
-  size_t val3 ;
+  long long val3 ;
   int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
@@ -8704,11 +8751,11 @@ SWIGINTERN PyObject *_wrap_FileWriter_write__SWIG_6(PyObject *SWIGUNUSEDPARM(sel
     SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FileWriter_write" "', argument " "2"" of type '" "sio::lite::FileHeader *""'"); 
   }
   arg2 = reinterpret_cast< sio::lite::FileHeader * >(argp2);
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  ecode3 = SWIG_AsVal_long_SS_long(obj2, &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "FileWriter_write" "', argument " "3"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "FileWriter_write" "', argument " "3"" of type '" "long long""'");
   } 
-  arg3 = static_cast< size_t >(val3);
+  arg3 = static_cast< long long >(val3);
   sio_lite_FileWriter_write__SWIG_6(arg1,arg2,arg3);
   resultobj = SWIG_Py_Void();
   return resultobj;
@@ -8777,7 +8824,7 @@ SWIGINTERN PyObject *_wrap_FileWriter_write(PyObject *self, PyObject *args) {
       _v = SWIG_CheckState(res);
       if (_v) {
         {
-          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
           _v = SWIG_CheckState(res);
         }
         if (_v) {
@@ -8940,7 +8987,7 @@ fail:
     "    sio::lite::FileWriter::write(sio::lite::FileHeader *,void const *)\n"
     "    sio::lite::FileWriter::write(int,int,int,int,void const *,int)\n"
     "    sio::lite::FileWriter::write(int,int,int,int,void const *)\n"
-    "    sio::lite::FileWriter::write(sio::lite::FileHeader *,size_t)\n");
+    "    sio::lite::FileWriter::write(sio::lite::FileHeader *,long long)\n");
   return 0;
 }
 
@@ -9425,11 +9472,11 @@ fail:
 SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   sio::lite::StreamReader *arg1 = (sio::lite::StreamReader *) 0 ;
-  size_t arg2 ;
+  long long arg2 ;
   size_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  size_t val2 ;
+  long long val2 ;
   int ecode2 = 0 ;
   size_t val3 ;
   int ecode3 = 0 ;
@@ -9444,11 +9491,11 @@ SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(se
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StreamReader_read" "', argument " "1"" of type '" "sio::lite::StreamReader *""'"); 
   }
   arg1 = reinterpret_cast< sio::lite::StreamReader * >(argp1);
-  ecode2 = SWIG_AsVal_size_t(obj1, &val2);
+  ecode2 = SWIG_AsVal_long_SS_long(obj1, &val2);
   if (!SWIG_IsOK(ecode2)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StreamReader_read" "', argument " "2"" of type '" "size_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "StreamReader_read" "', argument " "2"" of type '" "long long""'");
   } 
-  arg2 = static_cast< size_t >(val2);
+  arg2 = static_cast< long long >(val2);
   ecode3 = SWIG_AsVal_size_t(obj2, &val3);
   if (!SWIG_IsOK(ecode3)) {
     SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StreamReader_read" "', argument " "3"" of type '" "size_t""'");
@@ -9483,7 +9530,7 @@ SWIGINTERN PyObject *_wrap_StreamReader_read(PyObject *self, PyObject *args) {
     _v = SWIG_CheckState(res);
     if (_v) {
       {
-        int res = SWIG_AsVal_size_t(argv[1], NULL);
+        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
         _v = SWIG_CheckState(res);
       }
       if (_v) {
@@ -9521,7 +9568,7 @@ fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'StreamReader_read'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    sio::lite::StreamReader::read(sys::byte *,size_t)\n"
-    "    sio::lite::StreamReader::read(size_t,size_t)\n");
+    "    sio::lite::StreamReader::read(long long,size_t)\n");
   return 0;
 }
 
@@ -9942,10 +9989,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FileHeader_setNullTerminationFlag", _wrap_FileHeader_setNullTerminationFlag, METH_VARARGS, (char *)"FileHeader_setNullTerminationFlag(FileHeader self, bool flag)"},
 	 { (char *)"FileHeader_isDifferentByteOrdering", _wrap_FileHeader_isDifferentByteOrdering, METH_VARARGS, (char *)"FileHeader_isDifferentByteOrdering(FileHeader self) -> bool"},
 	 { (char *)"FileHeader_setIsDifferentByteOrdering", _wrap_FileHeader_setIsDifferentByteOrdering, METH_VARARGS, (char *)"FileHeader_setIsDifferentByteOrdering(FileHeader self, bool isDifferent)"},
-	 { (char *)"FileHeader_userDataFieldExists", _wrap_FileHeader_userDataFieldExists, METH_VARARGS, (char *)"FileHeader_userDataFieldExists(FileHeader self, std::string key) -> bool"},
+	 { (char *)"FileHeader_userDataFieldExists", _wrap_FileHeader_userDataFieldExists, METH_VARARGS, (char *)"FileHeader_userDataFieldExists(FileHeader self, std::string const & key) -> bool"},
 	 { (char *)"FileHeader_getAllUserDataFields", _wrap_FileHeader_getAllUserDataFields, METH_VARARGS, (char *)"FileHeader_getAllUserDataFields(FileHeader self, std::vector< std::string > & keys)"},
 	 { (char *)"FileHeader_getNumUserDataFields", _wrap_FileHeader_getNumUserDataFields, METH_VARARGS, (char *)"FileHeader_getNumUserDataFields(FileHeader self) -> size_t"},
-	 { (char *)"FileHeader_getUserData", _wrap_FileHeader_getUserData, METH_VARARGS, (char *)"FileHeader_getUserData(FileHeader self, std::string key) -> std::vector< sys::byte > &"},
+	 { (char *)"FileHeader_getUserData", _wrap_FileHeader_getUserData, METH_VARARGS, (char *)"FileHeader_getUserData(FileHeader self, std::string const & key) -> std::vector< sys::byte > &"},
 	 { (char *)"FileHeader_getUserDataSection", _wrap_FileHeader_getUserDataSection, METH_VARARGS, (char *)"\n"
 		"getUserDataSection() -> sio::lite::UserDataDictionary const\n"
 		"FileHeader_getUserDataSection(FileHeader self) -> sio::lite::UserDataDictionary &\n"
@@ -9971,7 +10018,7 @@ static PyMethodDef SwigMethods[] = {
 		"write(FileHeader header, void const * data)\n"
 		"write(int numLines, int numElements, int elementSize, int elementType, void const * data, int numBands=1)\n"
 		"write(int numLines, int numElements, int elementSize, int elementType, void const * data)\n"
-		"FileWriter_write(FileWriter self, FileHeader header, size_t data)\n"
+		"FileWriter_write(FileWriter self, FileHeader header, long long data)\n"
 		""},
 	 { (char *)"FileWriter_swigregister", FileWriter_swigregister, METH_VARARGS, NULL},
 	 { (char *)"AUTO_swigconstant", AUTO_swigconstant, METH_VARARGS, NULL},
@@ -9994,7 +10041,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"StreamReader_available", _wrap_StreamReader_available, METH_VARARGS, (char *)"StreamReader_available(StreamReader self) -> sys::Off_T"},
 	 { (char *)"StreamReader_read", _wrap_StreamReader_read, METH_VARARGS, (char *)"\n"
 		"read(sys::byte * b, size_t size) -> sys::SSize_T\n"
-		"StreamReader_read(StreamReader self, size_t data, size_t size) -> sys::SSize_T\n"
+		"StreamReader_read(StreamReader self, long long data, size_t size) -> sys::SSize_T\n"
 		""},
 	 { (char *)"StreamReader_swigregister", StreamReader_swigregister, METH_VARARGS, NULL},
 	 { (char *)"delete_FileReader", _wrap_delete_FileReader, METH_VARARGS, (char *)"delete_FileReader(FileReader self)"},

--- a/modules/python/sio.lite/source/sio_lite.i
+++ b/modules/python/sio.lite/source/sio_lite.i
@@ -8,6 +8,17 @@
     #include "import/sio/lite.h"
 %}
 
+// NOTE: In the cases below, need to use 'long long' rather
+//       than 'size_t'.  Otherwise, Swig will generate code
+//       using PyInt_FromLong().  This will work fine on
+//       64-bit Unix where sizeof(long) == 8 and works fine
+//       on 64-bit Windows where sizeof(long) == 4... until
+//       a value gets too large to represent in 4 bytes at
+//       which point you'll get cryptic/confusing runtime
+//       errors.  This happens in particular when trying to
+//       send NumPy arrays to/from C++ when you allocate an
+//       array > 4 GB.  It seems like Swig should be smarter
+//       in what it auto-generates to avoid this.
 %extend sio::lite::FileWriter
 {
     void write(sio::lite::FileHeader* header, long long data)
@@ -19,7 +30,7 @@
 
 %extend sio::lite::StreamReader
 {
-    sys::SSize_T read(long long data, size_t size)
+    sys::SSize_T read(long long data, long long size)
     {
         sys::byte* buffer = reinterpret_cast<sys::byte*>(data);
         return $self->read(buffer, size);

--- a/modules/python/sio.lite/source/sio_lite.i
+++ b/modules/python/sio.lite/source/sio_lite.i
@@ -10,7 +10,7 @@
 
 %extend sio::lite::FileWriter
 {
-    void write(sio::lite::FileHeader* header, size_t data)
+    void write(sio::lite::FileHeader* header, long long data)
     {
         const void* buffer = reinterpret_cast<const void*>(data);
         $self->write(header, buffer);
@@ -19,7 +19,7 @@
 
 %extend sio::lite::StreamReader
 {
-    sys::SSize_T read(size_t data, size_t size)
+    sys::SSize_T read(long long data, size_t size)
     {
         sys::byte* buffer = reinterpret_cast<sys::byte*>(data);
         return $self->read(buffer, size);


### PR DESCRIPTION
Large NumPy arrays going to/from C++ did not work properly on 64-bit Windows because Swig was trying to use a `long` to represent a `size_t` (which is 8 bytes on Unix so is ok but only 4 bytes on Windows)... you got a cryptic runtime error about it not being able to find the appropriate function because the conversion would fail in the C++ bindings.  To force Swig to generate C++ code with an 8 byte type, the only thing that seemed to make it do this was using `long long` (seems like it should have been smarter with `size_t` than it was).

@chvink @clydestanfield