### PR TITLE
Want a standalone utility that knows how to escape XML characters

### DIFF
--- a/modules/c++/logging/include/logging/XMLFormatter.h
+++ b/modules/c++/logging/include/logging/XMLFormatter.h
@@ -57,15 +57,12 @@ class XMLFormatter : public logging::Formatter
 public:
 
     static const char DEFAULT_FORMAT[];
-    static const char XML_SAFE_CONVERSION[];
 
     XMLFormatter();
     XMLFormatter(const std::string& fmt, 
                  const std::string& prologue = "<Log>",
                  const std::string& epilogue = "</Log>");
 
-    virtual ~XMLFormatter(){}
-    
     virtual void format(const logging::LogRecord* record, io::OutputStream& os) const;
 
 };

--- a/modules/c++/logging/source/XMLFormatter.cpp
+++ b/modules/c++/logging/source/XMLFormatter.cpp
@@ -34,15 +34,6 @@ const char logging::XMLFormatter::DEFAULT_FORMAT[] =
 \t\t<Message>%m</Message>\n\
 \t</Record>";
 
-// add to this list as more characters are needed -- 
-// separate the xml non-safe from conversion by a comma
-//
-// &amp must be the first character, because it will replace
-// all other safe characters if it came later
-const char logging::XMLFormatter::XML_SAFE_CONVERSION[]       
-    = "&,&amp;,<,&lt;,>,&gt;,\",&quot;,',&apos;,\n, ,"; 
-
-
 logging::XMLFormatter::XMLFormatter() : logging::Formatter(DEFAULT_FORMAT, "<Log>", "</Log>")
 {
     // TODO: Generate a better prologue that contains
@@ -66,12 +57,8 @@ void logging::XMLFormatter::format(const logging::LogRecord* record, io::OutputS
     std::string line = str::toString<int>(record->getLineNum());
     std::string threadID =  str::toString(sys::getThreadID());
 
-
-    std::string xmlSC = XML_SAFE_CONVERSION;
-    std::vector<std::string> xmlSafeConvert = str::split(xmlSC, ",");
-    std::vector<std::string> logRecord;
-
     // populate vector with record
+    std::vector<std::string> logRecord;
     logRecord.push_back(threadID);
     logRecord.push_back(name);    
     logRecord.push_back(record->getLevelName());    
@@ -85,23 +72,7 @@ void logging::XMLFormatter::format(const logging::LogRecord* record, io::OutputS
     // update record with SGML escape characters
     for (size_t chr = 4; chr < logRecord.size(); chr++)
     { 
-        // every non-safe xml character pair
-        for (size_t xml = 0; xml < xmlSafeConvert.size(); xml += 2)          
-        {
-            // convert until no more cases are found
-            size_t start = 0;
-            while (start < logRecord[chr].length())
-            {
-                start = str::replace(logRecord[chr], 
-                                     xmlSafeConvert[xml], 
-                                     xmlSafeConvert[xml+1], 
-                                     start);
-
-                // incremented due to replacing 
-                // '&' to '&amp'
-                start++;
-            }
-        }
+        str::escapeForXML(logRecord[chr]);
     }
 
 

--- a/modules/c++/str/include/str/Manip.h
+++ b/modules/c++/str/include/str/Manip.h
@@ -143,6 +143,12 @@ void lower(std::string& s);
 //! Uses std::transform to convert all chars to upper case
 void upper(std::string& s);
 
+/*!
+ * Replaces any characters that are invalid in XML (&, <, >, ', ") with their
+ * escaped counterparts
+ */
+void escapeForXML(std::string& str);
+
 template<typename T>
 std::string join(std::vector<T> toks, std::string with)
 {

--- a/modules/c++/str/source/Manip.cpp
+++ b/modules/c++/str/source/Manip.cpp
@@ -274,6 +274,7 @@ void escapeForXML(std::string& str)
     replaceAll(str, ">", "&gt;");
     replaceAll(str, "\"", "&quot;");
     replaceAll(str, "'", "&apos;");
-    replaceAll(str, "\n", " ");
+    replaceAll(str, "\n", "&#10;");
+    replaceAll(str, "\r", "&#13;");
 }
 }

--- a/modules/c++/str/source/Manip.cpp
+++ b/modules/c++/str/source/Manip.cpp
@@ -20,16 +20,49 @@
  *
  */
 
-#include "str/Manip.h"
 #include <iostream>
 #include <sstream>
 #include <algorithm>
 #include <climits>
 #include <cstdio>
 
-void str::trim(std::string & s)
+#include <str/Manip.h>
+
+namespace
 {
-    unsigned int i;
+int transformCheck(int c, int (*transform)(int))
+{
+    // Ensure the character can be represented
+    // as an unsigned char or is 'EOF', as the
+    // behavior for all other characters is undefined
+    if ((c >= 0 && c <= UCHAR_MAX) || c == EOF)
+    {
+        return transform(c);
+    }
+    else
+    {
+        // Invalid char for transform: no-op
+        return c;
+    }
+}
+
+int tolowerCheck(int c)
+{
+    return transformCheck(c, (int(*)(int)) tolower);
+}
+
+int toupperCheck(int c)
+{
+    return transformCheck(c, (int(*)(int)) toupper);
+}
+}
+
+
+namespace str
+{
+void trim(std::string & s)
+{
+    size_t i;
     for (i = 0; i < s.length(); i++)
     {
         if (!isspace(s[i]))
@@ -47,7 +80,7 @@ void str::trim(std::string & s)
         s.erase(i + 1);
 }
 
-bool str::endsWith(const std::string & s, const std::string & match)
+bool endsWith(const std::string & s, const std::string & match)
 {
     const size_t mLen = match.length();
     const size_t sLen = s.length();
@@ -57,7 +90,7 @@ bool str::endsWith(const std::string & s, const std::string & match)
     return sLen >= mLen;
 }
 
-bool str::startsWith(const std::string & s, const std::string & match)
+bool startsWith(const std::string & s, const std::string & match)
 {
     const size_t mLen = match.length();
     const size_t sLen = s.length();
@@ -67,10 +100,10 @@ bool str::startsWith(const std::string & s, const std::string & match)
     return sLen >= mLen;
 }
 
-size_t str::replace(std::string& str, 
-                    const std::string& search,
-                    const std::string& replace,
-                    size_t start)
+size_t replace(std::string& str,
+               const std::string& search,
+               const std::string& replace,
+               size_t start)
 {
     size_t index = str.find(search, start);
 
@@ -87,29 +120,26 @@ size_t str::replace(std::string& str,
     return start;        
 }
 
-void str::replaceAll(std::string& string, 
-                     const std::string& search,
-                     const std::string& replace)
+void replaceAll(std::string& string,
+                const std::string& search,
+                const std::string& replace)
 {
     size_t start = 0;
     while (start < string.length())
     {
-        start = str::replace(string, 
-                             search, 
-                             replace, 
-                             start);
+        start = str::replace(string, search, replace, start);
         // skip ahead --
         // avoids inifinite loop if replace contains search 
         start += replace.length();                             
     }
 }
 
-bool str::contains(const std::string& str, const std::string& match)
+bool contains(const std::string& str, const std::string& match)
 {
     return str.find(match) != std::string::npos;
 }
 
-bool str::isAlpha(const std::string& s)
+bool isAlpha(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -120,7 +150,7 @@ bool str::isAlpha(const std::string& s)
     return !s.empty();
 }
 
-bool str::isAlphaSpace(const std::string& s)
+bool isAlphaSpace(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -131,7 +161,7 @@ bool str::isAlphaSpace(const std::string& s)
     return !s.empty();
 }
 
-bool str::isNumeric(const std::string& s)
+bool isNumeric(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -142,7 +172,7 @@ bool str::isNumeric(const std::string& s)
     return !s.empty();
 }
 
-bool str::isNumericSpace(const std::string& s)
+bool isNumericSpace(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -153,7 +183,7 @@ bool str::isNumericSpace(const std::string& s)
     return !s.empty();
 }
 
-bool str::isWhitespace(const std::string& s)
+bool isWhitespace(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -164,7 +194,7 @@ bool str::isWhitespace(const std::string& s)
     return true;
 }
 
-bool str::isAlphanumeric(const std::string& s)
+bool isAlphanumeric(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -175,7 +205,7 @@ bool str::isAlphanumeric(const std::string& s)
     return !s.empty();
 }
 
-bool str::isAsciiPrintable(const std::string& s)
+bool isAsciiPrintable(const std::string& s)
 {
     typedef std::string::const_iterator StringIter;
     for (StringIter it = s.begin(); it != s.end(); ++it)
@@ -187,7 +217,7 @@ bool str::isAsciiPrintable(const std::string& s)
     return true;
 }
 
-bool str::containsOnly(const std::string& s, const std::string& validChars)
+bool containsOnly(const std::string& s, const std::string& validChars)
 {
     typedef std::string::const_iterator StringIter;
     std::vector<bool> chars(255, false);
@@ -199,7 +229,7 @@ bool str::containsOnly(const std::string& s, const std::string& validChars)
     return true;
 }
 
-std::vector<std::string> str::split(const std::string& s,
+std::vector<std::string> split(const std::string& s,
         const std::string& splitter, size_t maxSplit)
 {
     std::vector < std::string > vec;
@@ -225,39 +255,25 @@ std::vector<std::string> str::split(const std::string& s,
     return vec;
 }
 
-static int transformCheck(int c, int (*transform)(int))
-{
-    // Ensure the character can be represented
-    // as an unsigned char or is 'EOF', as the
-    // behavior for all other characters is undefined
-    if ((c >= 0 && c <= UCHAR_MAX) || c == EOF)
-    {
-        return transform(c);
-    }
-    else
-    {
-        // Invalid char for transform: no-op
-        return c;
-    }
-}
-
-static int tolowerCheck(int c)
-{
-    return transformCheck(c, (int(*)(int)) tolower);
-}
-
-static int toupperCheck(int c)
-{
-    return transformCheck(c, (int(*)(int)) toupper);
-}
-
-void str::lower(std::string& s)
+void lower(std::string& s)
 {
     std::transform(s.begin(), s.end(), s.begin(), (int(*)(int)) tolowerCheck);
 }
 
-void str::upper(std::string& s)
+void upper(std::string& s)
 {
     std::transform(s.begin(), s.end(), s.begin(), (int(*)(int)) toupperCheck);
 }
 
+void escapeForXML(std::string& str)
+{
+    // & needs to be first or else it'll mess up the other characters that we
+    // replace
+    replaceAll(str, "&", "&amp;");
+    replaceAll(str, "<", "&lt;");
+    replaceAll(str, ">", "&gt;");
+    replaceAll(str, "\"", "&quot;");
+    replaceAll(str, "'", "&apos;");
+    replaceAll(str, "\n", " ");
+}
+}

--- a/modules/c++/str/unittests/test_str.cpp
+++ b/modules/c++/str/unittests/test_str.cpp
@@ -23,6 +23,8 @@
 #include <import/str.h>
 #include "TestCase.h"
 
+namespace
+{
 TEST_CASE(testTrim)
 {
     std::string s = "  test   ";
@@ -155,23 +157,49 @@ TEST_CASE(testRoundDouble)
     TEST_ASSERT_EQ((int)std::ceil(nv), (int)numerator);
 }
 
+TEST_CASE(testEscapeForXMLNoReplace)
+{
+    const std::string origMessage("This is a perfectly fine string");
+    std::string message(origMessage);
+    str::escapeForXML(message);
+    TEST_ASSERT_EQ(message, origMessage);
+}
+
+TEST_CASE(testEscapeForXMLKitchenSink)
+{
+    std::string message(
+            "This & that with <angles> and \"quotes\" & single 'quotes' & "
+            "why not a\nnewline at the end?");
+
+    const std::string expectedMessage(
+            "This &amp; that with &lt;angles&gt; and &quot;quotes&quot; &amp; "
+            "single &apos;quotes&apos; &amp; why not a newline at the end?");
+
+    str::escapeForXML(message);
+    TEST_ASSERT_EQ(message, expectedMessage);
+}
+}
+
 int main(int, char**)
 {
-    TEST_CHECK( testTrim);
-    TEST_CHECK( testUpper);
-    TEST_CHECK( testLower);
-    TEST_CHECK( testReplace);
-    TEST_CHECK( testReplaceAllInfinite);
-    TEST_CHECK( testReplaceAllRecurse);
-    TEST_CHECK( testContains);
-    TEST_CHECK( testNotContains);
-    TEST_CHECK( testSplit);
-    TEST_CHECK( testIsAlpha);
-    TEST_CHECK( testIsAlphaSpace);
-    TEST_CHECK( testIsNumeric);
-    TEST_CHECK( testIsNumericSpace);
-    TEST_CHECK( testIsAlphanumeric);
-    TEST_CHECK( testIsWhitespace);
-    TEST_CHECK( testContainsOnly);
-    TEST_CHECK( testRoundDouble);
+    TEST_CHECK(testTrim);
+    TEST_CHECK(testUpper);
+    TEST_CHECK(testLower);
+    TEST_CHECK(testReplace);
+    TEST_CHECK(testReplaceAllInfinite);
+    TEST_CHECK(testReplaceAllRecurse);
+    TEST_CHECK(testContains);
+    TEST_CHECK(testNotContains);
+    TEST_CHECK(testSplit);
+    TEST_CHECK(testIsAlpha);
+    TEST_CHECK(testIsAlphaSpace);
+    TEST_CHECK(testIsNumeric);
+    TEST_CHECK(testIsNumericSpace);
+    TEST_CHECK(testIsAlphanumeric);
+    TEST_CHECK(testIsWhitespace);
+    TEST_CHECK(testContainsOnly);
+    TEST_CHECK(testRoundDouble);
+    TEST_CHECK(testEscapeForXMLNoReplace);
+    TEST_CHECK(testEscapeForXMLKitchenSink);
+    return 0;
 }

--- a/modules/c++/str/unittests/test_str.cpp
+++ b/modules/c++/str/unittests/test_str.cpp
@@ -169,11 +169,12 @@ TEST_CASE(testEscapeForXMLKitchenSink)
 {
     std::string message(
             "This & that with <angles> and \"quotes\" & single 'quotes' & "
-            "why not a\nnewline at the end?");
+            "why not a\nnewline & \rcarriage return at the end?");
 
     const std::string expectedMessage(
             "This &amp; that with &lt;angles&gt; and &quot;quotes&quot; &amp; "
-            "single &apos;quotes&apos; &amp; why not a newline at the end?");
+            "single &apos;quotes&apos; &amp; why not a&#10;newline &amp; "
+            "&#13;carriage return at the end?");
 
     str::escapeForXML(message);
     TEST_ASSERT_EQ(message, expectedMessage);


### PR DESCRIPTION
We have a need for this functionality elsewhere... originally I was going to put it in xml.lite but then I saw that logging::XMLFormatter was actually already doing what I wanted to do (but could have been using `str::replaceAll()` to simplify it.  `logging` doesn't depend on `xml.lite`, so rather than add a dependency I put the functionality in `str` (which you could argue has no business knowing about XML but neither did `logging`).  I think it's more useful to have it here than it is to have two versions of the same code.  Added unittests for it.