### PR TITLE
mem::VectorOfPointers<>::erase

### DIFF
--- a/modules/c++/mem/include/mem/VectorOfPointers.h
+++ b/modules/c++/mem/include/mem/VectorOfPointers.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <vector>
 #include <memory>
+#include <algorithm>
 
 #include <mem/SharedPtr.h>
 
@@ -122,19 +123,7 @@ public:
         return mValues.erase(pos);
     }
 
-    const_iterator erase(const const_iterator &pos)
-    {
-        delete *pos;
-        return mValues.erase(pos);
-    }
-
     iterator erase(const iterator &first, const iterator &last)
-    {
-        std::for_each(first, last, Deleter());
-        return mValues.erase(first, last);
-    }
-
-    const_iterator erase(const const_iterator &first, const const_iterator &last)
     {
         std::for_each(first, last, Deleter());
         return mValues.erase(first, last);
@@ -239,17 +228,7 @@ public:
         return mValues.erase(pos);
     }
 
-    const_iterator erase(const const_iterator &pos)
-    {
-        return mValues.erase(pos);
-    }
-
     iterator erase(const iterator &first, const iterator &last)
-    {
-        return mValues.erase(first, last);
-    }
-
-    const_iterator erase(const const_iterator &first, const const_iterator &last)
     {
         return mValues.erase(first, last);
     }

--- a/modules/c++/mem/include/mem/VectorOfPointers.h
+++ b/modules/c++/mem/include/mem/VectorOfPointers.h
@@ -26,7 +26,6 @@
 #include <cstddef>
 #include <vector>
 #include <memory>
-#include <algorithm>
 
 #include <mem/SharedPtr.h>
 
@@ -129,7 +128,7 @@ public:
         while (iter != last)
         {
             delete *iter;
-            iter++;
+            ++iter;
         }
 
         return mValues.erase(first, last);

--- a/modules/c++/mem/include/mem/VectorOfPointers.h
+++ b/modules/c++/mem/include/mem/VectorOfPointers.h
@@ -116,10 +116,36 @@ public:
     iterator end() { return mValues.end(); }
     const_iterator end() const { return mValues.end(); }
 
+    iterator erase(const iterator &pos)
+    {
+        delete *pos;
+        return mValues.erase(pos);
+    }
+
+    const_iterator erase(const const_iterator &pos)
+    {
+        delete *pos;
+        return mValues.erase(pos);
+    }
+
+    iterator erase(const iterator &first, const iterator &last)
+    {
+        std::for_each(first, last, Deleter());
+        return mValues.erase(first, last);
+    }
+
+    const_iterator erase(const const_iterator &first, const const_iterator &last)
+    {
+        std::for_each(first, last, Deleter());
+        return mValues.erase(first, last);
+    }
+
 private:
     // Noncopyable
     VectorOfPointers(const VectorOfPointers& );
     const VectorOfPointers& operator=(const VectorOfPointers& );
+    
+    struct Deleter { void operator()(T* elem) { delete elem; } };
 
 private:
     std::vector<T*> mValues;
@@ -207,6 +233,26 @@ public:
     const_iterator begin() const { return mValues.begin(); }
     iterator end() { return mValues.end(); }
     const_iterator end() const { return mValues.end(); }
+
+    iterator erase(const iterator &pos)
+    {
+        return mValues.erase(pos);
+    }
+
+    const_iterator erase(const const_iterator &pos)
+    {
+        return mValues.erase(pos);
+    }
+
+    iterator erase(const iterator &first, const iterator &last)
+    {
+        return mValues.erase(first, last);
+    }
+
+    const_iterator erase(const const_iterator &first, const const_iterator &last)
+    {
+        return mValues.erase(first, last);
+    }
 
 private:
     std::vector<SharedPtr<T> > mValues;

--- a/modules/c++/mem/include/mem/VectorOfPointers.h
+++ b/modules/c++/mem/include/mem/VectorOfPointers.h
@@ -117,15 +117,21 @@ public:
     iterator end() { return mValues.end(); }
     const_iterator end() const { return mValues.end(); }
 
-    iterator erase(const iterator &pos)
+    iterator erase(iterator pos)
     {
         delete *pos;
         return mValues.erase(pos);
     }
 
-    iterator erase(const iterator &first, const iterator &last)
+    iterator erase(iterator first, iterator last)
     {
-        std::for_each(first, last, Deleter());
+        iterator iter = first;
+        while (iter != last)
+        {
+            delete *iter;
+            iter++;
+        }
+
         return mValues.erase(first, last);
     }
 
@@ -133,8 +139,6 @@ private:
     // Noncopyable
     VectorOfPointers(const VectorOfPointers& );
     const VectorOfPointers& operator=(const VectorOfPointers& );
-    
-    struct Deleter { void operator()(T* elem) { delete elem; } };
 
 private:
     std::vector<T*> mValues;
@@ -223,12 +227,12 @@ public:
     iterator end() { return mValues.end(); }
     const_iterator end() const { return mValues.end(); }
 
-    iterator erase(const iterator &pos)
+    iterator erase(iterator pos)
     {
         return mValues.erase(pos);
     }
 
-    iterator erase(const iterator &first, const iterator &last)
+    iterator erase(iterator first, iterator last)
     {
         return mValues.erase(first, last);
     }

--- a/modules/c++/mem/unittests/test_vector_pointers.cpp
+++ b/modules/c++/mem/unittests/test_vector_pointers.cpp
@@ -1,0 +1,134 @@
+/* =========================================================================
+ * This file is part of mem-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * mem-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <mem/VectorOfPointers.h>
+
+#include "TestCase.h"
+
+namespace
+{
+
+TEST_CASE(testVecOfRawPointers)
+{
+    mem::VectorOfPointers<int> myVec;
+
+    myVec.push_back(new int(1));
+    myVec.push_back(new int(2));
+    myVec.push_back(new int(3));
+    myVec.push_back(new int(4));
+    myVec.push_back(new int(5));
+
+    TEST_ASSERT_EQ(myVec.size(), 5);
+
+    myVec.erase(myVec.begin() + 2);
+
+    TEST_ASSERT_EQ(myVec.size(), 4);
+    TEST_ASSERT_EQ(*myVec[2], 4);
+
+    myVec.push_back(new int(6));
+
+    TEST_ASSERT_EQ(myVec.size(), 5);
+
+    myVec.erase(myVec.begin(), myVec.begin() + 4);
+
+    TEST_ASSERT_EQ(myVec.size(), 1);
+    TEST_ASSERT_EQ(*myVec[0], 6);
+
+    myVec.erase(myVec.begin());
+    TEST_ASSERT_TRUE(myVec.empty());
+
+    // Now make sure everything works fine with constant iterators too
+    mem::VectorOfPointers<int>::const_iterator cBegin = myVec.begin();
+
+    myVec.push_back(new int(1));
+    myVec.push_back(new int(2));
+    myVec.push_back(new int(3));
+    myVec.push_back(new int(4));
+    myVec.push_back(new int(5));
+    myVec.push_back(new int(6));
+
+    myVec.erase(cBegin, cBegin + 5);
+
+    TEST_ASSERT_EQ(myVec.size(), 1);
+    TEST_ASSERT_EQ(*myVec[0], 6);
+
+    cBegin = myVec.begin();
+    myVec.erase(cBegin);
+    TEST_ASSERT_TRUE(myVec.empty());
+}
+
+TEST_CASE(testVecOfSharedPointers)
+{
+    mem::VectorOfSharedPointers<int> myVec;
+
+    myVec.push_back(new int(1));
+    myVec.push_back(new int(2));
+    myVec.push_back(new int(3));
+    myVec.push_back(new int(4));
+    myVec.push_back(new int(5));
+
+    TEST_ASSERT_EQ(myVec.size(), 5);
+
+    myVec.erase(myVec.begin() + 2);
+
+    TEST_ASSERT_EQ(myVec.size(), 4);
+    TEST_ASSERT_EQ(*myVec[2], 4);
+
+    myVec.push_back(new int(6));
+
+    TEST_ASSERT_EQ(myVec.size(), 5);
+
+    myVec.erase(myVec.begin(), myVec.begin() + 4);
+
+    TEST_ASSERT_EQ(myVec.size(), 1);
+    TEST_ASSERT_EQ(*myVec[0], 6);
+
+    myVec.erase(myVec.begin());
+    TEST_ASSERT_TRUE(myVec.empty());
+
+    // Now make sure everything works fine with constant iterators too
+    mem::VectorOfSharedPointers<int>::const_iterator cBegin = myVec.begin();
+
+    myVec.push_back(new int(1));
+    myVec.push_back(new int(2));
+    myVec.push_back(new int(3));
+    myVec.push_back(new int(4));
+    myVec.push_back(new int(5));
+    myVec.push_back(new int(6));
+
+    myVec.erase(cBegin, cBegin + 5);
+
+    TEST_ASSERT_EQ(myVec.size(), 1);
+    TEST_ASSERT_EQ(*myVec[0], 6);
+
+    cBegin = myVec.begin();
+    myVec.erase(cBegin);
+    TEST_ASSERT_TRUE(myVec.empty());
+}
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(testVecOfRawPointers);
+    TEST_CHECK(testVecOfSharedPointers);
+    return 0;
+}

--- a/modules/c++/mem/unittests/test_vector_pointers.cpp
+++ b/modules/c++/mem/unittests/test_vector_pointers.cpp
@@ -55,25 +55,6 @@ TEST_CASE(testVecOfRawPointers)
 
     myVec.erase(myVec.begin());
     TEST_ASSERT_TRUE(myVec.empty());
-
-    // Now make sure everything works fine with constant iterators too
-    mem::VectorOfPointers<int>::const_iterator cBegin = myVec.begin();
-
-    myVec.push_back(new int(1));
-    myVec.push_back(new int(2));
-    myVec.push_back(new int(3));
-    myVec.push_back(new int(4));
-    myVec.push_back(new int(5));
-    myVec.push_back(new int(6));
-
-    myVec.erase(cBegin, cBegin + 5);
-
-    TEST_ASSERT_EQ(myVec.size(), 1);
-    TEST_ASSERT_EQ(*myVec[0], 6);
-
-    cBegin = myVec.begin();
-    myVec.erase(cBegin);
-    TEST_ASSERT_TRUE(myVec.empty());
 }
 
 TEST_CASE(testVecOfSharedPointers)
@@ -103,25 +84,6 @@ TEST_CASE(testVecOfSharedPointers)
     TEST_ASSERT_EQ(*myVec[0], 6);
 
     myVec.erase(myVec.begin());
-    TEST_ASSERT_TRUE(myVec.empty());
-
-    // Now make sure everything works fine with constant iterators too
-    mem::VectorOfSharedPointers<int>::const_iterator cBegin = myVec.begin();
-
-    myVec.push_back(new int(1));
-    myVec.push_back(new int(2));
-    myVec.push_back(new int(3));
-    myVec.push_back(new int(4));
-    myVec.push_back(new int(5));
-    myVec.push_back(new int(6));
-
-    myVec.erase(cBegin, cBegin + 5);
-
-    TEST_ASSERT_EQ(myVec.size(), 1);
-    TEST_ASSERT_EQ(*myVec[0], 6);
-
-    cBegin = myVec.begin();
-    myVec.erase(cBegin);
     TEST_ASSERT_TRUE(myVec.empty());
 }
 }


### PR DESCRIPTION
As I'm going through some SDS code, I found a similar class in that codebase to our `mem::VectorOfPointers`, so I removed it and added the `erase()` function to CODA's so we can instead use the CODA version.