### PR TITLE
Removing exception specifications from sys::File

### DIFF
--- a/modules/c++/sys/include/sys/File.h
+++ b/modules/c++/sys/include/sys/File.h
@@ -99,13 +99,13 @@ public:
      *  \param creationFlags File creation flags
      */
     File(const Path& path, int accessFlags = READ_ONLY, 
-         int creationFlags = EXISTING) throw (sys::SystemException)
+         int creationFlags = EXISTING)
     {
         create(path.getPath(), accessFlags, creationFlags);
     }
 
     File(const Path& parent, std::string name, int accessFlags = READ_ONLY,
-         int creationFlags = EXISTING) throw (sys::SystemException)
+         int creationFlags = EXISTING)
     {
         create(parent.join(name).getPath(), accessFlags, creationFlags);
     }
@@ -117,7 +117,7 @@ public:
      *  \param creationFlags File creation flags
      */
     File(std::string str, int accessFlags = READ_ONLY, 
-         int creationFlags = EXISTING) throw (sys::SystemException)
+         int creationFlags = EXISTING)
     {
         create(str, accessFlags, creationFlags);
     }
@@ -166,7 +166,7 @@ public:
      *  \param creationFlags File creation flags
      */
     void create(const std::string& str, int accessFlags, 
-                int creationFlags) throw (sys::SystemException);
+                int creationFlags);
 
     /*!
      *  Read from the File into a buffer 'size' bytes.
@@ -178,7 +178,7 @@ public:
      *  \param buffer The buffer to put to
      *  \param size The number of bytes
      */
-    void readInto(char* buffer, Size_T size) throw (sys::SystemException);
+    void readInto(char* buffer, Size_T size);
 
     /*!
      *  Write from a buffer 'size' bytes into the 
@@ -191,7 +191,7 @@ public:
      *  \param size The number of bytes to write out
      */
     void writeFrom(const char* buffer, 
-                   Size_T size) throw (sys::SystemException);
+                   Size_T size);
 
     /*!
      *  Seek to the specified offset, relative to 'whence.'
@@ -201,14 +201,14 @@ public:
      */
 
     sys::Off_T seekTo(sys::Off_T offset, 
-                      int whence) throw (sys::SystemException);
+                      int whence);
 
     /*!
      *  Report current offset within file.
      *
      *  \return Current offset;
      */
-    sys::Off_T getCurrentOffset() throw (sys::SystemException)
+    sys::Off_T getCurrentOffset()
     {
         return seekTo(0, sys::File::FROM_CURRENT);
     }
@@ -217,13 +217,13 @@ public:
      * Report the length of the file.
      * \return The length
      */
-    sys::Off_T length() throw (sys::SystemException);
+    sys::Off_T length();
 
     /*!
      * Returns the last modified time of the file, in millis.
      * \return last modified time
      */
-    sys::Off_T lastModifiedTime() throw (sys::SystemException);
+    sys::Off_T lastModifiedTime();
 
     /*!
      *  Flush the file to disk

--- a/modules/c++/sys/source/FileUnix.cpp
+++ b/modules/c++/sys/source/FileUnix.cpp
@@ -29,7 +29,7 @@
 #include <errno.h>
 
 void sys::File::create(const std::string& str, int accessFlags,
-        int creationFlags) throw (sys::SystemException)
+        int creationFlags)
 {
 
     if (accessFlags & sys::File::WRITE_ONLY)
@@ -45,7 +45,6 @@ void sys::File::create(const std::string& str, int accessFlags,
 }
 
 void sys::File::readInto(char *buffer, Size_T size)
-        throw (sys::SystemException)
 {
     SSize_T bytesRead = 0;
     Size_T totalBytesRead = 0;
@@ -92,7 +91,6 @@ void sys::File::readInto(char *buffer, Size_T size)
 }
 
 void sys::File::writeFrom(const char *buffer, Size_T size)
-        throw (sys::SystemException)
 {
     Size_T bytesActuallyWritten = 0;
 
@@ -111,7 +109,6 @@ void sys::File::writeFrom(const char *buffer, Size_T size)
 }
 
 sys::Off_T sys::File::seekTo(sys::Off_T offset, int whence)
-        throw (sys::SystemException)
 {
     sys::Off_T off = ::lseek(mHandle, offset, whence);
     if (off == (sys::Off_T) - 1)
@@ -119,7 +116,7 @@ sys::Off_T sys::File::seekTo(sys::Off_T offset, int whence)
     return off;
 }
 
-sys::Off_T sys::File::length() throw (sys::SystemException)
+sys::Off_T sys::File::length()
 {
     struct stat buf;
     int rval = fstat(mHandle, &buf);
@@ -128,7 +125,7 @@ sys::Off_T sys::File::length() throw (sys::SystemException)
     return buf.st_size;
 }
 
-sys::Off_T sys::File::lastModifiedTime() throw (sys::SystemException)
+sys::Off_T sys::File::lastModifiedTime()
 {
     struct stat buf;
     int rval = fstat(mHandle, &buf);


### PR DESCRIPTION
These are deprecated in C++11.  They weren't compiling on Windows with gcc because FileWin32.cpp didn't have them in (I guess VS didn't care).

FYI @clydestanfield @chvink 