### PR TITLE
Make equality operators non-member functions

### DIFF
--- a/modules/c++/mem/include/mem/ScopedCloneablePtr.h
+++ b/modules/c++/mem/include/mem/ScopedCloneablePtr.h
@@ -87,26 +87,6 @@ public:
         return *this;
     }
 
-    bool operator==(const ScopedCloneablePtr<T>& rhs) const
-    {
-        if (get() == NULL && rhs.get() == NULL)
-        {
-            return true;
-        }
-
-        if (get() == NULL || rhs.get() == NULL)
-        {
-            return false;
-        }
-
-        return (*(this->mPtr) == *rhs);
-    }
-
-    bool operator!=(const ScopedCloneablePtr<T>& rhs) const
-    {
-        return !(*this == rhs);
-    }
-
     T* get() const
     {
         return mPtr.get();
@@ -135,6 +115,28 @@ public:
 private:
     std::auto_ptr<T> mPtr;
 };
+
+template<class T>
+bool operator==(const ScopedCloneablePtr<T>& lhs, const ScopedCloneablePtr<T>& rhs)
+{
+    if (lhs.get() == NULL && rhs.get() == NULL)
+    {
+        return true;
+    }
+
+    if (lhs.get() == NULL || rhs.get() == NULL)
+    {
+        return false;
+    }
+
+    return (*lhs == *rhs);
+}
+
+template<class T>
+bool operator!=(const ScopedCloneablePtr<T>& lhs, const ScopedCloneablePtr<T>& rhs)
+{
+    return !(lhs == rhs);
+}
 }
 
 #endif

--- a/modules/c++/mem/include/mem/ScopedCopyablePtr.h
+++ b/modules/c++/mem/include/mem/ScopedCopyablePtr.h
@@ -87,26 +87,6 @@ public:
         return *this;
     }
 
-    bool operator==(const ScopedCopyablePtr<T>& rhs) const
-    {
-        if (get() == NULL && rhs.get() == NULL)
-        {
-            return true;
-        }
-
-        if (get() == NULL || rhs.get() == NULL)
-        {
-            return false;
-        }
-
-        return (*(this->mPtr) == *rhs);
-    }
-
-    bool operator!=(const ScopedCopyablePtr<T>& rhs) const
-    {
-        return !(*this == rhs);
-    }
-
     T* get() const
     {
         return mPtr.get();
@@ -135,6 +115,28 @@ public:
 private:
     std::auto_ptr<T> mPtr;
 };
+
+template<class T>
+bool operator==(const ScopedCopyablePtr<T>& lhs, const ScopedCopyablePtr<T>& rhs)
+{
+    if (lhs.get() == NULL && rhs.get() == NULL)
+    {
+        return true;
+    }
+
+    if (lhs.get() == NULL || rhs.get() == NULL)
+    {
+        return false;
+    }
+
+    return (*lhs == *rhs);
+}
+
+template<class T>
+bool operator!=(const ScopedCopyablePtr<T>& lhs, const ScopedCopyablePtr<T>& rhs)
+{
+    return !(lhs == rhs);
+}
 }
 
 #endif


### PR DESCRIPTION
This causes SWIG to not wrap the operator.