### PR TITLE
Numpyutils update2

### DIFF
--- a/modules/c++/numpyutils/examples/scripts/numpyutilstest.py
+++ b/modules/c++/numpyutils/examples/scripts/numpyutilstest.py
@@ -29,7 +29,6 @@ import numpy
 # SWIG interface.  This is the python version calling the C implementation
 # in source/numpyutilstest.i
 
-
 print(coda.numpyutilstest.elementDoubleTest.__doc__)
 
 numpyarray = numpy.zeros((2,3), dtype=numpy.float32)
@@ -38,5 +37,3 @@ print("Before Doubling", numpyarray)
 
 numpyarray = coda.numpyutilstest.elementDoubleTest(numpyarray)
 print("After Doubling", numpyarray)
-
-

--- a/modules/c++/numpyutils/examples/source/generated/numpyutilstest_wrap.cxx
+++ b/modules/c++/numpyutils/examples/source/generated/numpyutilstest_wrap.cxx
@@ -4493,7 +4493,7 @@ namespace swig
         const float* input = numpyutils::getBuffer<float>(inputNPArray);
         float* output = numpyutils::getBuffer<float >(outputNPArray);
 
-        for(int i=0;i<dims.area();i++)
+        for(size_t i=0;i<dims.area();i++)
         {
             output[i] = input[i] * 2;
         }

--- a/modules/c++/numpyutils/examples/source/numpyutilstest.i
+++ b/modules/c++/numpyutils/examples/source/numpyutilstest.i
@@ -47,7 +47,7 @@
         const float* input = numpyutils::getBuffer<float>(inputNPArray);
         float* output = numpyutils::getBuffer<float >(outputNPArray);
 
-        for(int i=0;i<dims.area();i++)
+        for(size_t i=0;i<dims.area();i++)
         {
             output[i] = input[i] * 2;
         }

--- a/modules/c++/numpyutils/examples/wscript
+++ b/modules/c++/numpyutils/examples/wscript
@@ -1,0 +1,14 @@
+
+import os
+from os.path import join, basename
+from waflib import Utils
+
+distclean = options = lambda p: None
+
+def configure(conf):
+     1
+def build(bld):
+  bld.swigModule(name = 'numpyutilstest',
+                 use = 'types-python except-python numpyutils-c++' ,
+                 package = 'coda')
+

--- a/modules/c++/numpyutils/examples/wscript
+++ b/modules/c++/numpyutils/examples/wscript
@@ -3,10 +3,8 @@ import os
 from os.path import join, basename
 from waflib import Utils
 
-distclean = options = lambda p: None
+distclean = options = configure = lambda p: None
 
-def configure(conf):
-     1
 def build(bld):
   bld.swigModule(name = 'numpyutilstest',
                  use = 'types-python except-python numpyutils-c++' ,

--- a/modules/c++/numpyutils/examples/wscript
+++ b/modules/c++/numpyutils/examples/wscript
@@ -6,7 +6,7 @@ from waflib import Utils
 distclean = options = configure = lambda p: None
 
 def build(bld):
-  bld.swigModule(name = 'numpyutilstest',
-                 use = 'types-python except-python numpyutils-c++' ,
-                 package = 'coda')
+    bld.swigModule(name = 'numpyutilstest',
+                   use = 'types-python except-python numpyutils-c++',
+                   package = 'coda')
 

--- a/modules/c++/numpyutils/include/numpyutils/numpyutils.h
+++ b/modules/c++/numpyutils/include/numpyutils/numpyutils.h
@@ -23,6 +23,11 @@
 #ifndef __NUMPYUTILS_NUMPYUTILS_H__
 #define __NUMPYUTILS_NUMPYUTILS_H__
 
+#ifdef NO_IMPORT_ARRAY
+#define NUMPYUTILS_NO_IMPORT_ARRAY_ALREADY_SET
+#endif
+#define NO_IMPORT_ARRAY
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <types/RowCol.h>
 
@@ -131,4 +136,9 @@ T* getBuffer(PyObject* pyObject)
 }
 
 }
+
+#ifndef NUMPYUTILS_NO_IMPORT_ARRAY_ALREADY_SET
+#undef NO_IMPORT_ARRAY
+#endif
+
 #endif

--- a/modules/c++/numpyutils/include/numpyutils/numpyutils.h
+++ b/modules/c++/numpyutils/include/numpyutils/numpyutils.h
@@ -23,10 +23,6 @@
 #ifndef __NUMPYUTILS_NUMPYUTILS_H__
 #define __NUMPYUTILS_NUMPYUTILS_H__
 
-#ifdef NO_IMPORT_ARRAY
-#define NUMPYUTILS_NO_IMPORT_ARRAY_ALREADY_SET
-#endif
-#define NO_IMPORT_ARRAY
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 #include <types/RowCol.h>
@@ -123,6 +119,13 @@ void prepareInputAndOutputArray(PyObject* pyInObject,
                                 int inputTypeNum, 
                                 int outputTypeNum);
 
+/*! 
+ * Helper function to get data array.  
+ * \param pyInObject array to get data buffer of
+ * \returns a pointer to the array's buffer interpreted as an array of type char*
+ * */
+char* getDataBuffer(PyArrayObject* pyInObject);
+
 /*! Extract PyArray Buffer as raw array of type T* 
  * \param pyObject object to turn into raw pointer
  * \returns a pointer to the array's buffer interpreted as an array of type T
@@ -131,14 +134,10 @@ template<typename T>
 T* getBuffer(PyObject* pyObject)
 {
     return reinterpret_cast<T*>(
-            PyArray_BYTES(
+            getDataBuffer(
                 reinterpret_cast<PyArrayObject*>(pyObject)));
 }
 
 }
-
-#ifndef NUMPYUTILS_NO_IMPORT_ARRAY_ALREADY_SET
-#undef NO_IMPORT_ARRAY
-#endif
 
 #endif

--- a/modules/c++/numpyutils/source/numpyutils.cpp
+++ b/modules/c++/numpyutils/source/numpyutils.cpp
@@ -20,6 +20,10 @@
  *
  */
 
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+// The numpy/array object should come before the numpyutils include
+// Because NO_IMPORT is defined in the header.
+#include <numpy/arrayobject.h> 
 #include <numpyutils/numpyutils.h>
 
 #include <except/Exception.h>
@@ -77,7 +81,7 @@ struct InitializeNumPy
 {
     InitializeNumPy()
     {
-        Py_Initialize;
+        Py_Initialize();
         init_numpy();
     }
 };
@@ -145,14 +149,14 @@ void createOrVerify(PyObject*& pyObject,
 {
     if (pyObject == Py_None) // none passed in-- so create new
     {
-        npy_intp odims[2] = {dims.row, dims.col};
+        npy_intp odims[2] = {static_cast<npy_intp>(dims.row), static_cast<npy_intp>(dims.col)};
         pyObject = PyArray_SimpleNew(2, odims, typeNum);
     }
     else
     {
         verifyArrayType(pyObject, typeNum);
         const npy_intp* const outdims = getDimensions(pyObject);
-        if (outdims[0] != dims.row  || outdims[1] != dims.col)
+        if (outdims[0] != static_cast<npy_intp>(dims.row)  || outdims[1] != static_cast<npy_intp>(dims.col))
         {
             throw except::Exception(Ctxt(
                         "Desired array does not match required row, cols"));
@@ -181,6 +185,5 @@ void prepareInputAndOutputArray(PyObject* pyInObject,
                                outputTypeNum,
                                getDimensionsRC(pyInObject));
 }
-                     
+                    
 }
-

--- a/modules/c++/numpyutils/source/numpyutils.cpp
+++ b/modules/c++/numpyutils/source/numpyutils.cpp
@@ -20,12 +20,7 @@
  *
  */
 
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-// The numpy/array object should come before the numpyutils include
-// Because NO_IMPORT is defined in the header.
-#include <numpy/arrayobject.h> 
 #include <numpyutils/numpyutils.h>
-
 #include <except/Exception.h>
 #include <sys/Conf.h>
 
@@ -184,6 +179,11 @@ void prepareInputAndOutputArray(PyObject* pyInObject,
                                inputTypeNum,
                                outputTypeNum,
                                getDimensionsRC(pyInObject));
+}
+
+char* getDataBuffer(PyArrayObject* pyInObject)
+{
+   return PyArray_BYTES(pyInObject);
 }
                     
 }

--- a/modules/c++/numpyutils/wscript
+++ b/modules/c++/numpyutils/wscript
@@ -6,7 +6,7 @@ USELIB          = 'NUMPY PYEXT'
 
 from waflib import Options
 
-distclean = options = configure = lambda x: None
+distclean = options = lambda x: None
 
 def configure(conf):
     conf.recurse(['examples'])


### PR DESCRIPTION
Take a look at the #define stuff I added in the .h.  I'm not really sure this was a good idea, but as a brief explanation of what's going on.

- we're including numpy headers in the numpyutils header
- this means that all downstream compilation units get a warning because they don't have their own import_arrays call
- I tried some gymnastics with forward declaring numpy stuff, but ran into some trouble with C and typedef forwards and gave up on the basis of not being worth the time.  Not sure if this is possible but this might be an a good alternative (and would have the benefit of not appearing to provide numpy operators to downstream modules) when we don't safely

So I settled on this to #define NO_IMPORT which causes the header to suppress those warnings (and the definitions of import_arrays).  And then added some other stuff just in case NO_IMPORT is 
set beforehand in which case I don't want to clear it.

We could also just accept the warning and not do any of this of course.