### PR TITLE
Extended python coda_types to support pickling.

### DIFF
--- a/modules/python/types/source/types.i
+++ b/modules/python/types/source/types.i
@@ -40,6 +40,52 @@
 %include "types/RowCol.h"
 %include "types/RgAz.h"
 
+// Pickle utilities
+%pythoncode
+%{
+    import cPickle as pickle
+%}
+
+%extend types::RowCol
+{
+%pythoncode
+%{
+    def __getstate__(self):
+        return (self.row, self.col)
+
+    def __setstate__(self, state):
+        self.__init__(state[0], state[1])
+%}
+}
+
+%extend types::RgAz
+{
+%pythoncode
+%{
+    def __getstate__(self):
+        return (self.rg, self.az)
+
+    def __setstate__(self, state):
+        self.__init__(state[0], state[1])
+%}
+}
+
+%extend std::vector
+{
+%pythoncode
+%{
+    def __getstate__(self):
+        # Return a nonempty (thus non-false) tuple with dummy value in first position
+        return (-1, tuple(pickle.dumps(elem) for elem in self))
+        
+    def __setstate__(self, state):
+        self.__init__()
+        # State will have a dummy entry in the first position
+        for elem in state[1]:
+            self.push_back(pickle.loads(elem))
+%}
+}
+
 %template(RowColDouble) types::RowCol<double>;
 %template(RowColInt) types::RowCol<sys::SSize_T>;
 %template(RowColSizeT) types::RowCol<size_t>;
@@ -47,93 +93,3 @@
 
 %template(VectorRowColInt) std::vector<types::RowCol<sys::SSize_T> >;
 %template(VectorSizeT) std::vector<size_t>;
-
-// Pickle utilities
-%pythoncode
-%{
-    import cPickle as pickle
-%}
-
-%extend types::RowCol<double>
-{
-%pythoncode
-%{
-def __getstate__(self):
-    return (self.row, self.col)
-    
-def __setstate__(self, state):
-    self.this = _coda_types.new_RowColDouble()
-    (self.row, self.col) = state
-%}
-}
-
-%extend types::RowCol<sys::SSize_T>
-{
-%pythoncode
-%{
-def __getstate__(self):
-    return (self.row, self.col)
-    
-def __setstate__(self, state):
-    self.this = _coda_types.new_RowColInt()
-    (self.row, self.col) = state
-%}
-}
-
-%extend types::RowCol<size_t>
-{
-%pythoncode
-%{
-def __getstate__(self):
-    return (self.row, self.col)
-    
-def __setstate__(self, state):
-    self.this = _coda_types.new_RowColSizeT()
-    (self.row, self.col) = state
-%}
-}
-
-%extend types::RgAz<double>
-{
-%pythoncode
-%{
-def __getstate__(self):
-    return (self.row, self.col)
-    
-def __setstate__(self, state):
-    self.this = _coda_types.new_RgAzDouble()
-    (self.row, self.col) = state
-%}
-}
-
-%extend std::vector<types::RowCol<sys::SSize_T> >
-{
-%pythoncode
-%{
-def __getstate__(self):
-    # Return a nonempty (thus non-false) tuple with dummy value in first position
-    return (-1, tuple(pickle.dumps(elem) for elem in self))
-    
-def __setstate__(self, state):
-    self.this = _coda_types.new_VectorRowColInt()
-    # State will have a dummy entry in the first position
-    for elem in state[1]:
-        self.push_back(pickle.loads(elem))
-%}
-}
-
-%extend std::vector<size_t>
-{
-%pythoncode
-%{
-def __getstate__(self):
-    # Return a nonempty (thus non-false) tuple with dummy value in first position
-    return (-1, tuple(pickle.dumps(elem) for elem in self))
-    
-def __setstate__(self, state):
-    self.this = _coda_types.new_VectorSizeT()
-    # State will have a dummy entry in the first position
-    for elem in state[1]:
-        self.push_back(pickle.loads(elem))
-%}
-}

--- a/modules/python/types/source/types.i
+++ b/modules/python/types/source/types.i
@@ -47,3 +47,93 @@
 
 %template(VectorRowColInt) std::vector<types::RowCol<sys::SSize_T> >;
 %template(VectorSizeT) std::vector<size_t>;
+
+// Pickle utilities
+%pythoncode
+%{
+    import cPickle as pickle
+%}
+
+%extend types::RowCol<double>
+{
+%pythoncode
+%{
+def __getstate__(self):
+    return (self.row, self.col)
+    
+def __setstate__(self, state):
+    self.this = _coda_types.new_RowColDouble()
+    (self.row, self.col) = state
+%}
+}
+
+%extend types::RowCol<sys::SSize_T>
+{
+%pythoncode
+%{
+def __getstate__(self):
+    return (self.row, self.col)
+    
+def __setstate__(self, state):
+    self.this = _coda_types.new_RowColInt()
+    (self.row, self.col) = state
+%}
+}
+
+%extend types::RowCol<size_t>
+{
+%pythoncode
+%{
+def __getstate__(self):
+    return (self.row, self.col)
+    
+def __setstate__(self, state):
+    self.this = _coda_types.new_RowColSizeT()
+    (self.row, self.col) = state
+%}
+}
+
+%extend types::RgAz<double>
+{
+%pythoncode
+%{
+def __getstate__(self):
+    return (self.row, self.col)
+    
+def __setstate__(self, state):
+    self.this = _coda_types.new_RgAzDouble()
+    (self.row, self.col) = state
+%}
+}
+
+%extend std::vector<types::RowCol<sys::SSize_T> >
+{
+%pythoncode
+%{
+def __getstate__(self):
+    # Return a nonempty (thus non-false) tuple with dummy value in first position
+    return (-1, tuple(pickle.dumps(elem) for elem in self))
+    
+def __setstate__(self, state):
+    self.this = _coda_types.new_VectorRowColInt()
+    # State will have a dummy entry in the first position
+    for elem in state[1]:
+        self.push_back(pickle.loads(elem))
+%}
+}
+
+%extend std::vector<size_t>
+{
+%pythoncode
+%{
+def __getstate__(self):
+    # Return a nonempty (thus non-false) tuple with dummy value in first position
+    return (-1, tuple(pickle.dumps(elem) for elem in self))
+    
+def __setstate__(self, state):
+    self.this = _coda_types.new_VectorSizeT()
+    # State will have a dummy entry in the first position
+    for elem in state[1]:
+        self.push_back(pickle.loads(elem))
+%}
+}

--- a/modules/python/types/tests/test_coda_types.py
+++ b/modules/python/types/tests/test_coda_types.py
@@ -1,0 +1,38 @@
+import unittest
+import cPickle as pickle
+
+from coda import coda_types
+
+class TestCodaTypes(unittest.TestCase):
+
+    def test_RowCol_pickle(self):
+        x = coda_types.RowColDouble(1.2, 3.4)
+        y = pickle.loads(pickle.dumps(x))
+        self.assertEqual(x, y)
+
+        x = coda_types.RowColInt(1, 2)
+        y = pickle.loads(pickle.dumps(x))
+        self.assertEqual(x, y)
+
+        x = coda_types.RowColSizeT(1, 2)
+        y = pickle.loads(pickle.dumps(x))
+        self.assertEqual(x, y)
+
+    def test_RgAz_pickle(self):
+        x = coda_types.RgAzDouble(1.2, 3.4)
+        y = pickle.loads(pickle.dumps(x))
+        self.assertEqual(x, y)
+
+    def test_vector_pickle(self):
+        x = coda_types.VectorSizeT(tuple(range(10)))
+        y = pickle.loads(pickle.dumps(x))
+        self.assertEqual(tuple(x), tuple(y))
+
+        x = coda_types.VectorRowColInt(tuple(coda_types.RowColInt(i+1,i+2)
+                                             for i in range(10)))
+        y = pickle.loads(pickle.dumps(x))
+        self.assertEqual(tuple(x), tuple(y))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By default, swig-wrapped objects do not play nicely with pickle (because the python layer doesn’t necessarily know how to serialize the c++ data), so this revision adds python extensions for the templated types defined in types.i.