### PR TITLE
Versions of numpy prior to 1.10 require Python.h be included manually

### DIFF
--- a/modules/c++/numpyutils/include/numpyutils/numpyutils.h
+++ b/modules/c++/numpyutils/include/numpyutils/numpyutils.h
@@ -24,6 +24,7 @@
 #define __NUMPYUTILS_NUMPYUTILS_H__
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <Python.h>
 #include <numpy/arrayobject.h>
 #include <types/RowCol.h>
 

--- a/modules/drivers/numpy/wscript
+++ b/modules/drivers/numpy/wscript
@@ -32,7 +32,7 @@ def configure(conf):
             conf.check(uselib_store='NUMPY',
                        use='PYEXT',
                        lib='npymath',  
-                       header_name='numpy/arrayobject.h',
+                       header_name=['Python.h','numpy/arrayobject.h'],
                        includes=inc_dir,
                        libpath=lib_dir,
                        msg='Checking for library numpy' + warningmessage, 


### PR DESCRIPTION
This solves the "Must use Python with unicode enabled" issue we've seen in a few places.