### PR TITLE
Updates to net.ssl 

### DIFF
--- a/modules/c++/net.ssl/include/net/ssl/SSLConnection.h
+++ b/modules/c++/net.ssl/include/net/ssl/SSLConnection.h
@@ -20,12 +20,13 @@
  *
  */
 
-#if defined(USE_OPENSSL)
  
 #ifndef __NET_SSL_CONNECTION_H__
 #define __NET_SSL_CONNECTION_H__
 
-#include "net/NetConnection.h"
+#include <net/ssl/net_ssl_config.h>
+#if defined(USE_OPENSSL)
+#include <net/NetConnection.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 

--- a/modules/c++/net.ssl/include/net/ssl/SSLConnectionClientFactory.h
+++ b/modules/c++/net.ssl/include/net/ssl/SSLConnectionClientFactory.h
@@ -28,9 +28,9 @@
  *  \brief Contains class for creating client socket connections
  *  This class hides the details of client creation.
  */
- 
-#include "net/NetConnectionClientFactory.h"
-#include "net/ssl/SSLConnection.h"
+
+#include <net/NetConnectionClientFactory.h>
+#include <net/ssl/SSLConnection.h>
 
 namespace net
 {
@@ -76,12 +76,12 @@ public:
      */
     virtual ~SSLConnectionClientFactory() 
     {
-#               if defined(USE_OPENSSL)	
+# if defined(USE_OPENSSL)	
         if(mCtx != NULL)
         {
             SSL_CTX_free(mCtx);
         }
-#              endif
+# endif
     }
 
 protected:

--- a/modules/c++/net.ssl/source/SSLConnection.cpp
+++ b/modules/c++/net.ssl/source/SSLConnection.cpp
@@ -20,11 +20,10 @@
  *
  */
 
+#include <net/ssl/SSLConnection.h>
+#include <net/ssl/SSLExceptions.h>
 #if defined(USE_OPENSSL)
  
-#include "net/ssl/SSLConnection.h"
-#include "net/ssl/SSLExceptions.h"
-
 net::ssl::SSLConnection::SSLConnection(std::auto_ptr<net::Socket> socket, 
                                        SSL_CTX * ctx,
                                        bool serverAuth,

--- a/modules/c++/net.ssl/source/SSLConnectionClientFactory.cpp
+++ b/modules/c++/net.ssl/source/SSLConnectionClientFactory.cpp
@@ -51,8 +51,13 @@ void net::ssl::SSLConnectionClientFactory::initializeContext()
 #if defined(USE_OPENSSL)
     SSL_library_init();
     SSL_load_error_strings();
-    
+
+#if defined(OPENSSL_0_9_8)
     SSL_METHOD *method = SSLv23_client_method();
+#else
+    const SSL_METHOD *method = SSLv23_client_method();
+#endif
+
     if(method == NULL)
     {
         throw net::ssl::SSLException(Ctxt(FmtX("SSLv23_client_method failed")));

--- a/modules/c++/net.ssl/tests/SSLTestClientNoURL.cpp
+++ b/modules/c++/net.ssl/tests/SSLTestClientNoURL.cpp
@@ -49,7 +49,8 @@ int main(int argc, char **argv)
         cout << port << endl;
 
         cout << "Connecting to: " << host << ":" << port << endl;
-        URL url(host, port);
+        URL url(host);
+        url.setPort(port);
 
         net::ssl::SSLConnectionClientFactory clientBuilder;
         NetConnection * toUrl = clientBuilder.create(url);

--- a/modules/c++/net.ssl/wscript
+++ b/modules/c++/net.ssl/wscript
@@ -5,6 +5,7 @@ MODULE_DEPS     = 'net'
 USELIB          = 'SSL'
 
 from waflib import Options
+from build import writeConfig
 
 distclean = lambda p: None
 
@@ -13,75 +14,107 @@ def options(opt):
                    help='Specify the OpenSSL home directory')
 
 def configure(conf):
-    sslHome = Options.options.ssl_home
-    sslLib = 'ssl'
-    sslUselib = 'SSL'
-    sslHeader = 'openssl/ssl.h'
-    sslFunction = 'SSL_library_init'
-    sslDef = 'USE_OPENSSL'
-    sslOldDef = 'OPENSSL_0_9_8'
-    sslFragment098 = '''
-        #include "openssl/ssl.h"
-        int main()
-        {
-            SSL_library_init();
-            SSL_load_error_strings();
+    uselib = None
+    include_path = None
+    lib_path = None
 
-            SSL_METHOD *method = SSLv23_client_method();
-            SSL_CTX* ctx = SSL_CTX_new(method);
-            return 0;
-        }
-        '''
-    sslFragment100 = '''
-        #include "openssl/ssl.h"
-        int main()
-        {
-            SSL_library_init();
-            SSL_load_error_strings();
+    class NetSSLCallback:
+        def __init__(self):
+            self.uselib = None
+            self.includes = None
+            self.libpath = None
 
-            const SSL_METHOD *method = SSLv23_client_method();
-            SSL_CTX* ctx = SSL_CTX_new(method);
-            return 0;
-        }
-        '''
+        def __call__(self, conf):
+            sslHome = Options.options.ssl_home
+            sslLib = 'ssl'
+            sslUselib = 'SSL'
+            sslHeader = 'openssl/ssl.h'
+            sslFunction = 'SSL_library_init'
+            sslDef = 'USE_OPENSSL'
+            sslOldDef = 'OPENSSL_0_9_8'
+            sslFragment098 = '''
+                #include "openssl/ssl.h"
+                int main()
+                {
+                    SSL_library_init();
+                    SSL_load_error_strings();
 
-    if sslHome:
-        if conf.check(lib=sslLib, uselib_store=sslUselib,
-                      header_name=sslHeader,
-                      function_name=sslFunction,
-                      fragment=sslFragment098,
-                      libpath=os.path.join(sslHome, 'lib'),
-                      includes=os.path.join(sslHome, 'include'),
-                      msg='Checking for version 0.9.8 ssl library',
-                      okmsg=sslHome,
-                      mandatory=False):
-            conf.define(sslOldDef, True)
-        else:
-            conf.check(lib=sslLib, uselib_store=sslUselib,
-                       header_name=sslHeader,
-                       function_name=sslFunction,
-                       fragment=sslFragment100,
-                       libpath=os.path.join(sslHome, 'lib'),
-                       includes=os.path.join(sslHome, 'include'),
-                       msg='Checking for version library',
-                       okmsg=sslHome,
-                       mandatory=True)
-        conf.define(sslDef, True)
-    elif conf.check(lib=sslLib, uselib_store=sslUselib,
-                    header_name=sslHeader,
-                    function_name=sslFunction,
-                    fragment=sslFragment098,
-                    msg='Checking for version 0.9.8 ssl library',
-                    mandatory=False):
-        conf.define(sslDef, True)
-        conf.define(sslOldDef, True)
-    elif conf.check(lib=sslLib, uselib_store=sslUselib,
-                    header_name=sslHeader,
-                    function_name=sslFunction,
-                    fragment=sslFragment100,
-                    msg='Checking for version library',
-                    mandatory=False):
-        conf.define(sslDef, True)
+                    SSL_METHOD *method = SSLv23_client_method();
+                    SSL_CTX* ctx = SSL_CTX_new(method);
+                    return 0;
+                }
+                '''
+            sslFragment100 = '''
+                #include "openssl/ssl.h"
+                int main()
+                {
+                    SSL_library_init();
+                    SSL_load_error_strings();
+
+                    const SSL_METHOD *method = SSLv23_client_method();
+                    SSL_CTX* ctx = SSL_CTX_new(method);
+                    return 0;
+                }
+                '''
+
+            if sslHome:
+                if conf.check(lib=sslLib, uselib_store=sslUselib,
+                              header_name=sslHeader,
+                              function_name=sslFunction,
+                              fragment=sslFragment098,
+                              libpath=os.path.join(sslHome, 'lib'),
+                              includes=os.path.join(sslHome, 'include'),
+                              msg='Checking for version 0.9.8 of ssl library',
+                              okmsg=sslHome,
+                              define_name=sslOldDef,
+                              mandatory=False):
+                    conf.define(sslOldDef, True)
+                else:
+                    conf.check(lib=sslLib, uselib_store=sslUselib,
+                               header_name=sslHeader,
+                               function_name=sslFunction,
+                               fragment=sslFragment100,
+                               libpath=os.path.join(sslHome, 'lib'),
+                               includes=os.path.join(sslHome, 'include'),
+                               msg='Checking for version 1.0.0 of ssl library',
+                               okmsg=sslHome,
+                               mandatory=True)
+                conf.define(sslDef, True)
+            elif conf.check(lib=sslLib, uselib_store=sslUselib,
+                            header_name=sslHeader,
+                            function_name=sslFunction,
+                            fragment=sslFragment098,
+                            msg='Checking for version 0.9.8 of ssl library',
+                            mandatory=False):
+                conf.define(sslDef, True)
+                conf.define(sslOldDef, True)
+            elif conf.check(lib=sslLib, uselib_store=sslUselib,
+                            header_name=sslHeader,
+                            function_name=sslFunction,
+                            fragment=sslFragment100,
+                            msg='Checking for version 1.0.0 of ssl library',
+                            mandatory=False):
+                conf.define(sslDef, True)
+
+            # Update library information
+            if 'LIB_SSL' in conf.env:
+                self.uselib = conf.env['LIB_SSL']
+            if 'LIBPATH_SSL' in conf.env:
+                self.libpath = conf.env['LIBPATH_SSL']
+            if 'INCLUDES_SSL' in conf.env:
+                self.includes = conf.env['INCLUDES_SSL']
+
+        def updateConf(self, conf):
+            if self.uselib:
+                conf.env['LIB_SSL'] = self.uselib
+            if self.libpath:
+                conf.env['LIBPATH_SSL'] = self.libpath
+            if self.includes:
+                conf.env['INCLUDES_SSL'] = self.includes
+
+    netSSLCallback = NetSSLCallback()
+    writeConfig(conf, netSSLCallback, NAME)
+    netSSLCallback.updateConf(conf)
 
 def build(bld):
     bld.module(**globals())

--- a/modules/c++/net.ssl/wscript
+++ b/modules/c++/net.ssl/wscript
@@ -2,8 +2,86 @@ NAME            = 'net.ssl'
 MAINTAINER      = 'jmrandol@users.sourceforge.net'
 VERSION         = '1.0'
 MODULE_DEPS     = 'net'
+USELIB          = 'SSL'
 
-options = configure = distclean = lambda p: None
+from waflib import Options
+
+distclean = lambda p: None
+
+def options(opt):
+    opt.add_option('--with-ssl-home', action='store', dest='ssl_home',
+                   help='Specify the OpenSSL home directory')
+
+def configure(conf):
+    sslHome = Options.options.ssl_home
+    sslLib = 'ssl'
+    sslUselib = 'SSL'
+    sslHeader = 'openssl/ssl.h'
+    sslFunction = 'SSL_library_init'
+    sslDef = 'USE_OPENSSL'
+    sslOldDef = 'OPENSSL_0_9_8'
+    sslFragment098 = '''
+        #include "openssl/ssl.h"
+        int main()
+        {
+            SSL_library_init();
+            SSL_load_error_strings();
+
+            SSL_METHOD *method = SSLv23_client_method();
+            SSL_CTX* ctx = SSL_CTX_new(method);
+            return 0;
+        }
+        '''
+    sslFragment100 = '''
+        #include "openssl/ssl.h"
+        int main()
+        {
+            SSL_library_init();
+            SSL_load_error_strings();
+
+            const SSL_METHOD *method = SSLv23_client_method();
+            SSL_CTX* ctx = SSL_CTX_new(method);
+            return 0;
+        }
+        '''
+
+    if sslHome:
+        if conf.check(lib=sslLib, uselib_store=sslUselib,
+                      header_name=sslHeader,
+                      function_name=sslFunction,
+                      fragment=sslFragment098,
+                      libpath=os.path.join(sslHome, 'lib'),
+                      includes=os.path.join(sslHome, 'include'),
+                      msg='Checking for version 0.9.8 ssl library',
+                      okmsg=sslHome,
+                      mandatory=False):
+            conf.define(sslOldDef, True)
+        else:
+            conf.check(lib=sslLib, uselib_store=sslUselib,
+                       header_name=sslHeader,
+                       function_name=sslFunction,
+                       fragment=sslFragment100,
+                       libpath=os.path.join(sslHome, 'lib'),
+                       includes=os.path.join(sslHome, 'include'),
+                       msg='Checking for version library',
+                       okmsg=sslHome,
+                       mandatory=True)
+        conf.define(sslDef, True)
+    elif conf.check(lib=sslLib, uselib_store=sslUselib,
+                    header_name=sslHeader,
+                    function_name=sslFunction,
+                    fragment=sslFragment098,
+                    msg='Checking for version 0.9.8 ssl library',
+                    mandatory=False):
+        conf.define(sslDef, True)
+        conf.define(sslOldDef, True)
+    elif conf.check(lib=sslLib, uselib_store=sslUselib,
+                    header_name=sslHeader,
+                    function_name=sslFunction,
+                    fragment=sslFragment100,
+                    msg='Checking for version library',
+                    mandatory=False):
+        conf.define(sslDef, True)
 
 def build(bld):
     bld.module(**globals())


### PR DESCRIPTION
net.ssl now finds the openssl libraries and builds all its source by default.

There is an interface change between openssl 0.9.8(open) and openssl 1.0(back). I resolved this by building a fragment to determine which version we are using. If there is a better way to resolve this let me know.