### PR TITLE
Xml lite warnings

### DIFF
--- a/modules/c++/xml.lite/include/xml/lite/ValidatorInterface.h
+++ b/modules/c++/xml.lite/include/xml/lite/ValidatorInterface.h
@@ -109,9 +109,9 @@ public:
      *  \param recursive    Do a recursive search for schemas on directory 
      *                      input
      */
-    ValidatorInterface(const std::vector<std::string>& schemaPaths, 
-                       logging::Logger* log,
-                       bool recursive = true) {}
+    ValidatorInterface(const std::vector<std::string>& /*schemaPaths*/,
+                       logging::Logger* /*log*/,
+                       bool /*recursive*/ = true) {}
 
     //! Destructor.
     virtual ~ValidatorInterface() {}

--- a/modules/c++/xml.lite/source/UtilitiesXerces.cpp
+++ b/modules/c++/xml.lite/source/UtilitiesXerces.cpp
@@ -155,7 +155,7 @@ void xml::lite::XercesContentHandler::startElement(
 }
 
 void xml::lite::XercesErrorHandler::
-warning(const SAXParseException &exception)
+warning(const SAXParseException& /*exception*/)
 {
 }
 

--- a/modules/c++/xml.lite/wscript
+++ b/modules/c++/xml.lite/wscript
@@ -4,7 +4,7 @@ VERSION         = '1.2'
 MODULE_DEPS     = 'io mt logging'
 USELIB_CHECK    = 'XML'
 TEST_FILTER     = 'MMParserTest1.cpp MinidomParserTest2.cpp'
-TEST_DEPS       = 'io mt cli'
+TEST_DEPS       = 'cli'
 
 options = distclean = lambda p: None
 


### PR DESCRIPTION
Cleaning up a few warnings on Windows about unused variables