### PR TITLE
Fixing pointer check in strptime()

### DIFF
--- a/modules/c++/sys/source/DateTime.cpp
+++ b/modules/c++/sys/source/DateTime.cpp
@@ -94,7 +94,7 @@ char* strptime(const char *buf, const char *fmt, struct tm& tm, double& millis)
     while (isspace(*bp))
         bp++;
 
-    while (bp != '\0' && (fc = *fmt) != '\0')
+    while (*bp != '\0' && (fc = *fmt) != '\0')
     {
         if ((fc = *fmt++) != '%')
         {


### PR DESCRIPTION
Pointer should be dereferenced - the check is trying to find the end of the string.

FYI @clydestanfield @chvink 