### PR TITLE
Fix exception message for unrecognizable data type

### DIFF
--- a/modules/python/sio.lite/source/generated/sio_lite.py
+++ b/modules/python/sio.lite/source/generated/sio_lite.py
@@ -423,7 +423,7 @@ def dtypeFromSioType(elementType, elementSize):
                FileHeader.COMPLEX_FLOAT: 'complex'}
 
     if not elementType in typeMap:
-        raise Exception("Unknown element type: " + elementType)
+        raise Exception("Unknown element type: " + str(elementType))
 
     dtypeStr = "%s%s" % (typeMap[elementType], elementSize * 8)
 
@@ -459,7 +459,7 @@ def write(numpyArray, outputPathname, elementType = None):
     if not numpyArray.flags['C_CONTIGUOUS']:
         numpyArray = numpy.ascontiguousarray(numpyArray)
 
-    header = FileHeader(numpyArray.shape[0], 
+    header = FileHeader(numpyArray.shape[0],
                         numpyArray.shape[1],
                         numpyArray.strides[1],
                         elementType);

--- a/modules/python/sio.lite/source/sio_lite.i
+++ b/modules/python/sio.lite/source/sio_lite.i
@@ -60,7 +60,7 @@ def dtypeFromSioType(elementType, elementSize):
                FileHeader.COMPLEX_FLOAT: 'complex'}
 
     if not elementType in typeMap:
-        raise Exception("Unknown element type: " + elementType)
+        raise Exception("Unknown element type: " + str(elementType))
 
     dtypeStr = "%s%s" % (typeMap[elementType], elementSize * 8)
 
@@ -94,20 +94,20 @@ def write(numpyArray, outputPathname, elementType = None):
 
     if elementType == None:
         elementType = sioTypeFromDtype(numpyArray.dtype)
-    
+
     if not numpyArray.flags['C_CONTIGUOUS']:
         numpyArray = numpy.ascontiguousarray(numpyArray)
-            
-    header = FileHeader(numpyArray.shape[0], 
+
+    header = FileHeader(numpyArray.shape[0],
                         numpyArray.shape[1],
                         numpyArray.strides[1],
                         elementType);
-    
+
     pointer, ro = numpyArray.__array_interface__['data']
-    
+
     if pointer == 0 or pointer == None:
         raise Exception("Attempting to write a NULL image")
-    
+
     writer = FileWriter(outputPathname)
     writer.write(header, pointer)
 %}


### PR DESCRIPTION
Previously, it would throw an exception here for trying to concatenate string and int.