### PR TITLE
Center input values being used for 2D poly fit

### DIFF
--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -1014,28 +1014,6 @@ public:
     }
 
     /*!
-     *  Find the minumum and maximum values of all elements in this matrix.
-     *
-     *  \param minVal Output minumum value
-     *  \param maxVal Output maximum value
-     */
-    void minMax(_T& minVal, _T& maxVal) const
-    {
-        if (mMN == 0)
-            throw except::Exception(Ctxt(
-                    "Non-zero matrix size required for minMax"));
-
-        minVal = maxVal = mRaw[0];
-        for (size_t i = 1; i < mMN; ++i)
-        {
-            if (mRaw[i] < minVal)
-                minVal = mRaw[i];
-            if (mRaw[i] > maxVal)
-                maxVal = mRaw[i];
-        }
-    }
-
-    /*!
      *  Alias for this->add();
      *
      *  \code

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -1014,6 +1014,28 @@ public:
     }
 
     /*!
+     *  Find the minumum and maximum values of all elements in this matrix.
+     *
+     *  \param minVal Output minumum value
+     *  \param maxVal Output maximum value
+     */
+    void minMax(_T& minVal, _T& maxVal) const
+    {
+        if (mMN == 0)
+            throw except::Exception(Ctxt(
+                    "Non-zero matrix size required for minMax"));
+
+        minVal = maxVal = mRaw[0];
+        for (size_t i = 1; i < mMN; ++i)
+        {
+            if (mRaw[i] < minVal)
+                minVal = mRaw[i];
+            if (mRaw[i] > maxVal)
+                maxVal = mRaw[i];
+        }
+    }
+
+    /*!
      *  Alias for this->add();
      *
      *  \code

--- a/modules/c++/math.poly/include/math/poly/Fit.h
+++ b/modules/c++/math.poly/include/math/poly/Fit.h
@@ -5,6 +5,7 @@
 #include <math/poly/TwoD.h>
 #include <math/linear/Matrix2D.h>
 #include <math/linear/VectorN.h>
+#include <numeric>
 
 namespace math
 {
@@ -124,25 +125,18 @@ inline math::poly::TwoD<double> fit(const math::linear::Matrix2D<double>& x,
     if (n != y.cols())
         throw except::Exception(Ctxt("Matrices must be equally sized"));
 
-    // Compute min and max values for centering
-    double xmin;
-    double xmax;
-    double ymin;
-    double ymax;
-    x.minMax(xmin, xmax);
-    y.minMax(ymin, ymax);
+    // Compute mean values
+    double xoff = std::accumulate(x.get(), x.get() + mxn, 0.0) / mxn;
+    double yoff = std::accumulate(y.get(), y.get() + mxn, 0.0) / mxn;
 
-    // center the matrices' value ranges around zero
-    double xoff = (xmin + xmax) / 2.0;
-    double yoff = (ymin + ymax) / 2.0;
-
+    // Shift the matrix values by mean to center around zero
     math::linear::Matrix2D<double> xoffm(m, n, xoff);
     math::linear::Matrix2D<double> yoffm(m, n, yoff);
 
     math::linear::Matrix2D<double> xp = x - xoffm;
     math::linear::Matrix2D<double> yp = y - yoffm;
 
-    // Normalize the values in the matrix
+    // Normalize the values in the matrix using standard deviation
     double rxrms = 1 / std::sqrt(xp.normSq() / mxn);
     double ryrms = 1 / std::sqrt(yp.normSq() / mxn);
     xp.scale(rxrms);

--- a/modules/c++/math.poly/unittests/test_llsq.cpp
+++ b/modules/c++/math.poly/unittests/test_llsq.cpp
@@ -90,9 +90,82 @@ TEST_CASE(test2DPolyfit)
     TEST_ASSERT_EQ(poly, truth);
 }
 
+TEST_CASE(test2DPolyfitLarge)
+{
+    // Use a defined polynomial to generate mapped values.  This ensures
+    // it is possible to fit the points using at least as many coefficients.
+    double coeffs[] =
+    {
+        -1.021e-12, 7.5,    2.2,   5.5,
+         0.88,      4.825,  .52,   .69,
+         5.5,       1.0,    .62,   1.01,
+         .012,      6.32,   1.56,  .376
+    };
+
+    TwoD<double> truth(3, 3, coeffs);
+
+    // Specifically sampling points far from (0,0) to verify an issue
+    // identified when fitting non-centered input.
+
+    size_t gridSize = 9; // 9x9
+    size_t x_offset = 25000;
+    size_t x_sample = 2134;
+    size_t y_offset = 42000;
+    size_t y_sample = 3214;
+
+    Matrix2D<double> x(gridSize, gridSize);
+    for (size_t i = 0; i < gridSize; i++)
+    {
+        double xidx = x_offset + i * x_sample;
+        for (size_t j = 0; j < gridSize; j++)
+        {
+            x(i, j) = xidx;
+        }
+    }
+
+    Matrix2D<double> y(gridSize, gridSize);
+    for (size_t j = 0; j < gridSize; j++)
+    {
+        double yidx = y_offset + j * y_sample;
+        for (size_t i = 0; i < gridSize; i++)
+        {
+            y(i, j) = yidx;
+        }
+    }
+
+    Matrix2D<double> z(gridSize, gridSize);
+    for (size_t i = 0; i < gridSize; i++)
+    {
+        for (size_t j = 0; j < gridSize; j++)
+        {
+            z(i, j) = truth(i, j);
+        }
+    }
+
+    // Fit polynomial
+    TwoD<double> poly = fit(x, y, z, 5, 5);
+
+    // Calculate the mean residual error to determine goodness of fit.
+    double errorSum(0.0);
+    for (size_t i = 0; i < gridSize; i++)
+    {
+        for (size_t j = 0; j < gridSize; j++)
+        {
+            double diff = z(i, j) - poly(x(i, j), y(i, j));
+            errorSum += diff * diff;
+        }
+    }
+    double meanResidualError = errorSum / (gridSize * gridSize);
+
+    //std::cout << "meanResidualError: " << meanResidualError << std::endl;
+
+    TEST_ASSERT_ALMOST_EQ(meanResidualError, 0.0);
+}
+
 int main(int, char**)
 {
 
     TEST_CHECK(test1DPolyfit);
     TEST_CHECK(test2DPolyfit);
+    TEST_CHECK(test2DPolyfitLarge);
 }

--- a/modules/c++/math.poly/unittests/test_llsq.cpp
+++ b/modules/c++/math.poly/unittests/test_llsq.cpp
@@ -94,7 +94,7 @@ TEST_CASE(test2DPolyfitLarge)
 {
     // Use a defined polynomial to generate mapped values.  This ensures
     // it is possible to fit the points using at least as many coefficients.
-    double coeffs[] =
+    const double coeffs[] =
     {
         -1.021e-12, 7.5,    2.2,   5.5,
          0.88,      4.825,  .52,   .69,
@@ -108,15 +108,15 @@ TEST_CASE(test2DPolyfitLarge)
     // identified when fitting non-centered input.
 
     size_t gridSize = 9; // 9x9
-    size_t x_offset = 25000;
-    size_t x_sample = 2134;
-    size_t y_offset = 42000;
-    size_t y_sample = 3214;
+    size_t xOffset = 25000;
+    size_t xSpacing = 2134;
+    size_t yOffset = 42000;
+    size_t ySpacing = 3214;
 
     Matrix2D<double> x(gridSize, gridSize);
     for (size_t i = 0; i < gridSize; i++)
     {
-        double xidx = x_offset + i * x_sample;
+        double xidx = xOffset + i * xSpacing;
         for (size_t j = 0; j < gridSize; j++)
         {
             x(i, j) = xidx;
@@ -126,7 +126,7 @@ TEST_CASE(test2DPolyfitLarge)
     Matrix2D<double> y(gridSize, gridSize);
     for (size_t j = 0; j < gridSize; j++)
     {
-        double yidx = y_offset + j * y_sample;
+        double yidx = yOffset + j * ySpacing;
         for (size_t i = 0; i < gridSize; i++)
         {
             y(i, j) = yidx;


### PR DESCRIPTION
Center input values for 2D polynomial fit.

The unit test has been updated with a more stressing test using more points and a higher order polynomial.  The previous version of math::poly::fit would fail this test with a mean residual error of 4.96674e+12.  The new version achieves a mean residual error of 1.39047e-14.
