### PR TITLE
add negation operators to math.linear objects

### DIFF
--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -1092,9 +1092,12 @@ public:
      */
     Matrix2D operator-() const
     {
-        Matrix2D mneg(*this);
-        std::transform(mneg.mRaw, mneg.mRaw+mneg.mMN, mneg.mRaw, std::negate<_T>());
-        return mneg;
+        Matrix2D neg(*this);
+        std::transform(neg.mRaw,
+                       neg.mRaw + neg.mMN,
+                       neg.mRaw,
+                       std::negate<_T>());
+        return neg;
     }
 
     /*!

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <algorithm>
+#include <functional>
 #include <import/sys.h>
 #include <mem/ScopedArray.h>
 #include <math/linear/MatrixMxN.h>

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -1082,6 +1082,21 @@ public:
     }
 
     /*!
+     *  Negation operator;
+     *
+     *  \code
+           B = -A;
+     *  \endcode
+     *
+     */
+    Matrix2D operator-() const
+    {
+        Matrix2D mneg(*this);
+        std::transform(mneg.mRaw, mneg.mRaw+mneg.mMN, mneg.mRaw, std::negate<_T>());
+        return mneg;
+    }
+
+    /*!
      *  serialize out to a boost stream
      */
     template <class Archive>

--- a/modules/c++/math.linear/include/math/linear/MatrixMxN.h
+++ b/modules/c++/math.linear/include/math/linear/MatrixMxN.h
@@ -1189,8 +1189,26 @@ public:
         return multiply(mx);
     }
     
-
-
+    /*!
+     *  Negation operator;
+     *
+     *  \code
+           B = -A;
+     *  \endcode
+     *
+     */
+    Like_T operator-() const
+    {
+        Like_T mneg;
+        for (size_t i = 0; i < _MD; ++i)
+        {
+            for (size_t j = 0; j < _ND; ++j)
+            {
+                mneg.mRaw[i][j] = -mRaw[i][j];
+            }
+        }
+        return mneg;
+    }
 
 };
 

--- a/modules/c++/math.linear/include/math/linear/MatrixMxN.h
+++ b/modules/c++/math.linear/include/math/linear/MatrixMxN.h
@@ -1199,15 +1199,15 @@ public:
      */
     Like_T operator-() const
     {
-        Like_T mneg;
-        for (size_t i = 0; i < _MD; ++i)
+        Like_T neg;
+        for (size_t ii = 0; ii < _MD; ++ii)
         {
-            for (size_t j = 0; j < _ND; ++j)
+            for (size_t jj = 0; jj < _ND; ++jj)
             {
-                mneg.mRaw[i][j] = -mRaw[i][j];
+                neg.mRaw[ii][jj] = -mRaw[ii][jj];
             }
         }
-        return mneg;
+        return neg;
     }
 
 };

--- a/modules/c++/math.linear/include/math/linear/Vector.h
+++ b/modules/c++/math.linear/include/math/linear/Vector.h
@@ -317,6 +317,15 @@ public:
         return subtract(v);
     }
 
+    //!  Overloaded negation operator
+    Vector
+    operator-() const
+    {
+        Vector v(*this);
+        v.mRaw = -v.mRaw;
+        return v;
+    }
+
     //!  Element-wise multiply assign from another vector
     Vector& operator *=(const Vector& v)
     {

--- a/modules/c++/math.linear/include/math/linear/VectorN.h
+++ b/modules/c++/math.linear/include/math/linear/VectorN.h
@@ -281,6 +281,14 @@ public:
         return subtract(v);
     }
 
+    Like_T
+    operator-() const
+    {
+        Like_T v(*this);
+        v.mRaw = -v.mRaw;
+        return v;
+    }
+
     Like_T& operator *=(const Like_T& v)
     {
         for (size_t i = 0; i < _ND; i++)

--- a/modules/c++/math.linear/unittests/test_Vector.cpp
+++ b/modules/c++/math.linear/unittests/test_Vector.cpp
@@ -245,6 +245,17 @@ TEST_CASE(testOperatorMinusEquals)
 }
 
 
+TEST_CASE(testNegate)
+{
+    Vector<double> X(3);
+    Vector<double> Y(3);
+    X[0] = Y[2] =  1.;
+    X[1] = Y[1] =  0.;
+    X[2] = Y[0] = -1.;
+    TEST_ASSERT_EQ(X, -Y);
+}
+
+
 TEST_CASE(testAdd)
 {
     Vector<double> v1(3, 2.4);
@@ -439,6 +450,7 @@ int main()
     TEST_CHECK(testOperatorPlusEquals);
     TEST_CHECK(testOperatorPlus);
     TEST_CHECK(testOperatorMinus);
+    TEST_CHECK(testNegate);
     TEST_CHECK(testAdd);
     TEST_CHECK(testSubtract);
     TEST_CHECK(testOperatorMinus);

--- a/modules/c++/math.linear/unittests/test_VectorN.cpp
+++ b/modules/c++/math.linear/unittests/test_VectorN.cpp
@@ -277,6 +277,17 @@ TEST_CASE(testOperatorMinusEquals)
 }
 
 
+TEST_CASE(testNegate)
+{
+    VectorN<3,double> X;
+    VectorN<3,double> Y;
+    X[0] = Y[2] =  1.;
+    X[1] = Y[1] =  0.;
+    X[2] = Y[0] = -1.;
+    TEST_ASSERT_EQ(X, -Y);
+}
+
+
 TEST_CASE(testAdd)
 {
     VectorN<3,double> v1(2.4);
@@ -463,6 +474,7 @@ int main()
     TEST_CHECK(testOperatorPlusEquals);
     TEST_CHECK(testOperatorPlus);
     TEST_CHECK(testOperatorMinus);
+    TEST_CHECK(testNegate);
     TEST_CHECK(testAdd);
     TEST_CHECK(testSubtract);
     TEST_CHECK(testOperatorMinus);

--- a/modules/c++/math.linear/unittests/test_mx.cpp
+++ b/modules/c++/math.linear/unittests/test_mx.cpp
@@ -81,6 +81,38 @@ TEST_CASE(testScaleMultiplyMxN)
     TEST_ASSERT_EQ(B, C);
 }
 
+TEST_CASE(testNegateMxN)
+{
+    Matrix3x3 A = identityMatrix<3, double>();
+    Matrix3x3 B = -A;
+    Matrix3x3 C = -B;
+    TEST_ASSERT_EQ(A, C);
+
+    VectorN<3,double> X;
+    X[0] =  1.;
+    X[1] =  0.;
+    X[2] = -1.;
+    VectorN<3,double> Y = -X;
+    VectorN<3,double> Z = -Y;
+    TEST_ASSERT_EQ(X, Z);
+}
+
+TEST_CASE(testNegate)
+{
+    Matrix2D<double> A = identityMatrix<3, double>();
+    Matrix2D<double> B = -A;
+    Matrix2D<double> C = -B;
+    TEST_ASSERT_EQ(A, C);
+
+    Vector<double> X(3);
+    X[0] =  1.;
+    X[1] =  0.;
+    X[2] = -1.;
+    Vector<double> Y = -X;
+    Vector<double> Z = -Y;
+    TEST_ASSERT_EQ(X, Z);
+}
+
 TEST_CASE(testInvert2x2Complex)
 {
     std::complex<double> q[4];
@@ -560,6 +592,8 @@ int main()
     TEST_CHECK(testPtrAssign);
     TEST_CHECK(testSTLVectorAssign);
     TEST_CHECK(testOrthoTranspose5x5);
+    TEST_CHECK(testNegateMxN);
+    TEST_CHECK(testNegate);
 
        
 }

--- a/modules/c++/math.linear/unittests/test_mx.cpp
+++ b/modules/c++/math.linear/unittests/test_mx.cpp
@@ -85,32 +85,44 @@ TEST_CASE(testNegateMxN)
 {
     Matrix3x3 A = identityMatrix<3, double>();
     Matrix3x3 B = -A;
-    Matrix3x3 C = -B;
-    TEST_ASSERT_EQ(A, C);
+    Matrix3x3 C = A;
+    for (size_t i = 0; i < A.rows(); ++i)
+    {
+        for (size_t j = 0; j < A.cols(); ++j)
+        {
+            C[i][j] = -C[i][j];
+        }
+    }
+    TEST_ASSERT_EQ(B, C);
 
     VectorN<3,double> X;
-    X[0] =  1.;
-    X[1] =  0.;
-    X[2] = -1.;
-    VectorN<3,double> Y = -X;
-    VectorN<3,double> Z = -Y;
-    TEST_ASSERT_EQ(X, Z);
+    VectorN<3,double> Y;
+    X[0] = Y[2] =  1.;
+    X[1] = Y[1] =  0.;
+    X[2] = Y[0] = -1.;
+    TEST_ASSERT_EQ(X, -Y);
 }
 
 TEST_CASE(testNegate)
 {
     Matrix2D<double> A = identityMatrix<3, double>();
     Matrix2D<double> B = -A;
-    Matrix2D<double> C = -B;
-    TEST_ASSERT_EQ(A, C);
+    Matrix2D<double> C = A;
+    for (size_t i = 0; i < A.rows(); ++i)
+    {
+        for (size_t j = 0; j < A.cols(); ++j)
+        {
+            C[i][j] = -C[i][j];
+        }
+    }
+    TEST_ASSERT_EQ(B, C);
 
     Vector<double> X(3);
-    X[0] =  1.;
-    X[1] =  0.;
-    X[2] = -1.;
-    Vector<double> Y = -X;
-    Vector<double> Z = -Y;
-    TEST_ASSERT_EQ(X, Z);
+    Vector<double> Y(3);
+    X[0] = Y[2] =  1.;
+    X[1] = Y[1] =  0.;
+    X[2] = Y[0] = -1.;
+    TEST_ASSERT_EQ(X, -Y);
 }
 
 TEST_CASE(testInvert2x2Complex)

--- a/modules/c++/math.linear/unittests/test_mx.cpp
+++ b/modules/c++/math.linear/unittests/test_mx.cpp
@@ -83,46 +83,32 @@ TEST_CASE(testScaleMultiplyMxN)
 
 TEST_CASE(testNegateMxN)
 {
-    Matrix3x3 A = identityMatrix<3, double>();
-    Matrix3x3 B = -A;
+    const Matrix3x3 A = identityMatrix<3, double>();
+    const Matrix3x3 B = -A;
     Matrix3x3 C = A;
-    for (size_t i = 0; i < A.rows(); ++i)
+    for (size_t ii = 0; ii < A.rows(); ++ii)
     {
-        for (size_t j = 0; j < A.cols(); ++j)
+        for (size_t jj = 0; jj < A.cols(); ++jj)
         {
-            C[i][j] = -C[i][j];
+            C[ii][jj] = -C[ii][jj];
         }
     }
     TEST_ASSERT_EQ(B, C);
-
-    VectorN<3,double> X;
-    VectorN<3,double> Y;
-    X[0] = Y[2] =  1.;
-    X[1] = Y[1] =  0.;
-    X[2] = Y[0] = -1.;
-    TEST_ASSERT_EQ(X, -Y);
 }
 
 TEST_CASE(testNegate)
 {
-    Matrix2D<double> A = identityMatrix<3, double>();
-    Matrix2D<double> B = -A;
+    const Matrix2D<double> A = identityMatrix<3, double>();
+    const Matrix2D<double> B = -A;
     Matrix2D<double> C = A;
-    for (size_t i = 0; i < A.rows(); ++i)
+    for (size_t ii = 0; ii < A.rows(); ++ii)
     {
-        for (size_t j = 0; j < A.cols(); ++j)
+        for (size_t jj = 0; jj < A.cols(); ++jj)
         {
-            C[i][j] = -C[i][j];
+            C[ii][jj] = -C[ii][jj];
         }
     }
     TEST_ASSERT_EQ(B, C);
-
-    Vector<double> X(3);
-    Vector<double> Y(3);
-    X[0] = Y[2] =  1.;
-    X[1] = Y[1] =  0.;
-    X[2] = Y[0] = -1.;
-    TEST_ASSERT_EQ(X, -Y);
 }
 
 TEST_CASE(testInvert2x2Complex)
@@ -587,7 +573,6 @@ TEST_CASE(testArithmeticMxN)
 int main()
 {
 
-
     TEST_CHECK(testIdentityMxN);
     TEST_CHECK(testScaleMultiplyMxN);
     TEST_CHECK(testSetRows);
@@ -607,5 +592,5 @@ int main()
     TEST_CHECK(testNegateMxN);
     TEST_CHECK(testNegate);
 
-       
+    return 0;
 }


### PR DESCRIPTION
Added negation operator to Matrix2D, MatrixMxN, Vector, and VectorN, as well as unit tests.  Now you can do:
`  Matrix2D B = -A;`