### PR TITLE
Regex url fix

### DIFF
--- a/modules/c++/re/source/RegexPCRE.cpp
+++ b/modules/c++/re/source/RegexPCRE.cpp
@@ -103,7 +103,7 @@ public:
         }
         else
         {
-            return returnCode;
+            return pcre2_get_ovector_count(mMatchData);
         }
     }
 
@@ -114,11 +114,10 @@ public:
         const size_t index = outVector[idx * 2];
         const size_t end = outVector[idx * 2 + 1];
 
-        // If index is equal to end then we need to return an empty string.
-        // It is not always the case when this happens that these values will
-        // be less than or equal to the size of the string, so we need to
-        // explicitly return "" so nothing goes out of bounds.
-        if (index == end)
+        // If both index and end are set to PCRE2_UNSET then we did not find
+        // a match the index and end values are invalid for the substr call.
+        // In this case we need to return an empty string.
+        if (index == PCRE2_UNSET && end == PCRE2_UNSET)
         {
             return "";
         }

--- a/modules/c++/re/source/RegexPCRE.cpp
+++ b/modules/c++/re/source/RegexPCRE.cpp
@@ -83,7 +83,7 @@ public:
         // This returns the number of matches
         // But for no matches, it returns PCRE2_ERROR_NOMATCH
         // Other return codes less than 0 indicate an error
-        const int returnCode =
+        const int numMatches =
                 pcre2_match(mCode,
                             reinterpret_cast<PCRE2_SPTR>(subject.c_str()),
                             subject.length(),
@@ -103,6 +103,9 @@ public:
         }
         else
         {
+            // The num matches variable above won't include trailing empty
+            // matches. By returning the actual size including empty matches
+            // we now match the STL and Python versions of regex.
             return pcre2_get_ovector_count(mMatchData);
         }
     }

--- a/modules/c++/re/source/RegexPCRE.cpp
+++ b/modules/c++/re/source/RegexPCRE.cpp
@@ -114,6 +114,15 @@ public:
         const size_t index = outVector[idx * 2];
         const size_t end = outVector[idx * 2 + 1];
 
+        // If index is equal to end then we need to return an empty string.
+        // It is not always the case when this happens that these values will
+        // be less than or equal to the size of the string, so we need to
+        // explicitly return "" so nothing goes out of bounds.
+        if (index == end)
+        {
+            return "";
+        }
+
         if (end > str.length())
         {
             // Presumably this never happens

--- a/modules/c++/re/unittests/test_regex.cpp
+++ b/modules/c++/re/unittests/test_regex.cpp
@@ -508,6 +508,5 @@ int main(int, char**)
     TEST_CHECK(testSub);
     TEST_CHECK(testSplit);
     TEST_CHECK(testHttpResponse);
-    TEST_CHECK(testMatchOptional);
     return 0;
 }

--- a/modules/c++/re/unittests/test_regex.cpp
+++ b/modules/c++/re/unittests/test_regex.cpp
@@ -78,12 +78,14 @@ TEST_CASE(testMatchOptional)
     url = "http://localhost/page.com";
     matches.clear();
     rx.match(url, matches);
-    TEST_ASSERT_GREATER_EQ(matches.size(), 5);
+    TEST_ASSERT_GREATER_EQ(matches.size(), 7);
     TEST_ASSERT_EQ(matches[0], url)
     TEST_ASSERT_EQ(matches[1], "http");
     TEST_ASSERT_EQ(matches[2], "localhost");
     TEST_ASSERT_EQ(matches[3], "");
     TEST_ASSERT_EQ(matches[4], "/page.com");
+    TEST_ASSERT_EQ(matches[5], "");
+    TEST_ASSERT_EQ(matches[6], "");
 }
 
 TEST_CASE(testSearch)
@@ -492,7 +494,6 @@ TEST_CASE(testHttpResponse)
     TEST_ASSERT_EQ(p.getContentType(), "application/x-www-form-urlencoded");
     TEST_ASSERT_EQ(p.getContentLength(), "96");
 }
-
 
 int main(int, char**)
 {

--- a/modules/c++/re/unittests/test_regex.cpp
+++ b/modules/c++/re/unittests/test_regex.cpp
@@ -59,6 +59,33 @@ TEST_CASE(testMatches)
     TEST_ASSERT_EQ(matches[3], "");
 }
 
+TEST_CASE(testMatchOptional)
+{
+    re::RegexMatch matches;
+    re::Regex rx("([A-Za-z]+)://([^/?#:]+)(?::(\\d+))?(/[^?#:]+)?(?:[?]([^&#/]+(?:[&;][^&;#/]+)*)?)?(?:[#](.*))?");
+    std::string url = "http://localhost:80/something/page.com?param1=foo&param2=bar#fragment";
+
+    rx.match(url, matches);
+    TEST_ASSERT_EQ(matches.size(), 7);
+    TEST_ASSERT_EQ(matches[0], url)
+    TEST_ASSERT_EQ(matches[1], "http");
+    TEST_ASSERT_EQ(matches[2], "localhost");
+    TEST_ASSERT_EQ(matches[3], "80");
+    TEST_ASSERT_EQ(matches[4], "/something/page.com");
+    TEST_ASSERT_EQ(matches[5], "param1=foo&param2=bar");
+    TEST_ASSERT_EQ(matches[6], "fragment");
+
+    url = "http://localhost/page.com";
+    matches.clear();
+    rx.match(url, matches);
+    TEST_ASSERT_GREATER_EQ(matches.size(), 5);
+    TEST_ASSERT_EQ(matches[0], url)
+    TEST_ASSERT_EQ(matches[1], "http");
+    TEST_ASSERT_EQ(matches[2], "localhost");
+    TEST_ASSERT_EQ(matches[3], "");
+    TEST_ASSERT_EQ(matches[4], "/page.com");
+}
+
 TEST_CASE(testSearch)
 {
     re::Regex rx("ju.");
@@ -466,10 +493,12 @@ TEST_CASE(testHttpResponse)
     TEST_ASSERT_EQ(p.getContentLength(), "96");
 }
 
+
 int main(int, char**)
 {
     TEST_CHECK(testCompile);
     TEST_CHECK(testMatches);
+    TEST_CHECK(testMatchOptional);
     TEST_CHECK(testSearch);
     TEST_CHECK(testSearchAll);
     TEST_CHECK(testSearchAllWithOverlap);
@@ -479,5 +508,6 @@ int main(int, char**)
     TEST_CHECK(testSub);
     TEST_CHECK(testSplit);
     TEST_CHECK(testHttpResponse);
+    TEST_CHECK(testMatchOptional);
     return 0;
 }


### PR DESCRIPTION
I think this is correct?

I had to use the actual call in the net module to reproduce the issue. Using (abc)(d?)(efg) with "abcdefg" and "abcefg" would work as is. I am not regex savvy enough to parse everything going on in that call (I tried to put it into some online checkers and several of them failed on it).

This does work with the stl version of regex but that one always returns the maximum number of matches with extra empty strings at the end which is why line 81 is a check for GREATER rather than EQ. It looked like the code was setup to handle a variable number of returns so I assume PCRE is correct here (at least for our purposes). Do we want to change the stl version so it looks for trailing empty strings and removes them?