### PR TITLE
Throw exception for invalid fit (not enough points)

### DIFF
--- a/modules/c++/math.poly/include/math/poly/Fit.h
+++ b/modules/c++/math.poly/include/math/poly/Fit.h
@@ -6,6 +6,7 @@
 #include <math/linear/Matrix2D.h>
 #include <math/linear/VectorN.h>
 #include <numeric>
+#include <sstream>
 
 namespace math
 {
@@ -54,6 +55,16 @@ template<typename Vector_T> OneD<double> fit(const Vector_T& x,
     // n is polynomial order
     size_t sizeX = vx.size();
 
+    if (sizeX <= order)
+    {
+        std::ostringstream excSS;
+        excSS << "Not enough points for a unique fit solution ("
+              << sizeX << " points for an order-" << order
+              << "fit)!  You should really have at least (order+1) = "
+              << (order+1) << " points for this to do what you expect.";
+        throw except::Exception(Ctxt(excSS.str()));
+    }
+    
     // Compute mean value
     double mean = std::accumulate(vx.get(), vx.get() + sizeX, 0.0) / sizeX;
 
@@ -168,6 +179,17 @@ inline math::poly::TwoD<double> fit(const math::linear::Matrix2D<double>& x,
     yp.scale(ryrms);
 
     size_t acols = (nx+1) * (ny+1);
+
+    if (mxn < acols)
+    {
+        std::ostringstream excSS;
+        excSS << "Not enough points for a unique fit solution ("
+              << mxn << " points for a " << acols << "-coefficient fit)!"
+              << " You should really have at least (orderX+1)*(orderY+1) = "
+              << acols << " points for this to do what you expect.";
+        throw except::Exception(Ctxt(excSS.str()));
+    }
+    
 
     // R = M x N
     // C = NX+1 x NY+1

--- a/modules/c++/math.poly/include/math/poly/Fit.h
+++ b/modules/c++/math.poly/include/math/poly/Fit.h
@@ -1,10 +1,15 @@
 #ifndef __MATH_POLY_FIT_H__
 #define __MATH_POLY_FIT_H__
 
+// coda-oss
 #include <math/poly/OneD.h>
 #include <math/poly/TwoD.h>
 #include <math/linear/Matrix2D.h>
 #include <math/linear/VectorN.h>
+#include <sys/Conf.h>
+#include <except/Exception.h>
+
+// STL
 #include <numeric>
 #include <sstream>
 

--- a/modules/c++/math.poly/include/math/poly/Fit.h
+++ b/modules/c++/math.poly/include/math/poly/Fit.h
@@ -1,7 +1,6 @@
 #ifndef __MATH_POLY_FIT_H__
 #define __MATH_POLY_FIT_H__
 
-// coda-oss
 #include <math/poly/OneD.h>
 #include <math/poly/TwoD.h>
 #include <math/linear/Matrix2D.h>
@@ -9,7 +8,6 @@
 #include <sys/Conf.h>
 #include <except/Exception.h>
 
-// STL
 #include <numeric>
 #include <sstream>
 

--- a/modules/c++/math.poly/unittests/test_llsq.cpp
+++ b/modules/c++/math.poly/unittests/test_llsq.cpp
@@ -47,6 +47,9 @@ TEST_CASE(test1DPolyfit)
     const OneD<double> truth(3, zPoly);
     // First test the raw pointer signature
     const OneD<double> polyFromRaw = fit(4, xObs, yObs, 3);
+
+    // should fail with not enough points (order>=npoints)
+    TEST_EXCEPTION(fit(4, xObs, yObs, 4));
     
     // Now call the other one
     const Vector<double> xv(4, xObs);
@@ -148,6 +151,9 @@ TEST_CASE(test2DPolyfit)
     z(0, 0) = 1;   z(1, 0) = .3; z(2, 0) = 0;
     z(0, 1) = .16; z(1, 1) = 1;  z(2, 1) = 0;
     z(0, 2) = 0;   z(1, 2) = 0;  z(2, 2) = .85;
+
+    // should fail with not enough points: (orderX+1)*(orderY+1) > npoints
+    TEST_EXCEPTION(fit(x, y, z, 3, 3));
 
     TwoD<double> poly = fit(x, y, z, 1, 1);
     TEST_ASSERT_EQ(poly, truth);


### PR DESCRIPTION
math::poly::fit() throws if not enough points to constrain fit to unique solution; added unit tests for this.  For 1D case throw if npoints < order+1.  For 2D case throw if npoints < (orderX+1) * (orderY+1).  Essentially you need at least as many points as coefficients in your polynomial, or there are infinite solutions and the returned polynomial could be any of them (probably not what you want).