### PR TITLE
Always explicitly link to libcrypto if using net.ssl

### DIFF
--- a/modules/c++/net.ssl/wscript
+++ b/modules/c++/net.ssl/wscript
@@ -100,9 +100,7 @@ def configure(conf):
             # Update library information
             if 'LIB_SSL' in conf.env:
                 self.uselib = conf.env['LIB_SSL']
-                solarisRegex = r'sparc-sun.*|i.86-pc-solaris.*|sunos'
-                if re.match(solarisRegex, sys.platform):
-                    self.uselib += ['crypto']
+                self.uselib += ['crypto']
             if 'LIBPATH_SSL' in conf.env:
                 self.libpath = conf.env['LIBPATH_SSL']
             if 'INCLUDES_SSL' in conf.env:


### PR DESCRIPTION
More systems than just solaris require this explicit linking, and it
doesn't seem to hurt systems where it's implicitly linked.