### PR TITLE
Updated handlers to avoid calling virtual methods in the destructor

### DIFF
--- a/modules/c++/logging/include/logging/StreamHandler.h
+++ b/modules/c++/logging/include/logging/StreamHandler.h
@@ -1,7 +1,7 @@
 /* =========================================================================
- * This file is part of logging-c++ 
+ * This file is part of logging-c++
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2014, MDA Information Systems LLC
  *
  * logging-c++ is free software; you can redistribute it and/or modify
@@ -14,8 +14,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -48,28 +48,30 @@ public:
     //! Constructs a StreamHandler using the specified OutputStream
     StreamHandler(io::OutputStream* stream, LogLevel level = LogLevel::LOG_NOTSET);
 
-    virtual ~StreamHandler()
-    {
-        close();
-    }
+    virtual ~StreamHandler();
 
     //! adds the need to write epilogue before deleting formatter
     //  and then writing the prologue with the new formatter
     virtual void setFormatter(Formatter* formatter);
-    
+
     virtual void close();
 
 protected:
+    // This is necessary so this class and an inherited class can call a
+    // non-virtual version of close in its destructor.
+    void closeImpl();
 
     //! for general string write
     virtual void write(const std::string&);
 
-    //! for writing directly to stream, 
+    //! for writing directly to stream,
     // used for the bulk of the logging for speed
     virtual void emitRecord(const LogRecord* record);
 
-
     std::auto_ptr<io::OutputStream> mStream;
+
+private:
+    bool mClosed;
 };
 
 }

--- a/modules/c++/logging/source/Handler.cpp
+++ b/modules/c++/logging/source/Handler.cpp
@@ -1,7 +1,7 @@
 /* =========================================================================
- * This file is part of logging-c++ 
+ * This file is part of logging-c++
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2014, MDA Information Systems LLC
  *
  * logging-c++ is free software; you can redistribute it and/or modify
@@ -14,8 +14,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -26,8 +26,9 @@
 
 #include "logging/Handler.h"
 
-
-logging::Handler::Handler(logging::LogLevel level)
+namespace logging
+{
+Handler::Handler(LogLevel level)
 {
     mLevel = level;
 
@@ -35,20 +36,23 @@ logging::Handler::Handler(logging::LogLevel level)
     mFormatter = &mDefaultFormatter;
 }
 
-void logging::Handler::close()
+void Handler::close()
 {
     // delete if necessary
     if (mFormatter != &mDefaultFormatter &&
         mFormatter != NULL)
+    {
         delete mFormatter;
+        mFormatter = NULL;
+    }
 }
 
-void logging::Handler::setLevel(logging::LogLevel level)
+void Handler::setLevel(LogLevel level)
 {
     mLevel = level;
 }
 
-bool logging::Handler::handle(const logging::LogRecord* record)
+bool Handler::handle(const LogRecord* record)
 {
     bool rv = false;
     if (filter(record))
@@ -68,7 +72,7 @@ bool logging::Handler::handle(const logging::LogRecord* record)
     }
     return rv;
 }
-void logging::Handler::setFormatter(logging::Formatter* formatter)
+void Handler::setFormatter(Formatter* formatter)
 {
     //check if current formatter
     if (mFormatter != formatter)
@@ -78,4 +82,5 @@ void logging::Handler::setFormatter(logging::Formatter* formatter)
 
         mFormatter = formatter;
     }
+}
 }

--- a/modules/c++/logging/source/StreamHandler.cpp
+++ b/modules/c++/logging/source/StreamHandler.cpp
@@ -40,7 +40,8 @@ StreamHandler::StreamHandler(LogLevel level) :
 
 StreamHandler::StreamHandler(io::OutputStream* stream,
                              LogLevel level) :
-    Handler(level)
+    Handler(level),
+    mClosed(false)
 {
     mStream.reset(stream);
 

--- a/modules/c++/logging/source/StreamHandler.cpp
+++ b/modules/c++/logging/source/StreamHandler.cpp
@@ -1,7 +1,7 @@
 /* =========================================================================
- * This file is part of logging-c++ 
+ * This file is part of logging-c++
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2014, MDA Information Systems LLC
  *
  * logging-c++ is free software; you can redistribute it and/or modify
@@ -14,8 +14,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -26,26 +26,40 @@
 
 #include "logging/StreamHandler.h"
 
-logging::StreamHandler::StreamHandler(logging::LogLevel level) :
-    logging::Handler(level)
-{    
+namespace logging
+{
+StreamHandler::StreamHandler(LogLevel level) :
+    Handler(level),
+    mClosed(false)
+{
     mStream.reset(new io::StandardOutStream());
 
     // write prologue to stream
     write(mFormatter->getPrologue());
 }
 
-logging::StreamHandler::StreamHandler(io::OutputStream* stream,
-                                      logging::LogLevel level) :
-    logging::Handler(level)
+StreamHandler::StreamHandler(io::OutputStream* stream,
+                             LogLevel level) :
+    Handler(level)
 {
     mStream.reset(stream);
-    
+
     // write prologue to stream
     write(mFormatter->getPrologue());
 }
 
-void logging::StreamHandler::setFormatter(logging::Formatter* formatter)
+StreamHandler::~StreamHandler()
+{
+    try
+    {
+        closeImpl();
+    }
+    catch (...)
+    {
+    }
+}
+
+void StreamHandler::setFormatter(Formatter* formatter)
 {
     // end log with formatter injection
     write(mFormatter->getEpilogue());
@@ -57,19 +71,30 @@ void logging::StreamHandler::setFormatter(logging::Formatter* formatter)
     write(mFormatter->getPrologue());
 }
 
-void logging::StreamHandler::close()
+void StreamHandler::close()
 {
-    // end log with formatter injection
-    write(mFormatter->getEpilogue());
-
-    // delete formatter
-    Handler::close();
-
-    // kill stream
-    if (mStream.get())
-        mStream->close();
+    closeImpl();
 }
-void logging::StreamHandler::write(const std::string& str)
+
+void StreamHandler::closeImpl()
+{
+    if (!mClosed)
+    {
+        // end log with formatter injection
+        write(mFormatter->getEpilogue());
+
+        // delete formatter
+        Handler::close();
+
+        // kill stream
+        if (mStream.get())
+            mStream->close();
+
+        mClosed = true;
+    }
+}
+
+void StreamHandler::write(const std::string& str)
 {
     if (!str.empty())
     {
@@ -81,8 +106,9 @@ void logging::StreamHandler::write(const std::string& str)
         mStream->flush();
     }
 }
-void logging::StreamHandler::emitRecord(const LogRecord* record)
+void StreamHandler::emitRecord(const LogRecord* record)
 {
     mFormatter->format(record, *mStream);
     mStream->flush();
+}
 }


### PR DESCRIPTION
This updates the StreamHandler to no longer call a virtual method from inside its destructor.