### PR TITLE
Make the logger member of DefaultErrorHandler a SharedPtr & reduce some log levels.

### DIFF
--- a/modules/c++/logging/include/logging/Logger.h
+++ b/modules/c++/logging/include/logging/Logger.h
@@ -149,5 +149,6 @@ protected:
     Handlers_T mHandlers;
 
 };
+typedef mem::SharedPtr<Logger> LoggerPtr;
 }
 #endif

--- a/modules/c++/logging/include/logging/Setup.h
+++ b/modules/c++/logging/include/logging/Setup.h
@@ -45,7 +45,7 @@ namespace logging
  *  \param logCount - number of rotating logs to keep (default: 0 no rotation)
  *  \param logBytes - number of bytes per rotating log (default: 0 no rotation)
  */
-std::auto_ptr<logging::Logger> setupLogger(
+LoggerPtr setupLogger(
     const std::string& program, 
     const std::string& logLevel = "warning", 
     const std::string& logFile = "console",

--- a/modules/c++/logging/source/Setup.cpp
+++ b/modules/c++/logging/source/Setup.cpp
@@ -30,7 +30,7 @@
 
 #include "logging/Setup.h"
 
-std::auto_ptr<logging::Logger> 
+logging::LoggerPtr
 logging::setupLogger(const std::string& program, 
                      const std::string& logLevel, 
                      const std::string& logFile,
@@ -38,7 +38,7 @@ logging::setupLogger(const std::string& program,
                      size_t logCount,
                      size_t logBytes)
 {
-    std::auto_ptr <logging::Logger> log(new logging::Logger(program));
+    LoggerPtr log(new logging::Logger(program));
 
     // setup logging level
     std::string lev = logLevel;

--- a/modules/c++/plugin/include/plugin/ErrorHandler.h
+++ b/modules/c++/plugin/include/plugin/ErrorHandler.h
@@ -33,32 +33,37 @@ class ErrorHandler
 {
 public:
     ErrorHandler() {}
+
     virtual ~ErrorHandler() {}
 
     virtual void onPluginDirectoryNotFound(const std::string& dir) = 0;
+
     virtual void onPluginLoadedAlready(const std::string& file) = 0;
+
     virtual void onPluginLoadFailed(const std::string& file) = 0;
+
     virtual void onPluginVersionUnsupported(const std::string& message) = 0;
+
     virtual void onPluginError(except::Context& c) = 0;
 };
 
 class DefaultErrorHandler : public ErrorHandler
 {
 public:
-    DefaultErrorHandler(logging::Logger* logger = NULL);
+    DefaultErrorHandler(logging::LoggerPtr logger = logging::LoggerPtr());
 
-    virtual void onPluginDirectoryNotFound(const std::string& dir);
+    void onPluginDirectoryNotFound(const std::string& dir);
 
-    virtual void onPluginLoadFailed(const std::string& file);
+    void onPluginLoadedAlready(const std::string& file);
 
-    virtual void onPluginLoadedAlready(const std::string& file);
+    void onPluginLoadFailed(const std::string& file);
 
-    virtual void onPluginVersionUnsupported(const std::string& message);
+    void onPluginVersionUnsupported(const std::string& message);
 
-    virtual void onPluginError(except::Context& c);
+    void onPluginError(except::Context& c);
 
 protected:
-    mem::SharedPtr<logging::Logger> mLogger;
+    logging::LoggerPtr mLogger;
 };
 
 }

--- a/modules/c++/plugin/include/plugin/ErrorHandler.h
+++ b/modules/c++/plugin/include/plugin/ErrorHandler.h
@@ -58,7 +58,7 @@ public:
     virtual void onPluginError(except::Context& c);
 
 protected:
-    logging::Logger* mLogger;
+    mem::SharedPtr<logging::Logger> mLogger;
 };
 
 }

--- a/modules/c++/plugin/source/ErrorHandler.cpp
+++ b/modules/c++/plugin/source/ErrorHandler.cpp
@@ -23,7 +23,7 @@
 #include "plugin/ErrorHandler.h"
 
 plugin::DefaultErrorHandler::DefaultErrorHandler(logging::Logger* logger) :
-	mLogger(logger)
+	mLogger(mem::SharedPtr<logging::Logger>(logger))
 {
 }
 
@@ -38,20 +38,19 @@ onPluginDirectoryNotFound(const std::string& dir)
 
 void plugin::DefaultErrorHandler::onPluginLoadFailed(const std::string& file)
 {
-    if (mLogger)
+    if (mLogger.get())
         mLogger->warn("Plugin manager failed to load: " + file);
 }
 
 void plugin::DefaultErrorHandler::onPluginLoadedAlready(const std::string& file)
 {
-    if (mLogger)
-        mLogger->warn("Plugin manager already loaded: " + file);
+    if (mLogger.get())
+        mLogger->info("Plugin manager already loaded: " + file);
 }
-
 
 void plugin::DefaultErrorHandler::onPluginVersionUnsupported(const std::string& message)
 {
-    if (mLogger)
+    if (mLogger.get())
         mLogger->warn(message);
 }
 

--- a/modules/c++/plugin/source/ErrorHandler.cpp
+++ b/modules/c++/plugin/source/ErrorHandler.cpp
@@ -22,8 +22,8 @@
 
 #include "plugin/ErrorHandler.h"
 
-plugin::DefaultErrorHandler::DefaultErrorHandler(logging::Logger* logger) :
-	mLogger(mem::SharedPtr<logging::Logger>(logger))
+plugin::DefaultErrorHandler::DefaultErrorHandler(logging::LoggerPtr logger) :
+	mLogger(logger)
 {
 }
 

--- a/modules/c++/xml.lite/tests/ValidationTest.cpp
+++ b/modules/c++/xml.lite/tests/ValidationTest.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
         // parse!
         const std::auto_ptr<cli::Results>
             options(parser.parse(argc, (const char**) argv));
-        std::auto_ptr<logging::Logger> log(
+        logging::LoggerPtr log(
             logging::setupLogger("ValidationTest"));
 
         std::vector<std::string> schemaPaths;


### PR DESCRIPTION
As discussed with @msciaramitaro and @asylvest, removing `TaskErrorHandler` broke some behaviors others relied on. This fixes some of it.