### PR TITLE
No-Op invalid characters that are passed to str::upper and str::lower

### DIFF
--- a/modules/c++/str/source/Manip.cpp
+++ b/modules/c++/str/source/Manip.cpp
@@ -231,9 +231,14 @@ static int transformCheck(int c, int (*transform)(int))
     // as an unsigned char or is 'EOF', as the
     // behavior for all other characters is undefined
     if ((c >= 0 && c <= UCHAR_MAX) || c == EOF)
+    {
         return transform(c);
+    }
     else
-        throw except::Exception("Invalid character for upper/lower transform");
+    {
+        // Invalid char for transform: no-op
+        return c;
+    }
 }
 
 static int tolowerCheck(int c)


### PR DESCRIPTION
Throwing when we come across a `char` that has undefined behavior when passed to `tolower()` or `toupper()` isn't very helpful to the user, and also breaks existing programs in the case the system's implementation chose to just no-op it too.