### PR TITLE
Renaming RowCol's normL1() to area()

### DIFF
--- a/modules/c++/types/include/types/RowCol.h
+++ b/modules/c++/types/include/types/RowCol.h
@@ -213,10 +213,11 @@ template<typename T> struct RowCol
         return ! (RowCol::operator==(p));
     }
     
-    T normL1() const
+    T area() const
     {
         return std::abs(row) * std::abs(col);
     }
+
     T normL2() const
     {
         //! Should be able to just use sqrt() here but VC++ 2010 compiler
@@ -231,7 +232,7 @@ template<typename T> struct RowCol
 };
 
 template <>
-inline size_t RowCol<size_t>::normL1() const
+inline size_t RowCol<size_t>::area() const
 {
     return row * col;
 }
@@ -250,10 +251,6 @@ inline bool RowCol<double>::operator==(const RowCol<double>& p) const
     return std::abs(row - p.row) < eps &&
            std::abs(col - p.col) < eps;
 }
-
-
-
 }
-
 
 #endif

--- a/modules/python/types/source/generated/coda_types.py
+++ b/modules/python/types/source/generated/coda_types.py
@@ -275,9 +275,9 @@ class RowColDouble(_object):
         return _coda_types.RowColDouble___ne__(self, p)
 
 
-    def normL1(self):
-        """normL1(RowColDouble self) -> double"""
-        return _coda_types.RowColDouble_normL1(self)
+    def area(self):
+        """area(RowColDouble self) -> double"""
+        return _coda_types.RowColDouble_area(self)
 
 
     def normL2(self):
@@ -367,9 +367,9 @@ class RowColInt(_object):
         return _coda_types.RowColInt___ne__(self, p)
 
 
-    def normL1(self):
-        """normL1(RowColInt self) -> ssize_t"""
-        return _coda_types.RowColInt_normL1(self)
+    def area(self):
+        """area(RowColInt self) -> ssize_t"""
+        return _coda_types.RowColInt_area(self)
 
 
     def normL2(self):
@@ -459,9 +459,9 @@ class RowColSizeT(_object):
         return _coda_types.RowColSizeT___ne__(self, p)
 
 
-    def normL1(self):
-        """normL1(RowColSizeT self) -> size_t"""
-        return _coda_types.RowColSizeT_normL1(self)
+    def area(self):
+        """area(RowColSizeT self) -> size_t"""
+        return _coda_types.RowColSizeT_area(self)
 
 
     def normL2(self):

--- a/modules/python/types/source/generated/coda_types_wrap.cxx
+++ b/modules/python/types/source/generated/coda_types_wrap.cxx
@@ -6227,7 +6227,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_RowColDouble_normL1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_RowColDouble_area(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   types::RowCol< double > *arg1 = (types::RowCol< double > *) 0 ;
   void *argp1 = 0 ;
@@ -6235,13 +6235,13 @@ SWIGINTERN PyObject *_wrap_RowColDouble_normL1(PyObject *SWIGUNUSEDPARM(self), P
   PyObject * obj0 = 0 ;
   double result;
   
-  if (!PyArg_ParseTuple(args,(char *)"O:RowColDouble_normL1",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"O:RowColDouble_area",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_types__RowColT_double_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RowColDouble_normL1" "', argument " "1"" of type '" "types::RowCol< double > const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RowColDouble_area" "', argument " "1"" of type '" "types::RowCol< double > const *""'"); 
   }
   arg1 = reinterpret_cast< types::RowCol< double > * >(argp1);
-  result = (double)((types::RowCol< double > const *)arg1)->normL1();
+  result = (double)((types::RowCol< double > const *)arg1)->area();
   resultobj = SWIG_From_double(static_cast< double >(result));
   return resultobj;
 fail:
@@ -6856,7 +6856,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_RowColInt_normL1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_RowColInt_area(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   types::RowCol< sys::SSize_T > *arg1 = (types::RowCol< sys::SSize_T > *) 0 ;
   void *argp1 = 0 ;
@@ -6864,13 +6864,13 @@ SWIGINTERN PyObject *_wrap_RowColInt_normL1(PyObject *SWIGUNUSEDPARM(self), PyOb
   PyObject * obj0 = 0 ;
   ssize_t result;
   
-  if (!PyArg_ParseTuple(args,(char *)"O:RowColInt_normL1",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"O:RowColInt_area",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_types__RowColT_ssize_t_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RowColInt_normL1" "', argument " "1"" of type '" "types::RowCol< sys::SSize_T > const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RowColInt_area" "', argument " "1"" of type '" "types::RowCol< sys::SSize_T > const *""'"); 
   }
   arg1 = reinterpret_cast< types::RowCol< sys::SSize_T > * >(argp1);
-  result = ((types::RowCol< sys::SSize_T > const *)arg1)->normL1();
+  result = ((types::RowCol< sys::SSize_T > const *)arg1)->area();
   {
 #if PY_VERSION_HEX >= 0x03000000
     resultobj = PyLong_FromSsize_t(result);
@@ -7479,7 +7479,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_RowColSizeT_normL1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_RowColSizeT_area(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   types::RowCol< size_t > *arg1 = (types::RowCol< size_t > *) 0 ;
   void *argp1 = 0 ;
@@ -7487,13 +7487,13 @@ SWIGINTERN PyObject *_wrap_RowColSizeT_normL1(PyObject *SWIGUNUSEDPARM(self), Py
   PyObject * obj0 = 0 ;
   size_t result;
   
-  if (!PyArg_ParseTuple(args,(char *)"O:RowColSizeT_normL1",&obj0)) SWIG_fail;
+  if (!PyArg_ParseTuple(args,(char *)"O:RowColSizeT_area",&obj0)) SWIG_fail;
   res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_types__RowColT_size_t_t, 0 |  0 );
   if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RowColSizeT_normL1" "', argument " "1"" of type '" "types::RowCol< size_t > const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "RowColSizeT_area" "', argument " "1"" of type '" "types::RowCol< size_t > const *""'"); 
   }
   arg1 = reinterpret_cast< types::RowCol< size_t > * >(argp1);
-  result = ((types::RowCol< size_t > const *)arg1)->normL1();
+  result = ((types::RowCol< size_t > const *)arg1)->area();
   resultobj = SWIG_From_size_t(static_cast< size_t >(result));
   return resultobj;
 fail:
@@ -11994,7 +11994,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"RowColDouble___div__", _wrap_RowColDouble___div__, METH_VARARGS, (char *)"RowColDouble___div__(RowColDouble self, double scalar) -> RowColDouble"},
 	 { (char *)"RowColDouble___eq__", _wrap_RowColDouble___eq__, METH_VARARGS, (char *)"RowColDouble___eq__(RowColDouble self, RowColDouble p) -> bool"},
 	 { (char *)"RowColDouble___ne__", _wrap_RowColDouble___ne__, METH_VARARGS, (char *)"RowColDouble___ne__(RowColDouble self, RowColDouble p) -> bool"},
-	 { (char *)"RowColDouble_normL1", _wrap_RowColDouble_normL1, METH_VARARGS, (char *)"RowColDouble_normL1(RowColDouble self) -> double"},
+	 { (char *)"RowColDouble_area", _wrap_RowColDouble_area, METH_VARARGS, (char *)"RowColDouble_area(RowColDouble self) -> double"},
 	 { (char *)"RowColDouble_normL2", _wrap_RowColDouble_normL2, METH_VARARGS, (char *)"RowColDouble_normL2(RowColDouble self) -> double"},
 	 { (char *)"delete_RowColDouble", _wrap_delete_RowColDouble, METH_VARARGS, (char *)"delete_RowColDouble(RowColDouble self)"},
 	 { (char *)"RowColDouble_swigregister", RowColDouble_swigregister, METH_VARARGS, NULL},
@@ -12017,7 +12017,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"RowColInt___div__", _wrap_RowColInt___div__, METH_VARARGS, (char *)"RowColInt___div__(RowColInt self, ssize_t scalar) -> RowColInt"},
 	 { (char *)"RowColInt___eq__", _wrap_RowColInt___eq__, METH_VARARGS, (char *)"RowColInt___eq__(RowColInt self, RowColInt p) -> bool"},
 	 { (char *)"RowColInt___ne__", _wrap_RowColInt___ne__, METH_VARARGS, (char *)"RowColInt___ne__(RowColInt self, RowColInt p) -> bool"},
-	 { (char *)"RowColInt_normL1", _wrap_RowColInt_normL1, METH_VARARGS, (char *)"RowColInt_normL1(RowColInt self) -> ssize_t"},
+	 { (char *)"RowColInt_area", _wrap_RowColInt_area, METH_VARARGS, (char *)"RowColInt_area(RowColInt self) -> ssize_t"},
 	 { (char *)"RowColInt_normL2", _wrap_RowColInt_normL2, METH_VARARGS, (char *)"RowColInt_normL2(RowColInt self) -> ssize_t"},
 	 { (char *)"delete_RowColInt", _wrap_delete_RowColInt, METH_VARARGS, (char *)"delete_RowColInt(RowColInt self)"},
 	 { (char *)"RowColInt_swigregister", RowColInt_swigregister, METH_VARARGS, NULL},
@@ -12040,7 +12040,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"RowColSizeT___div__", _wrap_RowColSizeT___div__, METH_VARARGS, (char *)"RowColSizeT___div__(RowColSizeT self, size_t scalar) -> RowColSizeT"},
 	 { (char *)"RowColSizeT___eq__", _wrap_RowColSizeT___eq__, METH_VARARGS, (char *)"RowColSizeT___eq__(RowColSizeT self, RowColSizeT p) -> bool"},
 	 { (char *)"RowColSizeT___ne__", _wrap_RowColSizeT___ne__, METH_VARARGS, (char *)"RowColSizeT___ne__(RowColSizeT self, RowColSizeT p) -> bool"},
-	 { (char *)"RowColSizeT_normL1", _wrap_RowColSizeT_normL1, METH_VARARGS, (char *)"RowColSizeT_normL1(RowColSizeT self) -> size_t"},
+	 { (char *)"RowColSizeT_area", _wrap_RowColSizeT_area, METH_VARARGS, (char *)"RowColSizeT_area(RowColSizeT self) -> size_t"},
 	 { (char *)"RowColSizeT_normL2", _wrap_RowColSizeT_normL2, METH_VARARGS, (char *)"RowColSizeT_normL2(RowColSizeT self) -> size_t"},
 	 { (char *)"delete_RowColSizeT", _wrap_delete_RowColSizeT, METH_VARARGS, (char *)"delete_RowColSizeT(RowColSizeT self)"},
 	 { (char *)"RowColSizeT_swigregister", RowColSizeT_swigregister, METH_VARARGS, NULL},


### PR DESCRIPTION
`RowCol::normL1()` is really an area calculation, not a norm L1 calculation.  Renaming method to be consistent... if a norm L1 calculation is really needed down the road, we can add it, but we'll push this method out first so users see compiler errors and get a chance to fix things rather than getting incorrect behavior.

@jmrandol 
@apakanati 
@JonathanMeans 
@clydestanfield 
@mbojrab 
@msciaramitaro 