### PR TITLE
Revert __init__.py change

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1438,15 +1438,15 @@ def python_package(tg):
     if not os.path.isfile(fname):
         open(fname,'a').close()
 
-    # to install files the 'node' associated with the file
-    # needs to have a signature; the hash of the file is
-    # good enough for us.
-    relpath = os.path.join(pkg_name, tg.target)
-    nod = tg.bld.bldnode.make_node(relpath)
-    nod.sig = h_file(fname)
+        # to install files the 'node' associated with the file
+        # needs to have a signature; the hash of the file is
+        # good enough for us.
+        relpath = os.path.join(pkg_name, tg.target)
+        nod = tg.bld.bldnode.make_node(relpath)
+        nod.sig = h_file(fname)
 
-    # schedule the file for installation
-    tg.bld.install_files(install_path,nod)
+        # schedule the file for installation
+        tg.bld.install_files(install_path,nod)
 
 @task_gen
 @feature('untar')


### PR DESCRIPTION
I am very occasionally, (maybe 1 time in 7?) getting an error while installing: ` '/data1/u/jmeans/coda/install/lib/python2.7/site-packages/coda/__init__.py' does not exist`

Haven't figured out how to reliably reproduce it yet. Until it's fixed, I think it's better to have __init__.py not be installed in certain, rare, known circumstances, than to have the install randomly fail.


