### PR TITLE
Some systems require explicitly adding curl to link line

### DIFF
--- a/modules/drivers/curl/wscript
+++ b/modules/drivers/curl/wscript
@@ -8,6 +8,7 @@ def configure(conf):
     conf.env['HAVE_CURL'] = False
 
     if conf.check(uselib_store='CURL',
+                  lib='curl',
                   header_name='curl/curl.h',
                   function_name='curl_global_init',
                   msg='Checking for CURL',


### PR DESCRIPTION
I ran into a case where one of our net libraries wouldn't compile because configuration couldn't implicitly link to libcurl, this will always explicitly link to it.