### PR TITLE
Fix PCRE 10.22 linking on Windows

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1466,7 +1466,6 @@ def untar(tsk):
 
 def untarFile(path, fname, mode='r'):
     import tarfile
-    print mode
     f = path.find_or_declare(fname)
     tf = tarfile.open(f.abspath(), mode)
     p = path.abspath()

--- a/modules/c++/re/wscript
+++ b/modules/c++/re/wscript
@@ -22,6 +22,12 @@ def configure(conf):
         conf.env['DEFINES'] = []
         if conf.env['enable_std_regex']:
             conf.define('RE_ENABLE_STD_REGEX', 1)
+        elif not Options.options.shared_libs:
+            # We need this in order to link properly on Windows
+            # We could get this via export_defines in the modules/drivers/pcre/wscript
+            # but that won't work if someone is trying to link in our stuff from their
+            # own build system (or if they're using a prebuilt PCRE)
+            conf.define('PCRE2_STATIC', 1)
 
     writeConfig(conf, re_callback, NAME)
 


### PR DESCRIPTION
`PCRE2_STATIC` is not getting set in one additional spot which is causing linking issues on Windows