### PR TITLE
Two minor gcc 6.2 / Alpine Linux fixes

### DIFF
--- a/modules/c++/mt/include/mt/LinuxCPUAffinityThreadInitializer.h
+++ b/modules/c++/mt/include/mt/LinuxCPUAffinityThreadInitializer.h
@@ -29,7 +29,7 @@
 
 #include <sched.h>
 #include <sys/types.h>
-#include <linux/unistd.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 #define gettid() syscall(SYS_gettid)
 

--- a/modules/c++/sys/source/ExecUnix.cpp
+++ b/modules/c++/sys/source/ExecUnix.cpp
@@ -93,7 +93,9 @@ FILE* ExecPipe::openPipe(const std::string& command,
             //! call our command --
             //  this command replaces the forked process with
             //  command the user specified
-            execl("/bin/sh", "sh", "-c", command.c_str(), NULL);
+            execl("/bin/sh", "sh", "-c",
+                  command.c_str(),
+                  static_cast<char*>(NULL));
 
             //! exit the subprocess once it has completed
             exit(127);


### PR DESCRIPTION
`execl()` wanting a cast was a compiler warning
Not finding `linux/unistd.h` was an error