### PR TITLE
Fix checking for SWIG version

### DIFF
--- a/build/swig.py
+++ b/build/swig.py
@@ -175,13 +175,16 @@ def check_swig_version(self, minver=None):
         minver = [int(s) for s in minver]
     result = (minver is None) or (minver[:3] <= swigver[:3])
     swigver_full = '.'.join(map(str, swigver))
+    minver_str = minver and '.'.join(map(str, minver))
     if result:
         self.env['SWIG_VERSION'] = swigver_full
-    minver_str = minver and '.'.join(map(str, minver))
+    else:
+        raise RuntimeError('Minimum SWIG verion required: %s. Version found: %s'
+                % (minver_str, swigver_full))
     if minver is None:
         self.msg('swig version', swigver_full)
     else:
-        self.msg('swig version >= %s' % (minver_str,), result, option=swigver_full)
+        self.msg('swig version %s >= %s' % (swigver_full, minver_str,), result)
     return result
 
 def options(opt):


### PR DESCRIPTION
Two things here. I had to change the call to self.msg because option isn't a keyword argument. (docs: https://waf.io/apidocs/Context.html#waflib.Context.Context.msg)

And then it didn't actually do anything if it couldn't find the minimum version.