### PR TITLE
Typo in include guard

### DIFF
--- a/modules/c++/sio.lite/include/sio/lite/ReadUtils.h
+++ b/modules/c++/sio.lite/include/sio/lite/ReadUtils.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef __SIO_LITE_SIO_READER_H__
-#define __SIO_LITE_SIO_READER_H__
+#ifndef __SIO_LITE_READ_UTILS_H__
+#define __SIO_LITE_READ_UTILS_H__
 
 #include <string>
 #include <sys/Conf.h>


### PR DESCRIPTION
Doesn't look like this include guard was used elsewhere but it's still a mismatch.