### PR TITLE
fix (or turn off) some compiler warnings

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -969,9 +969,10 @@ def configureCompilerOptions(self):
         # specifications properly.
         # Skipping warning 4512 about being unable to generate an assignment
         # operator (since we often do this intentionally).
+	# warning C4100: '...' : unreferenced formal parameter
         # For warnings, use /W4 because /Wall
         # gives us tons of warnings in the VS headers themselves
-        warningFlags = '/W4 /wd4290 /wd4512'
+        warningFlags = '/W4 /wd4290 /wd4512 /wd4100'
         if Options.options.warningsAsErrors:
             warningFlags += ' /WX'
 

--- a/build/build.py
+++ b/build/build.py
@@ -969,10 +969,11 @@ def configureCompilerOptions(self):
         # specifications properly.
         # Skipping warning 4512 about being unable to generate an assignment
         # operator (since we often do this intentionally).
-	# warning C4100: '...' : unreferenced formal parameter
+        # warning C4100: '...' : unreferenced formal parameter
+        # warning C4127: conditional expression is constant
         # For warnings, use /W4 because /Wall
         # gives us tons of warnings in the VS headers themselves
-        warningFlags = '/W4 /wd4290 /wd4512 /wd4100'
+        warningFlags = '/W4 /wd4290 /wd4512 /wd4100 /wd4127'
         if Options.options.warningsAsErrors:
             warningFlags += ' /WX'
 

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -100,7 +100,7 @@ sys::Pid_T sys::OSWin32::getProcessId() const
 
 void sys::OSWin32::removeFile(const std::string& pathname) const
 {
-    if (DeleteFile(pathname.c_str()) != TRUE)
+    if (DeleteFile(pathname.c_str()) == FALSE) // "If the function succeeds, the return value is nonzero. If the function fails, the return value is zero (0)."
     {
         sys::Err err;
         std::ostringstream oss;
@@ -113,7 +113,7 @@ void sys::OSWin32::removeFile(const std::string& pathname) const
 
 void sys::OSWin32::removeDirectory(const std::string& pathname) const
 {
-	if (RemoveDirectory(pathname.c_str()) != TRUE)
+    if (RemoveDirectory(pathname.c_str()) == FALSE) // "If the function succeeds, the return value is nonzero. If the function fails, the return value is zero (0)."
     {
         sys::Err err;
         std::ostringstream oss;
@@ -312,7 +312,7 @@ void sys::OSWin32::createSymlink(const std::string& origPathname,
 
 void sys::OSWin32::removeSymlink(const std::string& symlinkPathname) const
 {
-	if (RemoveDirectory(symlinkPathname.c_str()) != TRUE)
+	if (RemoveDirectory(symlinkPathname.c_str()) == FALSE) // "If the function succeeds, the return value is nonzero. If the function fails, the return value is zero (0)."
     {
         sys::Err err;
         std::ostringstream oss;

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -100,7 +100,7 @@ sys::Pid_T sys::OSWin32::getProcessId() const
 
 void sys::OSWin32::removeFile(const std::string& pathname) const
 {
-    if (DeleteFile(pathname.c_str()) != true)
+    if (DeleteFile(pathname.c_str()) != TRUE)
     {
         sys::Err err;
         std::ostringstream oss;
@@ -113,7 +113,7 @@ void sys::OSWin32::removeFile(const std::string& pathname) const
 
 void sys::OSWin32::removeDirectory(const std::string& pathname) const
 {
-    if (RemoveDirectory(pathname.c_str()) != true)
+	if (RemoveDirectory(pathname.c_str()) != TRUE)
     {
         sys::Err err;
         std::ostringstream oss;
@@ -312,7 +312,7 @@ void sys::OSWin32::createSymlink(const std::string& origPathname,
 
 void sys::OSWin32::removeSymlink(const std::string& symlinkPathname) const
 {
-	if (RemoveDirectory(symlinkPathname.c_str()) != true)
+	if (RemoveDirectory(symlinkPathname.c_str()) != TRUE)
     {
         sys::Err err;
         std::ostringstream oss;

--- a/modules/c++/sys/unittests/test_symlink.cpp
+++ b/modules/c++/sys/unittests/test_symlink.cpp
@@ -33,8 +33,6 @@ namespace
 
 TEST_CASE(testCreateSymlink)
 {
-	bool test_assert_false = false;
-
     try
     {
         sys::OS os;
@@ -69,18 +67,18 @@ TEST_CASE(testCreateSymlink)
     catch (const std::exception& ex)
     {
         std::cerr << "Caught std::exception: " << ex.what() << std::endl;
-		TEST_ASSERT(test_assert_false);
+        TEST_ASSERT(false);
     }
     catch (const except::Exception& ex)
     {
         std::cerr << "Caught except::exception: " << ex.getMessage()
                   << std::endl;
-		TEST_ASSERT(test_assert_false);
+        TEST_ASSERT(false);
     }
     catch (...)
     {
         std::cerr << "Caught unknown exception\n";
-		TEST_ASSERT(test_assert_false);
+        TEST_ASSERT(false);
     }
 }
 

--- a/modules/c++/sys/unittests/test_symlink.cpp
+++ b/modules/c++/sys/unittests/test_symlink.cpp
@@ -33,6 +33,8 @@ namespace
 
 TEST_CASE(testCreateSymlink)
 {
+	bool test_assert_false = false;
+
     try
     {
         sys::OS os;
@@ -67,18 +69,18 @@ TEST_CASE(testCreateSymlink)
     catch (const std::exception& ex)
     {
         std::cerr << "Caught std::exception: " << ex.what() << std::endl;
-        TEST_ASSERT(false);
+		TEST_ASSERT(test_assert_false);
     }
     catch (const except::Exception& ex)
     {
         std::cerr << "Caught except::exception: " << ex.getMessage()
                   << std::endl;
-        TEST_ASSERT(false);
+		TEST_ASSERT(test_assert_false);
     }
     catch (...)
     {
         std::cerr << "Caught unknown exception\n";
-        TEST_ASSERT(false);
+		TEST_ASSERT(test_assert_false);
     }
 }
 


### PR DESCRIPTION
Incremental progress towards fixing (or turning off) various compiler warnings.  Some of these are rather pedantic (to say the least), but they can hide other (more important) warnings.
