### PR TITLE
Allow newConnection Overrides

### DIFF
--- a/modules/c++/net/include/net/NetConnectionClientFactory.h
+++ b/modules/c++/net/include/net/NetConnectionClientFactory.h
@@ -81,7 +81,7 @@ public:
      *
      *
      */
-    NetConnection* newConnection(std::auto_ptr<Socket> toServer);
+    virtual NetConnection* newConnection(std::auto_ptr<Socket> toServer);
     /*!
      * Destroy a spawned connection.
      * \param connection The connection to destroy


### PR DESCRIPTION
The Open SSL connection needs to be able to override this function.