### PR TITLE
str::lower and str::upper can fail/crash if a string contains a signed char

### DIFF
--- a/modules/c++/str/source/Manip.cpp
+++ b/modules/c++/str/source/Manip.cpp
@@ -24,6 +24,8 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <climits>
+#include <cstdio>
 
 void str::trim(std::string & s)
 {

--- a/modules/c++/str/source/Manip.cpp
+++ b/modules/c++/str/source/Manip.cpp
@@ -223,13 +223,34 @@ std::vector<std::string> str::split(const std::string& s,
     return vec;
 }
 
+static int transformCheck(int c, int (*transform)(int))
+{
+    // Ensure the character can be represented
+    // as an unsigned char or is 'EOF', as the
+    // behavior for all other characters is undefined
+    if ((c >= 0 && c <= UCHAR_MAX) || c == EOF)
+        return transform(c);
+    else
+        throw except::Exception("Invalid character for upper/lower transform");
+}
+
+static int tolowerCheck(int c)
+{
+    return transformCheck(c, (int(*)(int)) tolower);
+}
+
+static int toupperCheck(int c)
+{
+    return transformCheck(c, (int(*)(int)) toupper);
+}
+
 void str::lower(std::string& s)
 {
-    std::transform(s.begin(), s.end(), s.begin(), (int(*)(int)) tolower);
+    std::transform(s.begin(), s.end(), s.begin(), (int(*)(int)) tolowerCheck);
 }
 
 void str::upper(std::string& s)
 {
-    std::transform(s.begin(), s.end(), s.begin(), (int(*)(int)) toupper);
+    std::transform(s.begin(), s.end(), s.begin(), (int(*)(int)) toupperCheck);
 }
 


### PR DESCRIPTION
See http://en.cppreference.com/w/c/string/byte/tolower

In particular: character to be converted. If the value of ch is not representable as unsigned char and does not equal EOF, the behavior is undefined.

The undefined behavior on windows is to crash.

I added an helper function for std::transform that makes sure the characters are valid. An exception is thrown otherwise.