### PR TITLE
Made numpy driver more robust

### DIFF
--- a/modules/c++/numpyutils/wscript
+++ b/modules/c++/numpyutils/wscript
@@ -12,6 +12,6 @@ def configure(conf):
     conf.recurse(['examples'])
 
 def build(bld):
-    if bld.env['PY_HAVE_NUMPY'] and Options.options.enable_numpy:
+    if bld.env['PY_HAVE_NUMPY']:
        bld.module(**globals())
        bld.recurse(['examples'])

--- a/modules/drivers/numpy/wscript
+++ b/modules/drivers/numpy/wscript
@@ -10,7 +10,7 @@ def options(opt):
                    help='Turn off Numpy C headers/libs')
 
 def configure(conf):    
-    if Options.options.enable_numpy:
+    if Options.options.enable_numpy and Options.options.python:
         # a little magic borrowed from python-config and extended for numpy and -L flags
         try:
             from distutils import sysconfig
@@ -34,10 +34,9 @@ def configure(conf):
                        includes=inc_dir,
                        libpath=lib_dir,
                        msg='Checking for library numpy' + warningmessage, 
-                       mandatory=False) 
-            
+                       mandatory=True)
+
             conf.undefine("HAVE_NUMPY_NUMPYCONFIG_H")
             conf.env['PY_HAVE_NUMPY'] = True
         except:
             conf.env['PY_HAVE_NUMPY'] = False
-            conf.msg("Checking for library numpy", "FAILED", color="YELLOW")

--- a/modules/drivers/numpy/wscript
+++ b/modules/drivers/numpy/wscript
@@ -29,8 +29,9 @@ def configure(conf):
             lib_dir = np_info['library_dirs'][0]
 
             conf.check(uselib_store='NUMPY',
+                       use='PYEXT',
                        lib='npymath',  
-                       header_name='numpy/numpyconfig.h', 
+                       header_name='numpy/arrayobject.h',
                        includes=inc_dir,
                        libpath=lib_dir,
                        msg='Checking for library numpy' + warningmessage, 

--- a/modules/drivers/numpy/wscript
+++ b/modules/drivers/numpy/wscript
@@ -37,7 +37,7 @@ def configure(conf):
                        msg='Checking for library numpy' + warningmessage, 
                        mandatory=True)
 
-            conf.undefine("HAVE_NUMPY_NUMPYCONFIG_H")
+            conf.undefine("HAVE_NUMPY_ARRAYOBJECT_H")
             conf.env['PY_HAVE_NUMPY'] = True
         except:
             conf.env['PY_HAVE_NUMPY'] = False


### PR DESCRIPTION
I missed this when I moved this code into coda-oss. Jeff Pursell found the problem earlier today.

1. Added check to make sure python is enabled.
2. conf.check won't throw unless mandatory is true, getting a false positive if numpy/python were missing.
3. The msg() was unnecessary.