### PR TITLE
Add a reset() overload for mem::SharedPtr which takes an auto_ptr

### DIFF
--- a/modules/c++/mem/include/mem/SharedPtr.h
+++ b/modules/c++/mem/include/mem/SharedPtr.h
@@ -151,7 +151,6 @@ public:
         //       guarantee (i.e. the operation either succeeds or throws - the
         //       underlying object is always in a good state).
         sys::AtomicCounter* const newRefCtr = new sys::AtomicCounter(1);
-        T* ptr = scopedPtr.release();
 
         if (mRefCtr->decrementThenGet() == 0)
         {
@@ -162,14 +161,14 @@ public:
         }
 
         mRefCtr = newRefCtr;
-        mPtr = ptr;
+        mPtr = scopedPtr.release();
     }
 
     void reset(T* ptr = NULL)
     {
         // We take ownership of the pointer no matter what, so
         // temporarily wrap it in an auto_ptr in case creating
-        // the atomic counter throws later on.
+        // the atomic counter throws in the underlying method.
         reset(std::auto_ptr<T>(ptr));
     }
 

--- a/modules/c++/mem/unittests/test_shared_ptr.cpp
+++ b/modules/c++/mem/unittests/test_shared_ptr.cpp
@@ -91,6 +91,25 @@ TEST_CASE(testAutoPtrConstructor)
     TEST_ASSERT_EQ(ptr.getCount(), 1);
 }
 
+TEST_CASE(testAutoPtrReset)
+{
+    // Similar to the construction test,
+    // except using the reset() that takes an auto_ptr
+    int* const rawPtr1 = new int(90);
+    std::auto_ptr<int> autoPtr(rawPtr1);
+
+    int* const rawPtr2 = new int(100);
+    mem::SharedPtr<int> sharedPtr(rawPtr2);
+
+    TEST_ASSERT_EQ(autoPtr.get(), rawPtr1);
+    TEST_ASSERT_EQ(sharedPtr.get(), rawPtr2);
+
+    sharedPtr.reset(autoPtr);
+    TEST_ASSERT_EQ(sharedPtr.get(), rawPtr1);
+    TEST_ASSERT_NULL(autoPtr.get());
+    TEST_ASSERT_EQ(sharedPtr.getCount(), 1);
+}
+
 TEST_CASE(testCopying)
 {
     int * const rawPtr(new int(89));
@@ -236,6 +255,7 @@ int main(int, char**)
 {
    TEST_CHECK(testNullCopying);
    TEST_CHECK(testAutoPtrConstructor);
+   TEST_CHECK(testAutoPtrReset);
    TEST_CHECK(testCopying);
    TEST_CHECK(testAssigning);
    TEST_CHECK(testSyntax);


### PR DESCRIPTION
This is for issue #103 

I added a overload for `mem::SharedPtr<T>::reset` that takes in an `std::auto_ptr<T>` and did a bit of refactoring so we could use the existing code for `reset()`. Also added a unit test.
