### PR TITLE
calling this method with size of zero causes a segfault, because of t…

### DIFF
--- a/modules/c++/io/source/ByteStream.cpp
+++ b/modules/c++/io/source/ByteStream.cpp
@@ -67,6 +67,8 @@ void io::ByteStream::write(const sys::byte *b, sys::Size_T size)
 {
     if (mPosition < 0)
         throw except::Exception(Ctxt("Invalid write on eof"));
+    if (size == 0)
+        return;
 
     sys::Size_T newPos = mPosition + size;
     if (newPos >= mData.size())

--- a/modules/c++/io/source/ByteStream.cpp
+++ b/modules/c++/io/source/ByteStream.cpp
@@ -67,14 +67,17 @@ void io::ByteStream::write(const sys::byte *b, sys::Size_T size)
 {
     if (mPosition < 0)
         throw except::Exception(Ctxt("Invalid write on eof"));
-    if (size == 0)
-        return;
 
-    sys::Size_T newPos = mPosition + size;
-    if (newPos >= mData.size())
-        mData.resize(newPos);
-    std::copy(b, b+size, &mData[mPosition]);
-    mPosition = newPos;
+    // Guard against &mData[mPosition] below indexing out of bounds
+    // when mPosition is still 0
+    if (size > 0)
+    {
+        sys::Size_T newPos = mPosition + size;
+        if (newPos >= mData.size())
+            mData.resize(newPos);
+        std::copy(b, b+size, &mData[mPosition]);
+        mPosition = newPos;
+    }
 }
 
 sys::SSize_T io::ByteStream::read(sys::byte *b, sys::Size_T len)


### PR DESCRIPTION
…he index on line 76. xml::lite is making this call with zero at some point. Though it seems strange it would make a zero sized call, I'm fixing it here because it is ultimately a valid value.