### PR TITLE
Added isSetEnv and getEnvIfSet

### DIFF
--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -192,9 +192,10 @@ public:
     virtual bool isEnvSet(const std::string& s) const = 0;
 
     /*!
-     *  Get an environment variable, if set
+     *  Get an environment variable and updates value, but only if set.
+     *  Returns true if environment variable is set, false otherwise
      */
-    virtual bool getEnvIfSet(const std::string& envVar, std::string& value) const = 0;
+    bool getEnvIfSet(const std::string& envVar, std::string& value) const;
 
     /*!
      *  Set an environment variable

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -187,6 +187,16 @@ public:
     virtual std::string getEnv(const std::string& s) const = 0;
 
     /*!
+     *  Returns true if environment variable is set, false otherwise
+     */
+    virtual bool isEnvSet(const std::string& s) const = 0;
+
+    /*!
+     *  Get an environment variable, if set
+     */
+    virtual bool getEnvIfSet(const std::string& envVar, std::string& value) const = 0;
+
+    /*!
      *  Set an environment variable
      */
     virtual void setEnv(const std::string& var, 

--- a/modules/c++/sys/include/sys/OSUnix.h
+++ b/modules/c++/sys/include/sys/OSUnix.h
@@ -143,6 +143,17 @@ public:
     virtual std::string getEnv(const std::string& s) const;
 
     /*!
+     * Returns true if environment variable is set, false otherwise
+     */
+    virtual bool isEnvSet(const std::string& s) const;
+
+    /*!
+     * Gets environment variable, if set
+     */
+
+    virtual bool getEnvIfSet(const std::string& envVar, std::string& value) const;
+
+    /*!
      *  Set an environment variable
      */
     virtual void setEnv(const std::string& var, 

--- a/modules/c++/sys/include/sys/OSUnix.h
+++ b/modules/c++/sys/include/sys/OSUnix.h
@@ -148,12 +148,6 @@ public:
     virtual bool isEnvSet(const std::string& s) const;
 
     /*!
-     * Gets environment variable, if set
-     */
-
-    virtual bool getEnvIfSet(const std::string& envVar, std::string& value) const;
-
-    /*!
      *  Set an environment variable
      */
     virtual void setEnv(const std::string& var, 

--- a/modules/c++/sys/include/sys/OSWin32.h
+++ b/modules/c++/sys/include/sys/OSWin32.h
@@ -170,11 +170,6 @@ public:
     virtual bool isEnvSet(const std::string& s) const;
 
     /*!
-     * Gets environment variable, if set
-     */
-    virtual bool getEnvIfSet(const std::string& envVar, std::string& value) const;
-
-    /*!
      *  Set an environment variable
      */
     virtual void setEnv(const std::string& var, 

--- a/modules/c++/sys/include/sys/OSWin32.h
+++ b/modules/c++/sys/include/sys/OSWin32.h
@@ -165,6 +165,16 @@ public:
     virtual std::string getEnv(const std::string& s) const;
 
     /*!
+     * Returns true if environment variable is set, false otherwise
+     */
+    virtual bool isEnvSet(const std::string& s) const;
+
+    /*!
+     * Gets environment variable, if set
+     */
+    virtual bool getEnvIfSet(const std::string& envVar, std::string& value) const;
+
+    /*!
      *  Set an environment variable
      */
     virtual void setEnv(const std::string& var, 

--- a/modules/c++/sys/source/AbstractOS.cpp
+++ b/modules/c++/sys/source/AbstractOS.cpp
@@ -76,4 +76,17 @@ void AbstractOS::remove(const std::string& path) const
         removeFile(path);
     }
 }
+
+bool AbstractOS::getEnvIfSet(const std::string& envVar, std::string& value) const
+{
+    if (isEnvSet(envVar))
+    {
+        value = getEnv(value);
+        return true;
+    }
+    return false;
+}
+
+
+
 }

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -210,6 +210,30 @@ std::string sys::OSUnix::getEnv(const std::string& s) const
     return std::string(p); 
 }
 
+bool sys::OSUnix::isEnvSet(const std::string& s) const
+{
+    try
+    {
+        getEnv(s);
+    }
+    catch(sys::SystemException)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool sys::OSUnix::getEnvIfSet(const std::string& envVar, std::string& value) const
+{
+    if(isEnvSet(envVar))
+    {
+        value = getEnv(value);
+        return true;
+    }
+    return false;
+}
+
+
 void sys::OSUnix::setEnv(const std::string& var, 
                          const std::string& val,
                          bool overwrite)

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -212,27 +212,11 @@ std::string sys::OSUnix::getEnv(const std::string& s) const
 
 bool sys::OSUnix::isEnvSet(const std::string& s) const
 {
-    try
-    {
-        getEnv(s);
-    }
-    catch(sys::SystemException)
-    {
+    const char* p = getenv(s.c_str());
+    if (p == NULL)
         return false;
-    }
     return true;
 }
-
-bool sys::OSUnix::getEnvIfSet(const std::string& envVar, std::string& value) const
-{
-    if(isEnvSet(envVar))
-    {
-        value = getEnv(value);
-        return true;
-    }
-    return false;
-}
-
 
 void sys::OSUnix::setEnv(const std::string& var, 
                          const std::string& val,

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -202,20 +202,18 @@ std::string sys::OSUnix::operator[](const std::string& s) const
 
 std::string sys::OSUnix::getEnv(const std::string& s) const
 {
-    const char* p = getenv(s.c_str());
-    if (p == NULL)
+    const char* envVal = getenv(s.c_str());
+    if (envVal == NULL)
         throw sys::SystemException(
             Ctxt(FmtX("Unable to get unix environment variable %s", 
             s.c_str())));
-    return std::string(p); 
+    return std::string(envVal); 
 }
 
 bool sys::OSUnix::isEnvSet(const std::string& s) const
 {
-    const char* p = getenv(s.c_str());
-    if (p == NULL)
-        return false;
-    return true;
+    const char* envVal = getenv(s.c_str());
+    return (envVal != NULL);
 }
 
 void sys::OSUnix::setEnv(const std::string& var, 

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -28,6 +28,7 @@
 #include "sys/File.h"
 
 #include <iostream>
+#include <vector>
 
 std::string sys::OSWin32::getPlatformName() const
 {
@@ -221,11 +222,10 @@ std::string sys::OSWin32::getEnv(const std::string& s) const
 
     // If we can use a normal size buffer, lets not bother to malloc
 
-    vector<char> buffer;
+    std::vector<char> buffer;
     buffer.resize(size+1);
-    DWORD retVal = GetEnvironmentVariable(s.c_str(), buffer, size);
-    result = buffer;
-
+    DWORD retVal = GetEnvironmentVariable(s.c_str(), static_cast<char*>(&buffer[0]), size);
+    result = static_cast<char*>(&buffer[0]);
     return result;
 }
 

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -232,7 +232,7 @@ std::string sys::OSWin32::getEnv(const std::string& s) const
 bool sys::OSWin32::isEnvSet(const std::string& s) const
 {
     DWORD size = GetEnvironmentVariable(s.c_str(), NULL, 0);
-    return (size != 0)
+    return (size != 0);
 }
 
 void sys::OSWin32::setEnv(const std::string& var, 

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -229,6 +229,29 @@ std::string sys::OSWin32::getEnv(const std::string& s) const
     return result;
 }
 
+bool sys::OSWin32::isEnvSet(const std::string& s) const
+{
+    try
+    {
+        getEnv(s);
+    }
+    catch(sys::SystemException)
+    {
+        return false;
+    }
+    return true;
+}
+
+bool sys::OSWin32:getEnvIfSet(const std::string& envVar, std::string& value) const
+{
+    if(isEnvSet(envVar))
+    {
+        value = getEnv(value);
+        return true;
+    }
+    return false;
+}
+
 void sys::OSWin32::setEnv(const std::string& var, 
                           const std::string& val,
 			  bool overwrite)

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -221,35 +221,20 @@ std::string sys::OSWin32::getEnv(const std::string& s) const
 
     // If we can use a normal size buffer, lets not bother to malloc
 
-    char *buffer = new char[size + 1];
+    vector<char> buffer;
+    buffer.resize(size+1);
     DWORD retVal = GetEnvironmentVariable(s.c_str(), buffer, size);
     result = buffer;
-    delete [] buffer;
 
     return result;
 }
 
 bool sys::OSWin32::isEnvSet(const std::string& s) const
 {
-    try
-    {
-        getEnv(s);
-    }
-    catch(sys::SystemException)
-    {
+    DWORD size = GetEnvironmentVariable(s.c_str(), NULL, 0);
+    if (size == 0)
         return false;
-    }
     return true;
-}
-
-bool sys::OSWin32::getEnvIfSet(const std::string& envVar, std::string& value) const
-{
-    if(isEnvSet(envVar))
-    {
-        value = getEnv(value);
-        return true;
-    }
-    return false;
 }
 
 void sys::OSWin32::setEnv(const std::string& var, 

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -242,7 +242,7 @@ bool sys::OSWin32::isEnvSet(const std::string& s) const
     return true;
 }
 
-bool sys::OSWin32:getEnvIfSet(const std::string& envVar, std::string& value) const
+bool sys::OSWin32::getEnvIfSet(const std::string& envVar, std::string& value) const
 {
     if(isEnvSet(envVar))
     {

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -220,21 +220,19 @@ std::string sys::OSWin32::getEnv(const std::string& s) const
         throw sys::SystemException(Ctxt(FmtX(
             "Unable to get windows environment variable %s", s.c_str())));
 
-    // If we can use a normal size buffer, lets not bother to malloc
-
-    std::vector<char> buffer;
-    buffer.resize(size+1);
-    DWORD retVal = GetEnvironmentVariable(s.c_str(), static_cast<char*>(&buffer[0]), size);
-    result = static_cast<char*>(&buffer[0]);
+    std::vector<char> buffer(size + 1);
+    DWORD retVal = GetEnvironmentVariable(s.c_str(), &buffer[0], size);
+    if (retVal != size)
+        throw sys::SystemException(Ctxt(FmtX(
+           "Environment variable size does not match allocated size for %s", s.c_str())));
+    result = &buffer[0];
     return result;
 }
 
 bool sys::OSWin32::isEnvSet(const std::string& s) const
 {
     DWORD size = GetEnvironmentVariable(s.c_str(), NULL, 0);
-    if (size == 0)
-        return false;
-    return true;
+    return (size != 0)
 }
 
 void sys::OSWin32::setEnv(const std::string& var, 


### PR DESCRIPTION
Picked up some non-code changes  e.g. OSUnix.cpp:257-260 -> 281-284.  Not really sure why, but nothing should have changed in there.

Built on Win & Unix since there's define guards that change compilation on OS type.  Any testing recommendations welcome too.  Didn't see any tests pertaining to env var in the code base.  Could add a couple, but all I can reasonably think of is:  set -> isenvset -> get .   Let me know what you think here.

Also I added some more duplication of code between Win32 and Unix.  I chose to kept the abstract base class empty, but it might be better from a maintenance standpoint to put that in the base class, so feedback there would also be useful.

