### PR TITLE
Remove plugin manager warning

### DIFF
--- a/modules/c++/plugin/include/plugin/ErrorHandler.h
+++ b/modules/c++/plugin/include/plugin/ErrorHandler.h
@@ -25,6 +25,7 @@
 
 #include <import/except.h>
 #include <import/sys.h>
+#include <import/logging.h>
 
 namespace plugin
 {
@@ -44,8 +45,7 @@ public:
 class DefaultErrorHandler : public ErrorHandler
 {
 public:
-    DefaultErrorHandler();
-    virtual ~DefaultErrorHandler();
+    DefaultErrorHandler(logging::Logger* = NULL);
 
     virtual void onPluginDirectoryNotFound(const std::string& dir);
 
@@ -56,6 +56,9 @@ public:
     virtual void onPluginVersionUnsupported(const std::string& message);
 
     virtual void onPluginError(except::Context& c);
+
+protected:
+    logging::Logger* mLogger;
 };
 
 }

--- a/modules/c++/plugin/source/ErrorHandler.cpp
+++ b/modules/c++/plugin/source/ErrorHandler.cpp
@@ -22,8 +22,10 @@
 
 #include "plugin/ErrorHandler.h"
 
-plugin::DefaultErrorHandler::DefaultErrorHandler() {}
-plugin::DefaultErrorHandler::~DefaultErrorHandler() {}
+plugin::DefaultErrorHandler::DefaultErrorHandler(logging::Logger* logger) :
+	mLogger(logger)
+{
+}
 
 void plugin::DefaultErrorHandler::
 onPluginDirectoryNotFound(const std::string& dir)
@@ -31,26 +33,28 @@ onPluginDirectoryNotFound(const std::string& dir)
     throw except::FileNotFoundException(
         Ctxt(std::string("Plugin directory not found: ") +
              dir)
-
     );
 }
 
 void plugin::DefaultErrorHandler::onPluginLoadFailed(const std::string& file)
 {
-    std::cout << "Warning: plugin manager failed to load: " << file << std::endl;
+    if (mLogger)
+        mLogger->warn("Plugin manager failed to load: " + file);
 }
 
 void plugin::DefaultErrorHandler::onPluginLoadedAlready(const std::string& file)
 {
-    std::cout << "Warning: plugin manager already loaded: " << file << std::endl;
+    if (mLogger)
+        mLogger->warn("Plugin manager already loaded: " + file);
 }
 
 
 void plugin::DefaultErrorHandler::onPluginVersionUnsupported(const std::string& message)
 {
-    std::cout << "Warning: " << message << std::endl;
+    if (mLogger)
+        mLogger->warn(message);
 }
+
 void plugin::DefaultErrorHandler::onPluginError(except::Context&)
 {
 }
-

--- a/modules/c++/plugin/wscript
+++ b/modules/c++/plugin/wscript
@@ -1,7 +1,7 @@
 NAME            = 'plugin'
 MAINTAINER      = 'jmrandol@users.sourceforge.net'
 VERSION         = '1.0'
-MODULE_DEPS     = 'io mem'
+MODULE_DEPS     = 'io mem logging'
 
 options = configure = distclean = lambda p: None
 


### PR DESCRIPTION
When the plugin manager finds a DLL or SO that doesn't fit the "plugin" mold, it prints out a warning to stdout or stderr "Warning: plugin manager failed to load: Failed to load function: GetPluginIdentity: The specified procedure could not be found"

I added an optional logger to `DefaultErrorHandler` that will pass all messages to the logger rather than cout when specified. The plugin module now has a dependency on the logging module because of this.
