### PR TITLE
sys::SemaphoreWin32 max count data type 

### DIFF
--- a/modules/c++/sys/include/sys/SemaphoreWin32.h
+++ b/modules/c++/sys/include/sys/SemaphoreWin32.h
@@ -37,13 +37,9 @@ namespace sys
 class SemaphoreWin32 : public SemaphoreInterface
 {
 public:
-    SemaphoreWin32(unsigned int count = 0, LONG maxCount = std::numeric_limits<LONG>::max());
-    
-    virtual ~SemaphoreWin32()
-    {}
+    SemaphoreWin32(unsigned int count = 0, size_t maxCount = std::numeric_limits<size_t>::max());
 
-    void wait();
-    
+	void wait();
     void signal();
     
     HANDLE& getNative();

--- a/modules/c++/sys/include/sys/SemaphoreWin32.h
+++ b/modules/c++/sys/include/sys/SemaphoreWin32.h
@@ -39,7 +39,7 @@ class SemaphoreWin32 : public SemaphoreInterface
 public:
     SemaphoreWin32(unsigned int count = 0, size_t maxCount = std::numeric_limits<size_t>::max());
 
-	void wait();
+    void wait();
     void signal();
     
     HANDLE& getNative();

--- a/modules/c++/sys/include/sys/SemaphoreWin32.h
+++ b/modules/c++/sys/include/sys/SemaphoreWin32.h
@@ -40,6 +40,7 @@ public:
     SemaphoreWin32(unsigned int count = 0, size_t maxCount = std::numeric_limits<size_t>::max());
 
     void wait();
+
     void signal();
     
     HANDLE& getNative();

--- a/modules/c++/sys/source/SemaphoreWin32.cpp
+++ b/modules/c++/sys/source/SemaphoreWin32.cpp
@@ -27,12 +27,15 @@
 
 #include "sys/SemaphoreWin32.h"
 
-sys::SemaphoreWin32::SemaphoreWin32(unsigned int count, LONG maxCount)
+sys::SemaphoreWin32::SemaphoreWin32(unsigned int count, size_t _maxCount)
 {
+	// Ensure maxCount never becomes negative due to casting between signed/unsigned types
+	const LONG maxLong = std::numeric_limits<LONG>::max();
+	LONG maxCount = (_maxCount > maxLong) ? maxLong : static_cast<LONG>(_maxCount);
+
     mNative = CreateSemaphore(NULL, count, maxCount, NULL);
     if (mNative == NULL)
         throw sys::SystemException("CreateSemaphore Failed");
-
 }
 
 void sys::SemaphoreWin32::wait()


### PR DESCRIPTION
`sys::SemaphoreWin32` has a max count data type of `LONG` which is a valid Windows #define. However, some evil libraries define that or undefine it for themselves, so we should only reference it in the .cpp file not the .h file. Modify the class definition and .h file to use a `size_t` for max count, then cast to `LONG` in the .cpp file.