### PR TITLE
sendto() on Windows wants const char*

### DIFF
--- a/modules/c++/net/source/Socket.cpp
+++ b/modules/c++/net/source/Socket.cpp
@@ -174,7 +174,9 @@ void net::Socket::sendTo(const SocketAddress& address,
                          size_t len,
                          int flags)
 {
-    int numBytes = ::sendto(mNative, b, len, flags,
+    // sendto() second parameter is const void* on Unix but const char* on
+    // Windows
+    int numBytes = ::sendto(mNative, static_cast<const char*>(b), len, flags,
             (const struct sockaddr *) &(address.getAddress()),
             (net::SockLen_T) sizeof(address.getAddress()));
 


### PR DESCRIPTION
Broke the Windows build when changing things over to `void*`... `sendto()` on Unix takes in the buffer as `const void*` but on Windows it's `const char*`, so need to add a cast