### PR TITLE
Guarding against dividing / modulo'ing by 0

### DIFF
--- a/modules/c++/mt/source/ThreadPlanner.cpp
+++ b/modules/c++/mt/source/ThreadPlanner.cpp
@@ -37,10 +37,17 @@ bool ThreadPlanner::getThreadInfo(size_t threadNum,
 
 size_t ThreadPlanner::getNumThreadsThatWillBeUsed() const
 {
-    const size_t numThreads =
-            (mNumElements / mNumElementsPerThread) +
-            (mNumElements % mNumElementsPerThread != 0);
+    if (mNumElementsPerThread == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        const size_t numThreads =
+                (mNumElements / mNumElementsPerThread) +
+                (mNumElements % mNumElementsPerThread != 0);
 
-    return numThreads;
+        return numThreads;
+    }
 }
 }


### PR DESCRIPTION
If there are no elements per thread, you will simply use 0 threads.  This is way better than dividing / modulo'ing by 0 and getting everyone upset.