### PR TITLE
 Make some test macros work against NaNs 

### DIFF
--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -30,6 +30,7 @@
 #  include <import/sys.h>
 #  include <import/str.h>
 
+#  define IS_NAN(X) X != X
 #  define TEST_CHECK(X) try{ X(std::string(#X)); std::cerr << #X << ": PASSED" << std::endl; } catch(except::Throwable& ex) { die_printf("%s: FAILED: Exception thrown: %s\n", std::string(#X).c_str(), ex.toString().c_str()); }
 #  define TEST_ASSERT(X) if (!(X)) { die_printf("%s (%s,%s,%d): FAILED: Value should not be NULL\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__); }
 #  define TEST_ASSERT_NULL(X) if ((X) != NULL) { die_printf("%s (%s,%s,%d): FAILED: Value should be NULL\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__); }
@@ -39,8 +40,8 @@
 #  define TEST_ASSERT_EQ_MSG(msg, X1, X2) if ((X1) != (X2)) die_printf("%s (%s,%d): FAILED (%s): Recv'd %s, Expected %s\n", testName.c_str(), __FILE__, __LINE__, (msg).c_str(), str::toString((X1)).c_str(), str::toString((X2)).c_str());
 #  define TEST_ASSERT_NOT_EQ(X1, X2) if ((X1) == (X2)) { die_printf("%s (%s,%s,%d): FAILED: Recv'd %s should not equal %s\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__, str::toString(X1).c_str(), str::toString(X2).c_str()); }
 #  define TEST_ASSERT_NOT_EQ_MSG(msg, X1, X2) if ((X1) == (X2)) die_printf("%s (%s,%d): FAILED (%s): Recv'd %s should not equal %s\n", testName.c_str(), __FILE__, __LINE__, (msg).c_str(), str::toString((X1)).c_str(), str::toString((X2)).c_str());
-#  define TEST_ASSERT_ALMOST_EQ_EPS(X1, X2, EPS) if (std::abs((X1) - (X2)) > EPS) die_printf("%s (%s,%d): FAILED: Recv'd %s, Expected %s\n", testName.c_str(), __FILE__, __LINE__, str::toString((X1)).c_str(), str::toString((X2)).c_str());
-#  define TEST_ASSERT_ALMOST_EQ(X1, X2) if (std::abs((X1) - (X2)) > std::numeric_limits<float>::epsilon()) { die_printf("%s (%s,%s,%d): FAILED: Recv'd %s, Expected %s\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__, str::toString(X1).c_str(), str::toString(X2).c_str()); }
+#  define TEST_ASSERT_ALMOST_EQ_EPS(X1, X2, EPS) if (std::abs((X1) - (X2)) > EPS || IS_NAN(std::abs((X1) - (X2)))) die_printf("%s (%s,%d): FAILED: Recv'd %s, Expected %s\n", testName.c_str(), __FILE__, __LINE__, str::toString((X1)).c_str(), str::toString((X2)).c_str());
+#  define TEST_ASSERT_ALMOST_EQ(X1, X2) if (std::abs((X1) - (X2)) > std::numeric_limits<float>::epsilon() || IS_NAN(std::abs((X1) - (X2)))) { die_printf("%s (%s,%s,%d): FAILED: Recv'd %s, Expected %s\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__, str::toString(X1).c_str(), str::toString(X2).c_str()); }
 #  define TEST_ASSERT_GREATER_EQ(X1, X2) if ((X1) < X2) { die_printf("%s (%s,%s,%d): FAILED: Value should be greater than or equal\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__); }
 #  define TEST_ASSERT_GREATER(X1, X2) if ((X1) <= X2) { die_printf("%s (%s,%s,%d): FAILED: Value should be greater than\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__); }
 #  define TEST_ASSERT_LESSER_EQ(X1, X2) if ((X1) > X2) { die_printf("%s (%s,%s,%d): FAILED: Value should be less than or equal\n", testName.c_str(), __FILE__, SYS_FUNC, __LINE__); }

--- a/modules/c++/sys/unittests/test_NaN_testing.cpp
+++ b/modules/c++/sys/unittests/test_NaN_testing.cpp
@@ -1,5 +1,27 @@
-#include "TestCase.h"
+/* =========================================================================
+ * This file is part of sys-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 #include <limits>
+#include "TestCase.h"
 
 namespace
 {
@@ -15,12 +37,12 @@ TEST_CASE(testNaNsAreNotEqual)
     TEST_ASSERT_NOT_EQ(std::numeric_limits<float>::quiet_NaN(), 3.4);
 
 }
+
 TEST_CASE(testNaNIsNotAlmostEqualToNumber)
 {
     // Uncomment the test to see it work.
     // These test macros are supposed to fail here.
     // But I don't have a way to intercept the failure.
-    // the failure.
     //
     /*
     TEST_ASSERT_ALMOST_EQ(std::numeric_limits<float>::quiet_NaN(), 5);

--- a/modules/c++/sys/unittests/test_NaN_testing.cpp
+++ b/modules/c++/sys/unittests/test_NaN_testing.cpp
@@ -1,0 +1,46 @@
+#include "TestCase.h"
+#include <limits>
+
+namespace
+{
+TEST_CASE(testNaNsAreNotEqual)
+{
+    // This test exists mainly to document behavior
+    // It's not awesome that things work this way, but presumably
+    // the caller is testing against a known value, so if this comes up
+    // NaN oddness is already expected.
+    TEST_ASSERT_NOT_EQ(std::numeric_limits<float>::quiet_NaN(),
+        std::numeric_limits<float>::quiet_NaN());
+
+    TEST_ASSERT_NOT_EQ(std::numeric_limits<float>::quiet_NaN(), 3.4);
+
+}
+TEST_CASE(testNaNIsNotAlmostEqualToNumber)
+{
+    // Uncomment the test to see it work.
+    // These test macros are supposed to fail here.
+    // But I don't have a way to intercept the failure.
+    // the failure.
+    //
+    /*
+    TEST_ASSERT_ALMOST_EQ(std::numeric_limits<float>::quiet_NaN(), 5);
+    TEST_ASSERT_ALMOST_EQ_EPS(std::numeric_limits<float>::quiet_NaN(),
+                5, 3);
+    */
+}
+
+TEST_CASE(testIsNaN)
+{
+    TEST_ASSERT_TRUE(IS_NAN(std::numeric_limits<float>::quiet_NaN()));
+    TEST_ASSERT_FALSE(IS_NAN(5));
+    TEST_ASSERT_FALSE(IS_NAN(std::string("test string")));
+}
+}
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    TEST_CHECK(testNaNsAreNotEqual);
+    TEST_CHECK(testNaNIsNotAlmostEqualToNumber);
+    TEST_CHECK(testIsNaN);
+}
+


### PR DESCRIPTION
I ran into some surprises while testing.