### PR TITLE
defaulting SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS

### DIFF
--- a/build/swig.py
+++ b/build/swig.py
@@ -154,6 +154,8 @@ def i_file(self, node):
 
     flags = self.to_list(getattr(self, 'swig_flags', []))
     tsk.env.append_value('SWIGFLAGS', flags)
+    if not '-noextranative' in flags:
+        tsk.env.append_value('SWIGFLAGS', ['-extranative'])
 
     tsk.swig_install_fun = getattr(self, 'swig_install_fun', None)
 

--- a/modules/c++/numpyutils/examples/source/generated/numpyutilstest_wrap.cxx
+++ b/modules/c++/numpyutils/examples/source/generated/numpyutilstest_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/except/source/generated/coda_except_wrap.cxx
+++ b/modules/python/except/source/generated/coda_except_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/io/source/generated/coda_io_wrap.cxx
+++ b/modules/python/io/source/generated/coda_io_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/logging/source/generated/coda_logging_wrap.cxx
+++ b/modules/python/logging/source/generated/coda_logging_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/math.linear/source/generated/math_linear_wrap.cxx
+++ b/modules/python/math.linear/source/generated/math_linear_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/math.poly/source/generated/math_poly_wrap.cxx
+++ b/modules/python/math.poly/source/generated/math_poly_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/mem/source/generated/mem_wrap.cxx
+++ b/modules/python/mem/source/generated/mem_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/mt/source/generated/mt.py
+++ b/modules/python/mt/source/generated/mt.py
@@ -143,6 +143,11 @@ class ThreadPlanner(_object):
         return _mt.ThreadPlanner_getNumElementsPerThread(self)
 
 
+    def getNumThreadsThatWillBeUsed(self):
+        """getNumThreadsThatWillBeUsed(ThreadPlanner self) -> size_t"""
+        return _mt.ThreadPlanner_getNumThreadsThatWillBeUsed(self)
+
+
     def getThreadInfo(self, threadNum):
         """getThreadInfo(ThreadPlanner self, size_t threadNum) -> PyObject *"""
         return _mt.ThreadPlanner_getThreadInfo(self, threadNum)

--- a/modules/python/mt/source/generated/mt_wrap.cxx
+++ b/modules/python/mt/source/generated/mt_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus
@@ -3618,6 +3619,58 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_ThreadPlanner_getNumThreadsThatWillBeUsed(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  mt::ThreadPlanner *arg1 = (mt::ThreadPlanner *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  size_t result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:ThreadPlanner_getNumThreadsThatWillBeUsed",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_mt__ThreadPlanner, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "ThreadPlanner_getNumThreadsThatWillBeUsed" "', argument " "1"" of type '" "mt::ThreadPlanner const *""'"); 
+  }
+  arg1 = reinterpret_cast< mt::ThreadPlanner * >(argp1);
+  {
+    try
+    {
+      result = ((mt::ThreadPlanner const *)arg1)->getNumThreadsThatWillBeUsed();
+    } 
+    catch (const std::exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+      }
+    }
+    catch (const except::Exception& e)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
+      }
+    }
+    catch (...)
+    {
+      if (!PyErr_Occurred())
+      {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
+      }
+    }
+    if (PyErr_Occurred())
+    {
+      SWIG_fail;
+    }
+  }
+  resultobj = SWIG_From_size_t(static_cast< size_t >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_ThreadPlanner_getThreadInfo(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   mt::ThreadPlanner *arg1 = (mt::ThreadPlanner *) 0 ;
@@ -3950,6 +4003,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Runnable_swigregister", Runnable_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_ThreadPlanner", _wrap_new_ThreadPlanner, METH_VARARGS, (char *)"new_ThreadPlanner(size_t numElements, size_t numThreads) -> ThreadPlanner"},
 	 { (char *)"ThreadPlanner_getNumElementsPerThread", _wrap_ThreadPlanner_getNumElementsPerThread, METH_VARARGS, (char *)"ThreadPlanner_getNumElementsPerThread(ThreadPlanner self) -> size_t"},
+	 { (char *)"ThreadPlanner_getNumThreadsThatWillBeUsed", _wrap_ThreadPlanner_getNumThreadsThatWillBeUsed, METH_VARARGS, (char *)"ThreadPlanner_getNumThreadsThatWillBeUsed(ThreadPlanner self) -> size_t"},
 	 { (char *)"ThreadPlanner_getThreadInfo", _wrap_ThreadPlanner_getThreadInfo, METH_VARARGS, (char *)"ThreadPlanner_getThreadInfo(ThreadPlanner self, size_t threadNum) -> PyObject *"},
 	 { (char *)"delete_ThreadPlanner", _wrap_delete_ThreadPlanner, METH_VARARGS, (char *)"delete_ThreadPlanner(ThreadPlanner self)"},
 	 { (char *)"ThreadPlanner_swigregister", ThreadPlanner_swigregister, METH_VARARGS, NULL},

--- a/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
+++ b/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/sys/source/generated/coda_sys_wrap.cxx
+++ b/modules/python/sys/source/generated/coda_sys_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/types/source/generated/coda_types_wrap.cxx
+++ b/modules/python/types/source/generated/coda_types_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus

--- a/modules/python/xml.lite/source/generated/xml_lite_wrap.cxx
+++ b/modules/python/xml.lite/source/generated/xml_lite_wrap.cxx
@@ -14,6 +14,7 @@
 #endif
 
 #define SWIG_PYTHON_DIRECTOR_NO_VTABLE
+#define SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
This change is a global swig script change in order to change default SWIG behavior.  

In short, SWIG has an awesome default setting whereby depending on the number of elements in a vector, there is a covariant return type.

That is to say:
- a std::vector<T> of size 0 returns a tuple '()'
- a std::vector<T> of size 1 returns a T
- a std::vector<T> of size >1 returns a vector<T>

This introduces potentially really annoying handling at the python level.  I don't think that this is a good thing for us, and the benefit of whatever saving that might be is probably overwhelmed by the extra code maintenance.

After some digging, I came across this flag.  I think this is probably unintended behavior globally, so I've chosen to set a flag in swig.py unless -noextranative is explicitly passed:

If you're interested in what's going on at the preprocessor level, see below for SWIG 3.10 code:

  template <class Seq, class T = typename Seq::value_type >
  struct traits_from_stdseq {
    typedef Seq sequence;
    typedef T value_type;
    typedef typename Seq::size_type size_type;
    typedef typename sequence::const_iterator const_iterator;

    static PyObject *from(const sequence& seq) {
%#ifdef SWIG_PYTHON_EXTRA_NATIVE_CONTAINERS
      swig_type_info *desc = swig::type_info<sequence>();
      if (desc && desc->clientdata) {
    return SWIG_NewPointerObj(new sequence(seq), desc, SWIG_POINTER_OWN);
      }
%#endif
      size_type size = seq.size();
      if (size <= (size_type)INT_MAX) {
    PyObject *obj = PyTuple_New((Py_ssize_t)size);
    Py_ssize_t i = 0;
    for (const_iterator it = seq.begin(); it != seq.end(); ++it, ++i) {
      PyTuple_SetItem(obj,i,swig::from<value_type>(*it));
    }
    return obj;
      } else {
    PyErr_SetString(PyExc_OverflowError,"sequence size not valid in python");
    return NULL;
      }
    }
  };

The -extranative flag simply sets the define in generated CXX files so we always take the first option (e.g. a Vector<T>* regardless of its size.