### PR TITLE
BufferView constructor should be explicit

### DIFF
--- a/modules/c++/mem/include/mem/BufferView.h
+++ b/modules/c++/mem/include/mem/BufferView.h
@@ -45,7 +45,7 @@ namespace mem
 template <typename T>
 struct BufferView
 {
-    BufferView(T* buffer = NULL, size_t bufferSize = 0) :
+    explicit BufferView(T* buffer = NULL, size_t bufferSize = 0) :
         data(buffer), size(bufferSize)
     {
     }


### PR DESCRIPTION
Don't want implicit conversions from pointer types to `BufferView`s.  That is, we don't want...

```
void foo(mem::BufferView<float> values)
{
}

void someFunc()
{
    float* ptr = new float[10];
    foo(ptr);
}
```

to compile, but previously it would have since the second constructor argument to `BufferView` defaults to 0... it'll look like they passed in a `BufferView` with no bytes.  Just need to add `explicit` to the `BufferView` constructor.