### PR TITLE
Fixing incorrect call to getenv

### DIFF
--- a/modules/c++/sys/source/AbstractOS.cpp
+++ b/modules/c++/sys/source/AbstractOS.cpp
@@ -81,7 +81,7 @@ bool AbstractOS::getEnvIfSet(const std::string& envVar, std::string& value) cons
 {
     if (isEnvSet(envVar))
     {
-        value = getEnv(value);
+        value = getEnv(envVar);
         return true;
     }
     return false;


### PR DESCRIPTION
Well, oops.

@asylvest Should I just commit this as is in orcrist too or will that create more problems?
