### PR TITLE
Make io module easier to use

### DIFF
--- a/modules/c++/dbi/tests/SQLTest2.cpp
+++ b/modules/c++/dbi/tests/SQLTest2.cpp
@@ -50,13 +50,6 @@ int main(int argc, char* argv[])
 
         resultSet = myConn->query("CREATE TABLE MyTable (id INT NOT NULL PRIMARY KEY, name VARCHAR(25) NOT NULL, description TEXT NOT NULL)");
 
-        char document[5];
-        document[0] = 'J';
-        document[1] = 'E';
-        document[2] = '\0';
-        document[3] = 'F';
-        document[4] = 'F';
-
         resultSet = myConn->query("SELECT TMODEL_KEY, NAME, OVERVIEW_URL FROM TMODEL");
 
         myRow = resultSet->fetchRow();

--- a/modules/c++/io/include/io/ByteStream.h
+++ b/modules/c++/io/include/io/ByteStream.h
@@ -131,7 +131,7 @@ protected:
     /*!
      * Read up to len bytes of data from this buffer into an array
      * update the mark
-     * \param b   Buffer to read into
+     * \param buffer Buffer to read into
      * \param len The length to read
      * \throw IoException
      * \return  The number of bytes read

--- a/modules/c++/io/include/io/ByteStream.h
+++ b/modules/c++/io/include/io/ByteStream.h
@@ -92,21 +92,11 @@ public:
 
     /*!
      *  Writes the bytes in data to the stream.
-     *  \param b the data to write to the stream
+     *  \param buffer the data to write to the stream
      *  \param size the number of bytes to write to the stream
      */
     virtual
-    void write(const sys::byte *b, sys::Size_T size);
-
-    /*!
-     * Read up to len bytes of data from this buffer into an array
-     * update the mark
-     * \param b   Buffer to read into
-     * \param len The length to read
-     * \throw IoException
-     * \return  The number of bytes read
-     */
-    virtual sys::SSize_T read(sys::byte *b, sys::Size_T len);
+    void write(const void* buffer, size_t size);
 
     void reset()
     {
@@ -136,6 +126,17 @@ public:
     {
         return mData.size();
     }
+
+protected:
+    /*!
+     * Read up to len bytes of data from this buffer into an array
+     * update the mark
+     * \param b   Buffer to read into
+     * \param len The length to read
+     * \throw IoException
+     * \return  The number of bytes read
+     */
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
 
 private:
     std::vector<sys::ubyte> mData;

--- a/modules/c++/io/include/io/CountingStreams.h
+++ b/modules/c++/io/include/io/CountingStreams.h
@@ -44,9 +44,13 @@ public:
 
     using ProxyOutputStream::write;
 
-    virtual void write(const sys::byte* b, sys::Size_T len)
+    /*!
+     * \param buffer The byte array to write to the stream
+     * \param len The length of the byte array to write to the stream
+     */
+    virtual void write(const void* buffer, size_t len)
     {
-        ProxyOutputStream::write(b, len);
+        ProxyOutputStream::write(buffer, len);
         mByteCount += len;
     }
 

--- a/modules/c++/io/include/io/DataStream.h
+++ b/modules/c++/io/include/io/DataStream.h
@@ -63,21 +63,11 @@ public:
     }
 
     /*!
-     *  Read bytes from our byte stream into the buffer
-     *  \param data The data buffer to read to
-     *  \param size The size of the data buffer to read
-     */
-    virtual sys::SSize_T read(sys::byte* data, sys::Size_T size)
-    {
-        return mStringStream.read(data, size);
-    }
-
-    /*!
      *  Write bytes from into our byte stream from the buffer
      *  \param data The data buffer to read from
      *  \param size The size of the data buffer.
      */
-    virtual void write(const sys::byte* data, sys::Size_T size)
+    virtual void write(const void* data, sys::Size_T size)
     {
         mStringStream.write(data, size);
     }
@@ -108,7 +98,18 @@ public:
     {
         return mStringStream;
     }
+
 protected:
+    /*!
+     *  Read bytes from our byte stream into the buffer
+     *  \param data The data buffer to read to
+     *  \param size The size of the data buffer to read
+     */
+    virtual sys::SSize_T readImpl(void* data, sys::Size_T size)
+    {
+        return mStringStream.read(data, size);
+    }
+
     io::StringStream mStringStream;
 };
 }

--- a/modules/c++/io/include/io/DbgStream.h
+++ b/modules/c++/io/include/io/DbgStream.h
@@ -85,15 +85,15 @@ public:
     /*!
      * This method uses the bound OutputStream to print,
      * if the switch is on.
-     * \param b   The byte array to write to the stream
+     * \param buffer The byte array to write to the stream
      * \param len The length
      * \throw IOException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len)
+    virtual void write(const void* buffer, sys::Size_T len)
     {
         if (mOn)
         {
-            mStream->write(b, len);
+            mStream->write(buffer, len);
         }
     }
 

--- a/modules/c++/io/include/io/FileInputStreamIOS.h
+++ b/modules/c++/io/include/io/FileInputStreamIOS.h
@@ -121,17 +121,6 @@ public:
 
     //!  Close the file
     void close();
-    //using InputStream::read;
-    /*!
-     * Read up to len bytes of data from input stream into an array
-     * 
-     * \param b   Buffer to read into
-     * \param len The length to read
-     * \throw except::IOException
-     * \return  The number of bytes read
-     * 
-     */
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len);
 
     /*!
      *  Access the stream directly
@@ -141,7 +130,20 @@ public:
     {
         return mFStream;
     }
+
 protected:
+    /*!
+     * Read up to len bytes of data from input stream into an array
+     *
+     * \param buffer Buffer to read into
+     * \param len The length to read
+     * \throw except::IOException
+     * \return  The number of bytes read
+     *
+     */
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
+
+
     std::ifstream mFStream;
 };
 

--- a/modules/c++/io/include/io/FileInputStreamOS.h
+++ b/modules/c++/io/include/io/FileInputStreamOS.h
@@ -154,21 +154,19 @@ public:
         mFile.close();
     }
 
+protected:
     /*!
      * Read up to len bytes of data from input stream into an array
      * 
-     * \param b   Buffer to read into
+     * \param buffer Buffer to read into
      * \param len The length to read
      * \throw except::IOException
      * \return  The number of bytes read
      * 
      */
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len);
-
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
 };
-
-
-
 }
+
 #endif
 #endif

--- a/modules/c++/io/include/io/FileOutputStreamIOS.h
+++ b/modules/c++/io/include/io/FileOutputStreamIOS.h
@@ -107,11 +107,11 @@ public:
      * This method defines a given OutputStream. By defining,
      * this method, you can define the unique attributes of an OutputStream
      * inheriting class.
-     * \param b   The byte array to write to the stream
+     * \param buffer The byte array to write to the stream
      * \param len the length of bytes to write
      * \throw IoException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, size_t len);
     /*!
      *  Access the stream directly
      *  \return The stream in native C++

--- a/modules/c++/io/include/io/FileOutputStreamOS.h
+++ b/modules/c++/io/include/io/FileOutputStreamOS.h
@@ -106,14 +106,11 @@ public:
      * This method defines a given OutputStream. By defining,
      * this method, you can define the unique attributes of an OutputStream
      * inheriting class.
-     * \param b   The byte array to write to the stream
+     * \param buffer The byte array to write to the stream
      * \param len the length of bytes to write
      * \throw IoException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len);
-
-
-
+    virtual void write(const void* buffer, size_t len);
 };
 }
 

--- a/modules/c++/io/include/io/InputStream.h
+++ b/modules/c++/io/include/io/InputStream.h
@@ -87,7 +87,9 @@ public:
      * \throw IOException
      * \return  The number of bytes read, or -1 if EOF
      */
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len) = 0;
+    sys::SSize_T read(void* b,
+                      size_t len,
+                      bool verifyFullRead = false);
 
     /*!
      * Read either a buffer of len size, or up until a newline,
@@ -112,6 +114,15 @@ public:
     virtual sys::SSize_T streamTo(OutputStream& soi,
                                   sys::SSize_T numBytes = IS_END);
 
+protected:
+    /*!
+     * Read up to len bytes of data from input stream into an array
+     * \param b   Buffer to read into
+     * \param len The length to read
+     * \throw IOException
+     * \return  The number of bytes read, or -1 if EOF
+     */
+    virtual sys::SSize_T readImpl(void* b, size_t len) = 0;
 };
 }
 

--- a/modules/c++/io/include/io/InputStream.h
+++ b/modules/c++/io/include/io/InputStream.h
@@ -82,12 +82,15 @@ public:
 
     /*!
      * Read up to len bytes of data from input stream into an array
-     * \param b   Buffer to read into
+     * \param buffer Buffer to read into
      * \param len The length to read
+     * \param verifyFullRead If set to true, checks to see if 'len' bytes
+     * were read and, if not, throws.  Defaults to false.
      * \throw IOException
-     * \return  The number of bytes read, or -1 if EOF
+     * \return  The number of bytes read, or -1 if EOF.  If 'verifyFullRead'
+     * is true, this will always return 'len' bytes if it didn't throw.
      */
-    sys::SSize_T read(void* b,
+    sys::SSize_T read(void* buffer,
                       size_t len,
                       bool verifyFullRead = false);
 
@@ -117,12 +120,12 @@ public:
 protected:
     /*!
      * Read up to len bytes of data from input stream into an array
-     * \param b   Buffer to read into
+     * \param buffer   Buffer to read into
      * \param len The length to read
      * \throw IOException
      * \return  The number of bytes read, or -1 if EOF
      */
-    virtual sys::SSize_T readImpl(void* b, size_t len) = 0;
+    virtual sys::SSize_T readImpl(void* buffer, size_t len) = 0;
 };
 }
 

--- a/modules/c++/io/include/io/MMapInputStream.h
+++ b/modules/c++/io/include/io/MMapInputStream.h
@@ -70,12 +70,9 @@ public:
         return mMark;
     }
 
-    virtual ssize_t read(sys::byte* b, size_t len);
-
-
-
-
 protected:
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
+
     virtual void _map();
     virtual void _unmap();
     sys::OS mOs;

--- a/modules/c++/io/include/io/NullStreams.h
+++ b/modules/c++/io/include/io/NullStreams.h
@@ -46,20 +46,6 @@ public:
         return mAvailable;
     }
 
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len)
-    {
-        sys::Size_T numToRead =
-                (mAvailable >= (sys::SSize_T) len ? len : (sys::Size_T) mAvailable);
-
-        mAvailable -= (sys::SSize_T) numToRead;
-
-        if (numToRead == 0)
-            throw except::IOException(Ctxt("EOF - no more data to read"));
-
-        processBytes(b, numToRead);
-        return numToRead;
-    }
-
     virtual sys::SSize_T readln(sys::byte *cStr,
                                 const sys::Size_T strLenPlusNullByte)
     {
@@ -85,10 +71,24 @@ protected:
     {
         return (sys::byte) 0;
     }
-    virtual void processBytes(sys::byte* b, sys::Size_T len) const
+    virtual void processBytes(void* buffer, sys::Size_T len) const
     {
         //override for different behavior
-        memset(b, 0, len);
+        memset(buffer, 0, len);
+    }
+
+    virtual sys::SSize_T readImpl(void* buffer, size_t len)
+    {
+        size_t numToRead =
+                (mAvailable >= (sys::SSize_T) len ? len : (size_t) mAvailable);
+
+        mAvailable -= (sys::SSize_T) numToRead;
+
+        if (numToRead == 0)
+            throw except::IOException(Ctxt("EOF - no more data to read"));
+
+        processBytes(buffer, numToRead);
+        return numToRead;
     }
 };
 
@@ -114,16 +114,14 @@ public:
     {
     }
 
-    virtual void write(const sys::byte* , sys::Size_T )
+    virtual void write(const void* , size_t )
     {
     }
 
     virtual void flush()
     {
     }
-
 };
-
 }
 
 #endif

--- a/modules/c++/io/include/io/OutputStream.h
+++ b/modules/c++/io/include/io/OutputStream.h
@@ -88,11 +88,11 @@ public:
      * This method defines a given OutputStream. By defining,
      * this method, you can define the unique attributes of an OutputStream
      * inheriting class.
-     * \param b   The byte array to write to the stream
+     * \param buffer The byte array to write to the stream
      * \param len The length of the byte array to write to the stream
      * \throw IOException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len) = 0;
+    virtual void write(const void* buffer, size_t len) = 0;
 
     /*!
      *  Flush the stream if needed
@@ -107,7 +107,6 @@ public:
     virtual void close()
     {
     }
-
 };
 }
 

--- a/modules/c++/io/include/io/PipeStream.h
+++ b/modules/c++/io/include/io/PipeStream.h
@@ -73,12 +73,6 @@ public:
     }
 
     /*! 
-     *  \func read
-     *  \brief returns the requested size in bytes from the stream
-     */
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len);
-
-    /*! 
      *  \func readln
      *  \brief returns one line ending in a newline or the requested size --
      *         requested size cannot be greater than the maxLength
@@ -101,8 +95,12 @@ public:
     virtual sys::SSize_T streamTo(OutputStream& soi,
                                   sys::SSize_T numBytes = IS_END);
 
-
 protected:
+    /*!
+     *  \brief returns the requested size in bytes from the stream
+     */
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
+
 
     sys::ExecPipe mExecPipe;
     mem::ScopedArray<char> mCharString;

--- a/modules/c++/io/include/io/ProxyStreams.h
+++ b/modules/c++/io/include/io/ProxyStreams.h
@@ -49,11 +49,6 @@ public:
         return mProxy->available();
     }
 
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len)
-    {
-        return mProxy->read(b, len);
-    }
-
     virtual void setProxy(InputStream *proxy, bool ownPtr = false)
     {
         if (!mOwnPtr)
@@ -63,6 +58,11 @@ public:
     }
 
 protected:
+    virtual sys::SSize_T readImpl(void* buffer, size_t len)
+    {
+        return mProxy->read(buffer, len);
+    }
+
     std::auto_ptr<InputStream> mProxy;
     bool mOwnPtr;
 };
@@ -86,9 +86,9 @@ public:
 
     using OutputStream::write;
 
-    virtual void write(const sys::byte* b, sys::Size_T len)
+    virtual void write(const void* buffer, size_t len)
     {
-        mProxy->write(b, len);
+        mProxy->write(buffer, len);
     }
 
     virtual void flush()

--- a/modules/c++/io/include/io/ReadUtils.h
+++ b/modules/c++/io/include/io/ReadUtils.h
@@ -30,11 +30,34 @@
 
 namespace io
 {
+/*!
+ * Reads the contents of a file (binary or text), putting the raw bytes in
+ * 'buffer'.  These are the exact bytes of the file, so text files will not
+ * contain a null terminator.
+ *
+ * \param pathname Pathname of the file to read in
+ * \param buffer Raw bytes of the file
+ */
 void readFileContents(const std::string& pathname,
                       std::vector<sys::byte>& buffer);
 
+/*!
+ * Reads the contents of a file into a string.  The file is assumed to be a
+ * text file.
+ *
+ * \param pathname Pathname of the file to read in
+ * \param[out] str Contents of the file
+ */
 void readFileContents(const std::string& pathname, std::string& str);
 
+/*!
+ * Reads the contents of a file into a string.  The file is assumed to be a
+ * text file.
+ *
+ * \param pathname Pathname of the file to read in
+ *
+ * \return Contents of the file
+ */
 inline
 std::string readFileContents(const std::string& pathname)
 {

--- a/modules/c++/io/include/io/ReadUtils.h
+++ b/modules/c++/io/include/io/ReadUtils.h
@@ -1,0 +1,47 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __IO_READ_UTILS_H__
+#define __IO_READ_UTILS_H__
+
+#include <string>
+#include <vector>
+
+#include <sys/Conf.h>
+
+namespace io
+{
+void readFileContents(const std::string& pathname,
+                      std::vector<sys::byte>& buffer);
+
+void readFileContents(const std::string& pathname, std::string& str);
+
+inline
+std::string readFileContents(const std::string& pathname)
+{
+    std::string str;
+    readFileContents(pathname, str);
+    return str;
+}
+}
+
+#endif

--- a/modules/c++/io/include/io/RotatingFileOutputStream.h
+++ b/modules/c++/io/include/io/RotatingFileOutputStream.h
@@ -46,7 +46,7 @@ public:
 
     using CountingOutputStream::write;
 
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, size_t len);
 
 protected:
     std::string mFilename;

--- a/modules/c++/io/include/io/SeekableStreams.h
+++ b/modules/c++/io/include/io/SeekableStreams.h
@@ -49,7 +49,6 @@ public:
     {}
     virtual ~SeekableInputStream()
     {}
-    virtual sys::SSize_T read (sys::byte *b, sys::Size_T len) = 0;
     using InputStream::streamTo;
 };
 
@@ -61,7 +60,6 @@ public:
     {}
     virtual ~SeekableOutputStream()
     {}
-    virtual void write (const sys::byte *b, sys::Size_T len) = 0;
 };
 
 class SeekableBidirectionalStream :
@@ -72,8 +70,6 @@ public:
     {}
     virtual ~SeekableBidirectionalStream()
     {}
-    virtual sys::SSize_T read (sys::byte *b, sys::Size_T len) = 0;
-    virtual void write (const sys::byte *b, sys::Size_T len) = 0;
     using InputStream::streamTo;
 };
 

--- a/modules/c++/io/include/io/StandardStreams.h
+++ b/modules/c++/io/include/io/StandardStreams.h
@@ -62,11 +62,11 @@ public:
 
     /*!
      * This method defines a write to stdout.
-     * \param b   The byte array to write to the stream
+     * \param buffer The byte array to write to the stream
      * \param len the length of bytes to read
      * \throw except::IOException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, size_t len);
 
     /*!
      *  Flushes stdout
@@ -95,11 +95,11 @@ public:
 
     /*!
      * This method defines a write to stderr.
-     * \param b   The byte array to write to the stream
+     * \param buffer The byte array to write to the stream
      * \param len the length of bytes to read
      * \throw except::IOException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, sys::Size_T len);
 
     /*!
      *  Flushes stderr

--- a/modules/c++/io/include/io/StringStream.h
+++ b/modules/c++/io/include/io/StringStream.h
@@ -122,7 +122,7 @@ protected:
     /*!
      * Read up to len bytes of data from this buffer into an array
      * update the mark
-     * \param b   Buffer to read into
+     * \param buffer Buffer to read into
      * \param len The length to read
      * \throw IoException
      * \return  The number of bytes read

--- a/modules/c++/io/include/io/StringStream.h
+++ b/modules/c++/io/include/io/StringStream.h
@@ -100,20 +100,10 @@ public:
 
     /*!
      *  Writes the bytes in data to the stream.
-     *  \param b the data to write to the stream
+     *  \param buffer the data to write to the stream
      *  \param size the number of bytes to write to the stream
      */
-    void write(const sys::byte *b, sys::Size_T size);
-
-    /*!
-     * Read up to len bytes of data from this buffer into an array
-     * update the mark
-     * \param b   Buffer to read into
-     * \param len The length to read
-     * \throw IoException
-     * \return  The number of bytes read
-     */
-    virtual sys::SSize_T read(sys::byte *b, sys::Size_T len);
+    void write(const void* buffer, sys::Size_T size);
 
     //! Returns the internal std::stringstream
     std::stringstream& stream()
@@ -127,6 +117,17 @@ public:
         // clear eof/errors/etc.
         mData.clear();
     }
+
+protected:
+    /*!
+     * Read up to len bytes of data from this buffer into an array
+     * update the mark
+     * \param b   Buffer to read into
+     * \param len The length to read
+     * \throw IoException
+     * \return  The number of bytes read
+     */
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
 
 private:
     std::stringstream mData;

--- a/modules/c++/io/source/ByteStream.cpp
+++ b/modules/c++/io/source/ByteStream.cpp
@@ -63,7 +63,7 @@ sys::Off_T io::ByteStream::available()
     return (diff < 0) ? 0 : diff;
 }
 
-void io::ByteStream::write(const sys::byte *b, sys::Size_T size)
+void io::ByteStream::write(const void* buffer, sys::Size_T size)
 {
     if (mPosition < 0)
         throw except::Exception(Ctxt("Invalid write on eof"));
@@ -75,12 +75,15 @@ void io::ByteStream::write(const sys::byte *b, sys::Size_T size)
         sys::Size_T newPos = mPosition + size;
         if (newPos >= mData.size())
             mData.resize(newPos);
-        std::copy(b, b+size, &mData[mPosition]);
+
+        const sys::ubyte* const bufferPtr =
+                static_cast<const sys::ubyte*>(buffer);
+        std::copy(bufferPtr, bufferPtr + size, &mData[mPosition]);
         mPosition = newPos;
     }
 }
 
-sys::SSize_T io::ByteStream::read(sys::byte *b, sys::Size_T len)
+sys::SSize_T io::ByteStream::readImpl(void* buffer, size_t len)
 {
     if (mPosition < 0)
         throw except::Exception(Ctxt("Invalid read on eof"));
@@ -91,7 +94,7 @@ sys::SSize_T io::ByteStream::read(sys::byte *b, sys::Size_T len)
     if (maxSize <  static_cast<sys::Off_T>(len)) len = maxSize;
     if (len     <= 0)                            return 0;
 
-    ::memcpy(b, &mData[mPosition], len);
+    ::memcpy(buffer, &mData[mPosition], len);
     mPosition += len;
     return len;
 }

--- a/modules/c++/io/source/FileInputStreamIOS.cpp
+++ b/modules/c++/io/source/FileInputStreamIOS.cpp
@@ -102,13 +102,15 @@ void io::FileInputStreamIOS::close()
     mFStream.close();
 }
 
-sys::SSize_T io::FileInputStreamIOS::read(sys::byte* b, sys::Size_T len)
+sys::SSize_T io::FileInputStreamIOS::readImpl(void* buffer, size_t len)
 {
-    ::memset(b, 0, len);
+    ::memset(buffer, 0, len);
     sys::Off_T avail = available();
     if (mFStream.eof() || avail <= 0) return io::InputStream::IS_EOF;
     if (len < (sys::Size_T)avail)
         avail = len;
+
+    char* const bufferPtr = static_cast<char*>(buffer);
 
     if (avail > 0)
     {
@@ -119,10 +121,10 @@ sys::SSize_T io::FileInputStreamIOS::read(sys::byte* b, sys::Size_T len)
 
         while (bytesRead < avail && mFStream.good())
         {
-            b[bytesRead++] = mFStream.get();
+            bufferPtr[bytesRead++] = mFStream.get();
         }
 #else
-        mFStream.read((char *)b, avail);
+        mFStream.read(bufferPtr, avail);
         bytesRead = mFStream.gcount();
 #endif
         return bytesRead;

--- a/modules/c++/io/source/FileInputStreamOS.cpp
+++ b/modules/c++/io/source/FileInputStreamOS.cpp
@@ -43,20 +43,17 @@ sys::Off_T io::FileInputStreamOS::available()
 }
 
 
-sys::SSize_T io::FileInputStreamOS::read(sys::byte* b, sys::Size_T len)
+sys::SSize_T io::FileInputStreamOS::readImpl(void* buffer, size_t len)
 {
-    ::memset(b, 0, len);
+    ::memset(buffer, 0, len);
     sys::Off_T avail = available();
     if (!avail)
         return io::InputStream::IS_EOF;
     if (len > (sys::Size_T)avail)
         len = (sys::Size_T)avail;
 
-    mFile.readInto((char *)b, len);
-    return (sys::SSize_T)len;
-
+    mFile.readInto(buffer, len);
+    return static_cast<sys::SSize_T>(len);
 }
 
-
 #endif
-

--- a/modules/c++/io/source/FileOutputStreamIOS.cpp
+++ b/modules/c++/io/source/FileOutputStreamIOS.cpp
@@ -59,7 +59,8 @@ void io::FileOutputStreamIOS::open(const char *file,
     mFStream.open(file, mode);
     if (!isOpen())
     {
-        throw except::Error(Ctxt(FmtX("File could not be opened: %s", file)));
+        throw except::Error(Ctxt(
+                "File could not be opened: " + std::string(file)));
     }
 }
 
@@ -74,19 +75,9 @@ void io::FileOutputStreamIOS::close()
     }
 }
 
-/*!
- * This method defines a given OutputStream. By defining,
- * this method, you can define the unique attributes of an OutputStream
- * inheriting class.
- * \param b   The byte array to write to the stream
- * \param len the length of bytes to write
- * \throw IOException
- */
-void io::FileOutputStreamIOS::write(const sys::byte* b, sys::Size_T len)
+void io::FileOutputStreamIOS::write(const void* buffer, size_t len)
 {
-    //std::string s((const char*)b, len);
-    //EVAL(s.c_str());
-    mFStream.write((const char*)b, len);
+    mFStream.write((const char*)buffer, len);
 }
 
 

--- a/modules/c++/io/source/FileOutputStreamOS.cpp
+++ b/modules/c++/io/source/FileOutputStreamOS.cpp
@@ -43,18 +43,9 @@ void io::FileOutputStreamOS::create(const std::string& str,
     }
 }
 
-
-/*!
- * This method defines a given OutputStream. By defining,
- * this method, you can define the unique attributes of an OutputStream
- * inheriting class.
- * \param b   The byte array to write to the stream
- * \param len the length of bytes to write
- * \throw IOException
- */
-void io::FileOutputStreamOS::write(const sys::byte* b, sys::Size_T len)
+void io::FileOutputStreamOS::write(const void* buffer, size_t len)
 {
-    mFile.writeFrom((const char*)b, len);
+    mFile.writeFrom(buffer, len);
 }
 
 void io::FileOutputStreamOS::flush()
@@ -87,4 +78,3 @@ sys::Off_T io::FileOutputStreamOS::tell()
 }
 
 #endif
-

--- a/modules/c++/io/source/InputStream.cpp
+++ b/modules/c++/io/source/InputStream.cpp
@@ -20,9 +20,38 @@
  *
  */
 
-#include "io/InputStream.h"
+#include <sys/Conf.h>
+#include <except/Exception.h>
+#include <io/InputStream.h>
 
-sys::SSize_T io::InputStream::streamTo(io::OutputStream& soi, sys::SSize_T bytesToPipe)
+namespace io
+{
+sys::SSize_T InputStream::read(void* buffer,
+                               size_t len,
+                               bool verifyFullRead)
+{
+    const sys::SSize_T numBytes = readImpl(buffer, len);
+    if (verifyFullRead)
+    {
+        if (numBytes == -1)
+        {
+            std::ostringstream ostr;
+            ostr << "Tried to read " << len << " bytes but read failed";
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+        else if (numBytes != static_cast<sys::SSize_T>(len))
+        {
+            std::ostringstream ostr;
+            ostr << "Tried to read " << len << " bytes but only read "
+                 << numBytes << " bytes";
+            throw except::Exception(Ctxt(ostr.str()));
+        }
+    }
+
+    return numBytes;
+}
+
+sys::SSize_T InputStream::streamTo(OutputStream& soi, sys::SSize_T bytesToPipe)
 {
 
     // In this event, we want to find the end of file,
@@ -57,7 +86,7 @@ sys::SSize_T io::InputStream::streamTo(io::OutputStream& soi, sys::SSize_T bytes
     return totalBytesTransferred;
 }
 
-sys::SSize_T io::InputStream::readln(sys::byte *cStr, const sys::Size_T strLenPlusNullByte)
+sys::SSize_T InputStream::readln(sys::byte *cStr, const sys::Size_T strLenPlusNullByte)
 {
     // Put a null byte at the end by default
     ::memset(cStr, 0, strLenPlusNullByte);
@@ -72,4 +101,5 @@ sys::SSize_T io::InputStream::readln(sys::byte *cStr, const sys::Size_T strLenPl
         // Otherwise, append c;
     }
     return (sys::SSize_T)i;
+}
 }

--- a/modules/c++/io/source/InputStream.cpp
+++ b/modules/c++/io/source/InputStream.cpp
@@ -37,14 +37,14 @@ sys::SSize_T InputStream::read(void* buffer,
         {
             std::ostringstream ostr;
             ostr << "Tried to read " << len << " bytes but read failed";
-            throw except::Exception(Ctxt(ostr.str()));
+            throw except::IOException(Ctxt(ostr.str()));
         }
         else if (numBytes != static_cast<sys::SSize_T>(len))
         {
             std::ostringstream ostr;
             ostr << "Tried to read " << len << " bytes but only read "
                  << numBytes << " bytes";
-            throw except::Exception(Ctxt(ostr.str()));
+            throw except::IOException(Ctxt(ostr.str()));
         }
     }
 

--- a/modules/c++/io/source/MMapInputStream.cpp
+++ b/modules/c++/io/source/MMapInputStream.cpp
@@ -70,7 +70,7 @@ long io::MMapInputStream::seek(long off)
 }
 
 
-long io::MMapInputStream::read(sys::byte* b, long len)
+sys::SSize_T io::MMapInputStream::readImpl(void* buffer, size_t len)
 {
     int size = available();
     //    std::cout << "Available: " << size << std::endl;
@@ -78,7 +78,7 @@ long io::MMapInputStream::read(sys::byte* b, long len)
 
     if (len < size)
         size = len;
-    memcpy(b, &mData[mMark], size);
+    memcpy(buffer, &mData[mMark], size);
     mMark += size;
     //    std::cout << "Used: " << size << std::endl;
     return size;

--- a/modules/c++/io/source/PipeStream.cpp
+++ b/modules/c++/io/source/PipeStream.cpp
@@ -23,9 +23,11 @@
 
 using namespace io;
 
-sys::SSize_T io::PipeStream::read(sys::byte *cStr, sys::Size_T numBytes)
+sys::SSize_T io::PipeStream::readImpl(void* buffer, size_t numBytes)
 {
     FILE* pipe = mExecPipe.getPipe();
+
+    char* cStr = static_cast<char*>(buffer);
 
     size_t bytesLeft = numBytes;
     while (bytesLeft && !feof(pipe))

--- a/modules/c++/io/source/ReadUtils.cpp
+++ b/modules/c++/io/source/ReadUtils.cpp
@@ -1,0 +1,52 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <io/FileInputStream.h>
+
+namespace io
+{
+void readFileContents(const std::string& pathname,
+                      std::vector<sys::byte>& buffer)
+{
+    io::FileInputStream inStream(pathname);
+    buffer.resize(inStream.available());
+    if (!buffer.empty())
+    {
+        inStream.read(&buffer[0], buffer.size(), true);
+    }
+}
+
+void readFileContents(const std::string& pathname, std::string& str)
+{
+    std::vector<sys::byte> buffer;
+    readFileContents(pathname, buffer);
+
+    if (buffer.empty())
+    {
+        str.clear();
+    }
+    else
+    {
+        str.assign(reinterpret_cast<char*>(&buffer[0]), buffer.size());
+    }
+}
+}

--- a/modules/c++/io/source/RotatingFileOutputStream.cpp
+++ b/modules/c++/io/source/RotatingFileOutputStream.cpp
@@ -87,9 +87,9 @@ void io::RotatingFileOutputStream::doRollover()
     mByteCount = 0;
 }
 
-void io::RotatingFileOutputStream::write(const sys::byte* b, sys::Size_T len)
+void io::RotatingFileOutputStream::write(const void* buffer, size_t len)
 {
     if (shouldRollover(len))
         doRollover();
-    io::CountingOutputStream::write(b, len);
+    io::CountingOutputStream::write(buffer, len);
 }

--- a/modules/c++/io/source/StandardStreams.cpp
+++ b/modules/c++/io/source/StandardStreams.cpp
@@ -24,10 +24,10 @@
 
 _STDERR_DEFINE_MUTEX_SEMICOLON_
 _STDOUT_DEFINE_MUTEX_SEMICOLON_
-void io::StandardOutStream::write(const sys::byte* b, sys::Size_T len)
+void io::StandardOutStream::write(const void* buffer, sys::Size_T len)
 {
     _STDSTREAM_BEGIN_CS_SEMICOLON_
-    std::cout.write((const char*)b, len);
+    std::cout.write((const char*)buffer, len);
     _STDSTREAM_END_CS_SEMICOLON_
     //int returnVal = fwrite(b, len, len, stdout);
     if (!std::cout.good())
@@ -44,10 +44,10 @@ void io::StandardOutStream::flush()
     _STDSTREAM_END_CS_SEMICOLON_
 }
 
-void io::StandardErrStream::write(const sys::byte* b, sys::Size_T len)
+void io::StandardErrStream::write(const void* buffer, sys::Size_T len)
 {
     _STDSTREAM_BEGIN_CS_SEMICOLON_
-    std::cerr.write((const char*)b, len);
+    std::cerr.write((const char*)buffer, len);
     //int returnVal = fwrite(b, len, len, stderr);
     _STDSTREAM_END_CS_SEMICOLON_
     if (!std::cerr.good())

--- a/modules/c++/io/source/StringStream.cpp
+++ b/modules/c++/io/source/StringStream.cpp
@@ -33,12 +33,12 @@ sys::Off_T io::StringStream::available()
     return (until - where);
 }
 
-void io::StringStream::write(const sys::byte *b, sys::Size_T size)
+void io::StringStream::write(const void* buffer, size_t size)
 {
-    mData.write((const char*)b, size);
+    mData.write((const char*)buffer, size);
 }
 
-sys::SSize_T io::StringStream::read(sys::byte *b, sys::Size_T len)
+sys::SSize_T io::StringStream::readImpl(void* buffer, size_t len)
 {
     sys::Off_T maxSize = available();
     if (maxSize <= 0) return io::InputStream::IS_END;
@@ -56,11 +56,10 @@ sys::SSize_T io::StringStream::read(sys::byte *b, sys::Size_T len)
     }
     len = bytesRead;
 #else
-    mData.read((char *)b, len);
+    mData.read((char *)buffer, len);
 #endif
     // Could be problem if streams are broken
     // alternately could return gcount in else
     // case above
     return len;
 }
-

--- a/modules/c++/io/tests/PipeStreamTest.cpp
+++ b/modules/c++/io/tests/PipeStreamTest.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
 
         if (argc > 1)
         {
-            for (size_t ii = 1; ii < argc; ++ii)
+            for (int ii = 1; ii < argc; ++ii)
             {
                 cmd += std::string(argv[ii]) + " ";
             }

--- a/modules/c++/io/tests/test_read_file_contents.cpp
+++ b/modules/c++/io/tests/test_read_file_contents.cpp
@@ -1,0 +1,59 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <iostream>
+#include <stdexcept>
+
+#include <sys/Path.h>
+#include <except/Exception.h>
+#include <io/ReadUtils.h>
+
+int main(int argc, char** argv)
+{
+    try
+    {
+        if (argc != 2)
+        {
+            std::cerr << "Usage: " << sys::Path::basename(argv[0])
+                      << " <file to read in>\n\n";
+            return 1;
+        }
+
+        std::cout << io::readFileContents(argv[1]) << std::endl;
+    }
+    catch (const std::exception& ex)
+    {
+        std::cerr << ex.what() << std::endl;
+        return 1;
+    }
+    catch (const except::Exception& ex)
+    {
+        std::cerr << ex.toString() << std::endl;
+        return 1;
+    }
+    catch (...)
+    {
+        std::cerr << "Unknown exception\n";
+        return 1;
+    }
+    return 0;
+}

--- a/modules/c++/net/include/net/NetConnection.h
+++ b/modules/c++/net/include/net/NetConnection.h
@@ -131,7 +131,7 @@ public:
      *  This method defines a given OutputStream. By defining,
      *  this method, you can define the unique attributes of an OutputStream
      *  inheriting class.
-     *  \param b   The byte array to write to the stream
+     *  \param buffer The byte array to write to the stream
      *  \param len The length of the byte array to write to the stream
      *  \throw IOException
      */

--- a/modules/c++/net/include/net/NetConnection.h
+++ b/modules/c++/net/include/net/NetConnection.h
@@ -127,15 +127,6 @@ public:
         return mSocket;
     }
 
-
-    /*!
-     *  Read up to len bytes of data from input stream into an array
-     *  \param b   Buffer to read into
-     *  \param len The length to read
-     *  \throw IOException
-     *  \return  The number of bytes read, or -1 if eof
-     */
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len);
     /*!
      *  This method defines a given OutputStream. By defining,
      *  this method, you can define the unique attributes of an OutputStream
@@ -144,12 +135,21 @@ public:
      *  \param len The length of the byte array to write to the stream
      *  \throw IOException
      */
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, size_t len);
 
     using io::BidirectionalStream::read;
     using io::BidirectionalStream::write;
 
 protected:
+    /*!
+     *  Read up to len bytes of data from input stream into an array
+     *  \param b   Buffer to read into
+     *  \param len The length to read
+     *  \throw IOException
+     *  \return  The number of bytes read, or -1 if eof
+     */
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
+
     //! The socket
     mem::SharedPtr<net::Socket> mSocket;
 };

--- a/modules/c++/net/source/NetConnection.cpp
+++ b/modules/c++/net/source/NetConnection.cpp
@@ -22,13 +22,12 @@
 
 #include "net/NetConnection.h"
 
-sys::SSize_T net::NetConnection::read(sys::byte* b, sys::Size_T len)
+sys::SSize_T net::NetConnection::readImpl(void* buffer, size_t len)
 {
-    return mSocket->recv(b, len);
+    return mSocket->recv(buffer, len);
 }
 
-void net::NetConnection::write(const sys::byte* b, sys::Size_T len)
+void net::NetConnection::write(const void* buffer, size_t len)
 {
-    mSocket->send((const char*) b, len);
+    mSocket->send(buffer, len);
 }
-

--- a/modules/c++/sio.lite/include/sio/lite/FileReader.h
+++ b/modules/c++/sio.lite/include/sio/lite/FileReader.h
@@ -94,7 +94,7 @@ public:
     {
     }
 
-    FileReader(std::string file) : 
+    FileReader(const std::string& file) :
         StreamReader(new io::FileInputStream(file), true)
     {
     }

--- a/modules/c++/sio.lite/include/sio/lite/ReadUtils.h
+++ b/modules/c++/sio.lite/include/sio/lite/ReadUtils.h
@@ -62,8 +62,7 @@ void readSIO(const std::string& pathname,
 
     const size_t numPixels(dims.row * dims.col);
     image.reset(new InputT[numPixels]);
-    reader.read(reinterpret_cast<sys::byte*>(image.get()),
-        numPixels * sizeof(InputT));
+    reader.read(image.get(), numPixels * sizeof(InputT), true);
 }
 
 /*

--- a/modules/c++/sio.lite/include/sio/lite/StreamReader.h
+++ b/modules/c++/sio.lite/include/sio/lite/StreamReader.h
@@ -145,21 +145,21 @@ public:
         return inputStream->available();
     }
 
+protected:
     /**
      *  Implements the necessary function to make this
      *  all work.
      *
      * NOTE: You will need to byteswap if the endianness of the
      * machine is different from the stream endianness.
-     *  @param b The byte buffer to read into
+     *  @param buffer The byte buffer to read into
      *  @param size the Number of bytes to read
      *  @return The number of bytes read
      */
-    sys::SSize_T read(sys::byte* b, size_t size)
+    virtual sys::SSize_T readImpl(void* buffer, size_t size)
     {
-        return inputStream->read(b, size);
+        return inputStream->read(buffer, size);
     }
-protected:
 
     /**
      *  Read the next integer in the stream.  This is vital for

--- a/modules/c++/sio.lite/tests/FabricateTest.cpp
+++ b/modules/c++/sio.lite/tests/FabricateTest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv)
 
         //fill with trash data
         for (int i = 0; i < numBands; ++i)
-            for (int j = 0; j < bufSize; ++j)
+            for (size_t j = 0; j < bufSize; ++j)
                 rawData[i][j] = base + j;
 
         std::string outputFile = argv[1];
@@ -61,7 +61,7 @@ int main(int argc, char** argv)
         //add some test data to the header
         std::vector<sys::byte> udEntry;
         std::string uData = "ABCABCABCABC";
-        for (int i = 0; i < uData.size(); i++)
+        for (size_t i = 0; i < uData.size(); i++)
             udEntry.push_back((sys::byte)uData[i]);
         
         hdr.addUserData("junk", udEntry);
@@ -69,14 +69,17 @@ int main(int argc, char** argv)
         hdr.addUserData("int_12345", 12345);
 
         writer.write(&hdr, (const sys::byte*)rawData, numBands);
-        delete [] rawData;
+        for (int ii = 0; ii < numBands; ++ii)
+        {
+            delete[] rawData[ii];
+        }
+        delete[] rawData;
+        return 0;
     }
-    catch (Exception& e)
+    catch (const Exception& e)
     {
-        std::cout << "Caught exception: " << e.getMessage() << std::endl;
-        std::cout << "Trace:" << std::endl << e.getTrace() << std::endl;
+        std::cerr << "Caught exception: " << e.getMessage() << std::endl;
+        std::cerr << "Trace:" << std::endl << e.getTrace() << std::endl;
     }
-    return 0;
+    return 1;
 }
-
-

--- a/modules/c++/sys/include/sys/File.h
+++ b/modules/c++/sys/include/sys/File.h
@@ -178,7 +178,7 @@ public:
      *  \param buffer The buffer to put to
      *  \param size The number of bytes
      */
-    void readInto(char* buffer, Size_T size);
+    void readInto(void* buffer, size_t size);
 
     /*!
      *  Write from a buffer 'size' bytes into the 
@@ -190,8 +190,8 @@ public:
      *  \param buffer The buffer to read from
      *  \param size The number of bytes to write out
      */
-    void writeFrom(const char* buffer, 
-                   Size_T size);
+    void writeFrom(const void* buffer,
+                   size_t size);
 
     /*!
      *  Seek to the specified offset, relative to 'whence.'

--- a/modules/c++/sys/source/FileUnix.cpp
+++ b/modules/c++/sys/source/FileUnix.cpp
@@ -44,11 +44,13 @@ void sys::File::create(const std::string& str, int accessFlags,
     mPath = str;
 }
 
-void sys::File::readInto(char *buffer, Size_T size)
+void sys::File::readInto(void* buffer, Size_T size)
 {
     SSize_T bytesRead = 0;
     Size_T totalBytesRead = 0;
     int i;
+
+    sys::byte* bufferPtr = static_cast<sys::byte*>(buffer);
 
     /* make sure the user actually wants data */
     if (size == 0)
@@ -56,7 +58,7 @@ void sys::File::readInto(char *buffer, Size_T size)
 
     for (i = 1; i <= _SYS_MAX_READ_ATTEMPTS; i++)
     {
-        bytesRead = ::read(mHandle, buffer + totalBytesRead, size
+        bytesRead = ::read(mHandle, bufferPtr + totalBytesRead, size
                 - totalBytesRead);
 
         switch (bytesRead)
@@ -90,14 +92,16 @@ void sys::File::readInto(char *buffer, Size_T size)
     throw sys::SystemException(Ctxt("Unknown read state"));
 }
 
-void sys::File::writeFrom(const char *buffer, Size_T size)
+void sys::File::writeFrom(const void* buffer, size_t size)
 {
-    Size_T bytesActuallyWritten = 0;
+    size_t bytesActuallyWritten = 0;
+
+    const sys::byte* bufferPtr = static_cast<const sys::byte*>(buffer);
 
     do
     {
         const SSize_T bytesThisRead = ::write(mHandle,
-                                              buffer + bytesActuallyWritten,
+                                              bufferPtr + bytesActuallyWritten,
                                               size - bytesActuallyWritten);
         if (bytesThisRead == -1)
         {

--- a/modules/c++/sys/source/FileWin32.cpp
+++ b/modules/c++/sys/source/FileWin32.cpp
@@ -54,11 +54,13 @@ void sys::File::create(const std::string& str,
     mPath = str;
 }
 
-void sys::File::readInto(char *buffer, Size_T size)
+void sys::File::readInto(void* buffer, size_t size)
 {
     static const size_t MAX_READ_SIZE = std::numeric_limits<DWORD>::max();
     size_t bytesRead = 0;
     size_t bytesRemaining = size;
+
+    const sys::byte* bufferPtr = static_cast<const sys::byte*>(buffer);
 
     while (bytesRead < size)
     {
@@ -69,7 +71,7 @@ void sys::File::readInto(char *buffer, Size_T size)
         // Read from file
         DWORD bytesThisRead = 0;
         if (!ReadFile(mHandle,
-                      buffer + bytesRead,
+                      bufferPtr + bytesRead,
                       bytesToRead,
                       &bytesThisRead,
                       NULL))
@@ -89,11 +91,13 @@ void sys::File::readInto(char *buffer, Size_T size)
     }
 }
 
-void sys::File::writeFrom(const char *buffer, Size_T size)
+void sys::File::writeFrom(const void* buffer, size_t size)
 {
     static const size_t MAX_WRITE_SIZE = std::numeric_limits<DWORD>::max();
     size_t bytesRemaining = size;
     size_t bytesWritten = 0;
+
+    const sys::byte* bufferPtr = static_cast<const sys::byte*>(buffer);
 
     while (bytesWritten < size)
     {
@@ -104,7 +108,7 @@ void sys::File::writeFrom(const char *buffer, Size_T size)
         // Write the data
         DWORD bytesThisWrite = 0;
         if (!WriteFile(mHandle,
-                       buffer + bytesWritten,
+                       bufferPtr + bytesWritten,
                        bytesToWrite,
                        &bytesThisWrite,
                        NULL))

--- a/modules/c++/xml.lite/include/xml/lite/XMLReaderExpat.h
+++ b/modules/c++/xml.lite/include/xml/lite/XMLReaderExpat.h
@@ -176,8 +176,7 @@ private:
      *  \param data The buffer
      *  \param size The buffer size
      */
-    void write(const sys::byte * data,
-               sys::Size_T size)
+    virtual void write(const void* data, size_t size)
     {
         parse(data, (int)size, false);
     }

--- a/modules/c++/xml.lite/include/xml/lite/XMLReaderLibXML.h
+++ b/modules/c++/xml.lite/include/xml/lite/XMLReaderLibXML.h
@@ -125,8 +125,7 @@ private:
      *  \param data The buffer
      *  \param size The buffer size
      */
-    void write(const sys::byte * data,
-               sys::Size_T size)
+    virtual void write(const void* data, size_t size)
     {
         parse(data, (int)size, false);
     }

--- a/modules/c++/xml.lite/include/xml/lite/XMLReaderXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/XMLReaderXerces.h
@@ -109,10 +109,9 @@ public:
     std::string getDriverName() const { return "xerces"; }
 
 private:
-
-    void write(const sys::byte*, sys::Size_T)
+    virtual void write(const void*, size_t)
     {
-        throw xml::lite::XMLException(Ctxt("Im not sure how you got here!"));
+        throw xml::lite::XMLException(Ctxt("I'm not sure how you got here!"));
     }
 };
 

--- a/modules/c++/zip/include/zip/GZipInputStream.h
+++ b/modules/c++/zip/include/zip/GZipInputStream.h
@@ -44,12 +44,7 @@ class GZipInputStream: public io::InputStream
 public:
 
     //!  Constructor requires initialization
-    GZipInputStream(std::string file);
-
-    //!  Destructor
-    virtual ~GZipInputStream()
-    {
-    }
+    GZipInputStream(const std::string& file);
 
     /*!
      *  Close the gzip stream.  You must call this
@@ -57,12 +52,13 @@ public:
      */
     virtual void close();
 
+protected:
     /*!
      *  Read len bytes into the buffer from the stream.
      *  This is a little tricky since we do not know the
      *  length of the read.
      */
-    virtual sys::SSize_T read(sys::byte* b, sys::Size_T len);
+    virtual sys::SSize_T readImpl(void* buffer, size_t len);
 
 };
 }

--- a/modules/c++/zip/include/zip/GZipOutputStream.h
+++ b/modules/c++/zip/include/zip/GZipOutputStream.h
@@ -37,12 +37,7 @@ class GZipOutputStream: public io::OutputStream
     gzFile mFile;
 public:
     //!  Constructor requires initialization
-    GZipOutputStream(std::string file);
-
-    //!  Destructor
-    virtual ~GZipOutputStream()
-    {
-    }
+    GZipOutputStream(const std::string& file);
 
     /*!
      *  Write len (or less) bytes into the gzip stream.
@@ -51,17 +46,14 @@ public:
      *  the call returns.
      *
      */
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, size_t len);
 
     /*!
      *  Close the gzip stream.  You must call this
      *  afterward (it is not done automatically).
      */
     virtual void close();
-
 };
-
 }
 
 #endif
-

--- a/modules/c++/zip/include/zip/ZipOutputStream.h
+++ b/modules/c++/zip/include/zip/ZipOutputStream.h
@@ -76,14 +76,13 @@ public:
     void write(const std::string& inputPathname,
                const std::string& zipPathname);
 
-    virtual void write(const sys::byte* b, sys::Size_T len);
+    virtual void write(const void* buffer, size_t len);
 
     virtual void close();
 
 private:
     zipFile mZip;
 };
-
 }
 
 #endif

--- a/modules/c++/zip/source/GZipInputStream.cpp
+++ b/modules/c++/zip/source/GZipInputStream.cpp
@@ -24,12 +24,14 @@
 
 using namespace zip;
 
-GZipInputStream::GZipInputStream(std::string file)
+GZipInputStream::GZipInputStream(const std::string& file)
 {
     mFile = gzopen(file.c_str(), "rb");
     if (mFile == NULL)
-        throw except::IOException(Ctxt(FmtX("Failed to open gzip stream [%s]",
-                file.c_str())));
+    {
+        throw except::IOException(Ctxt(
+                "Failed to open gzip stream [" + file + "]"));
+    }
 }
 
 void GZipInputStream::close()
@@ -38,12 +40,12 @@ void GZipInputStream::close()
     mFile = NULL;
 }
 
-sys::SSize_T GZipInputStream::read(sys::byte* b, sys::Size_T len)
+sys::SSize_T GZipInputStream::readImpl(void* buffer, size_t len)
 {
-    int rv = gzread(mFile, b, len);
+    int rv = gzread(mFile, buffer, len);
     if (rv == -1)
     {
-        std::string err(gzerror(mFile, &rv));
+        const std::string err(gzerror(mFile, &rv));
         throw except::IOException(Ctxt(err));
     }
     else if (rv == 0)
@@ -51,4 +53,3 @@ sys::SSize_T GZipInputStream::read(sys::byte* b, sys::Size_T len)
 
     return (sys::SSize_T) rv;
 }
-

--- a/modules/c++/zip/source/GZipOutputStream.cpp
+++ b/modules/c++/zip/source/GZipOutputStream.cpp
@@ -24,25 +24,28 @@
 
 using namespace zip;
 
-GZipOutputStream::GZipOutputStream(std::string file)
+GZipOutputStream::GZipOutputStream(const std::string& file)
 {
     mFile = gzopen(file.c_str(), "wb");
     if (mFile == NULL)
-        throw except::IOException(Ctxt(FmtX("Failed to open gzip stream [%s]",
-                file.c_str())));
+    {
+        throw except::IOException(Ctxt(
+                "Failed to open gzip stream [" + file + "]"));
+    }
 
 }
 
-void GZipOutputStream::write(const sys::byte* b, sys::Size_T len)
+void GZipOutputStream::write(const void* buffer, size_t len)
 {
-    sys::Size_T written = 0;
+    size_t written = 0;
     int rv = 0;
+    const sys::byte* const bufferPtr = static_cast<const sys::byte*>(buffer);
     do
     {
-        rv = gzwrite(mFile, (const voidp)&(b[written]), len - written);
+        rv = gzwrite(mFile, bufferPtr + written, len - written);
         if (rv < 0)
         {
-            std::string err(gzerror(mFile, &rv));
+            const std::string err(gzerror(mFile, &rv));
             throw except::Exception(Ctxt(err));
         }
         if (!rv)
@@ -58,5 +61,3 @@ void GZipOutputStream::close()
     gzclose( mFile);
     mFile = NULL;
 }
-
-

--- a/modules/c++/zip/source/ZipOutputStream.cpp
+++ b/modules/c++/zip/source/ZipOutputStream.cpp
@@ -85,10 +85,10 @@ void ZipOutputStream::write(const std::string& inputPathname,
     closeFileInZip();
 }
 
-void ZipOutputStream::write(const sys::byte* b, sys::Size_T len)
+void ZipOutputStream::write(const void* buffer, size_t len)
 {
     // Write the contents to the location
-    sys::Int32_T results = zipWriteInFileInZip(mZip, b, len);
+    const sys::Int32_T results = zipWriteInFileInZip(mZip, buffer, len);
 
     if (results != Z_OK)
          throw except::IOException(Ctxt("Failed to write file to zip location."));

--- a/modules/c++/zip/tests/test_zipcompress.cpp
+++ b/modules/c++/zip/tests/test_zipcompress.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
         std::vector<std::string> inputPathnames;
         std::vector<std::string> zipPathnames;
 
-        size_t index = 1;
+        int index = 1;
         while (index < argc)
         {
             if (!::strcmp(argv[index], "-i"))

--- a/modules/python/io/source/generated/coda_io.py
+++ b/modules/python/io/source/generated/coda_io.py
@@ -117,9 +117,12 @@ class InputStream(_object):
         return _coda_io.InputStream_available(self)
 
 
-    def read(self, b, len):
-        """read(InputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"""
-        return _coda_io.InputStream_read(self, b, len)
+    def read(self, b, len, verifyFullRead=False):
+        """
+        read(InputStream self, void * b, size_t len, bool verifyFullRead=False) -> sys::SSize_T
+        read(InputStream self, void * b, size_t len) -> sys::SSize_T
+        """
+        return _coda_io.InputStream_read(self, b, len, verifyFullRead)
 
 
     def readln(self, cStr, strLenPlusNullByte):
@@ -160,7 +163,7 @@ class OutputStream(_object):
         """
         write(OutputStream self, sys::byte b)
         write(OutputStream self, std::string const & str)
-        write(OutputStream self, sys::byte const * b, sys::Size_T len)
+        write(OutputStream self, void const * buffer, size_t len)
         """
         return _coda_io.OutputStream_write(self, *args)
 
@@ -244,11 +247,6 @@ class SeekableInputStream(InputStream, Seekable):
     __swig_destroy__ = _coda_io.delete_SeekableInputStream
     __del__ = lambda self: None
 
-    def read(self, b, len):
-        """read(SeekableInputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"""
-        return _coda_io.SeekableInputStream_read(self, b, len)
-
-
     def streamTo(self, *args):
         """
         streamTo(SeekableInputStream self, OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T
@@ -276,11 +274,6 @@ class SeekableOutputStream(OutputStream, Seekable):
     __repr__ = _swig_repr
     __swig_destroy__ = _coda_io.delete_SeekableOutputStream
     __del__ = lambda self: None
-
-    def write(self, b, len):
-        """write(SeekableOutputStream self, sys::byte const * b, sys::Size_T len)"""
-        return _coda_io.SeekableOutputStream_write(self, b, len)
-
 SeekableOutputStream_swigregister = _coda_io.SeekableOutputStream_swigregister
 SeekableOutputStream_swigregister(SeekableOutputStream)
 
@@ -301,16 +294,6 @@ class SeekableBidirectionalStream(BidirectionalStream, Seekable):
     __repr__ = _swig_repr
     __swig_destroy__ = _coda_io.delete_SeekableBidirectionalStream
     __del__ = lambda self: None
-
-    def read(self, b, len):
-        """read(SeekableBidirectionalStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"""
-        return _coda_io.SeekableBidirectionalStream_read(self, b, len)
-
-
-    def write(self, b, len):
-        """write(SeekableBidirectionalStream self, sys::byte const * b, sys::Size_T len)"""
-        return _coda_io.SeekableBidirectionalStream_write(self, b, len)
-
 
     def streamTo(self, *args):
         """
@@ -362,14 +345,10 @@ class StringStream(SeekableBidirectionalStream):
         """
         write(StringStream self, sys::byte b)
         write(StringStream self, std::string const & str)
-        write(StringStream self, sys::byte const * b, sys::Size_T size)
+        write(StringStream self, void const * buffer, size_t len)
+        write(StringStream self, void const * buffer, sys::Size_T size)
         """
         return _coda_io.StringStream_write(self, *args)
-
-
-    def read(self, b, len):
-        """read(StringStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"""
-        return _coda_io.StringStream_read(self, b, len)
 
 
     def stream(self, *args):
@@ -422,11 +401,6 @@ class NullInputStream(InputStream):
         return _coda_io.NullInputStream_available(self)
 
 
-    def read(self, b, len):
-        """read(NullInputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"""
-        return _coda_io.NullInputStream_read(self, b, len)
-
-
     def readln(self, cStr, strLenPlusNullByte):
         """readln(NullInputStream self, sys::byte * cStr, sys::Size_T const strLenPlusNullByte) -> sys::SSize_T"""
         return _coda_io.NullInputStream_readln(self, cStr, strLenPlusNullByte)
@@ -474,7 +448,7 @@ class NullOutputStream(OutputStream):
         """
         write(NullOutputStream self, sys::byte arg2)
         write(NullOutputStream self, std::string const & arg2)
-        write(NullOutputStream self, sys::byte const * arg2, sys::Size_T arg3)
+        write(NullOutputStream self, void const * arg2, size_t arg3)
         """
         return _coda_io.NullOutputStream_write(self, *args)
 
@@ -541,11 +515,6 @@ class FileInputStream(SeekableInputStream):
     def close(self):
         """close(FileInputStream self)"""
         return _coda_io.FileInputStream_close(self)
-
-
-    def read(self, b, len):
-        """read(FileInputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"""
-        return _coda_io.FileInputStream_read(self, b, len)
 
 FileInputStream_swigregister = _coda_io.FileInputStream_swigregister
 FileInputStream_swigregister(FileInputStream)
@@ -614,7 +583,7 @@ class FileOutputStream(SeekableOutputStream):
         """
         write(FileOutputStream self, sys::byte b)
         write(FileOutputStream self, std::string const & str)
-        write(FileOutputStream self, sys::byte const * b, sys::Size_T len)
+        write(FileOutputStream self, void const * buffer, size_t len)
         """
         return _coda_io.FileOutputStream_write(self, *args)
 

--- a/modules/python/io/source/generated/coda_io.py
+++ b/modules/python/io/source/generated/coda_io.py
@@ -117,12 +117,12 @@ class InputStream(_object):
         return _coda_io.InputStream_available(self)
 
 
-    def read(self, b, len, verifyFullRead=False):
+    def read(self, buffer, len, verifyFullRead=False):
         """
-        read(InputStream self, void * b, size_t len, bool verifyFullRead=False) -> sys::SSize_T
-        read(InputStream self, void * b, size_t len) -> sys::SSize_T
+        read(InputStream self, void * buffer, size_t len, bool verifyFullRead=False) -> sys::SSize_T
+        read(InputStream self, void * buffer, size_t len) -> sys::SSize_T
         """
-        return _coda_io.InputStream_read(self, b, len, verifyFullRead)
+        return _coda_io.InputStream_read(self, buffer, len, verifyFullRead)
 
 
     def readln(self, cStr, strLenPlusNullByte):

--- a/modules/python/io/source/generated/coda_io_wrap.cxx
+++ b/modules/python/io/source/generated/coda_io_wrap.cxx
@@ -6771,8 +6771,8 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"delete_InputStream", _wrap_delete_InputStream, METH_VARARGS, (char *)"delete_InputStream(InputStream self)"},
 	 { (char *)"InputStream_available", _wrap_InputStream_available, METH_VARARGS, (char *)"InputStream_available(InputStream self) -> sys::Off_T"},
 	 { (char *)"InputStream_read", _wrap_InputStream_read, METH_VARARGS, (char *)"\n"
-		"read(void * b, size_t len, bool verifyFullRead=False) -> sys::SSize_T\n"
-		"InputStream_read(InputStream self, void * b, size_t len) -> sys::SSize_T\n"
+		"read(void * buffer, size_t len, bool verifyFullRead=False) -> sys::SSize_T\n"
+		"InputStream_read(InputStream self, void * buffer, size_t len) -> sys::SSize_T\n"
 		""},
 	 { (char *)"InputStream_readln", _wrap_InputStream_readln, METH_VARARGS, (char *)"InputStream_readln(InputStream self, sys::byte * cStr, sys::Size_T const strLenPlusNullByte) -> sys::SSize_T"},
 	 { (char *)"InputStream_streamTo", _wrap_InputStream_streamTo, METH_VARARGS, (char *)"\n"

--- a/modules/python/io/source/generated/coda_io_wrap.cxx
+++ b/modules/python/io/source/generated/coda_io_wrap.cxx
@@ -3146,6 +3146,270 @@ SWIGINTERNINLINE PyObject*
 }
 
 
+SWIGINTERN int
+SWIG_AsVal_double (PyObject *obj, double *val)
+{
+  int res = SWIG_TypeError;
+  if (PyFloat_Check(obj)) {
+    if (val) *val = PyFloat_AsDouble(obj);
+    return SWIG_OK;
+#if PY_VERSION_HEX < 0x03000000
+  } else if (PyInt_Check(obj)) {
+    if (val) *val = (double) PyInt_AsLong(obj);
+    return SWIG_OK;
+#endif
+  } else if (PyLong_Check(obj)) {
+    double v = PyLong_AsDouble(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    int dispatch = 0;
+    double d = PyFloat_AsDouble(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = d;
+      return SWIG_AddCast(SWIG_OK);
+    } else {
+      PyErr_Clear();
+    }
+    if (!dispatch) {
+      long v = PyLong_AsLong(obj);
+      if (!PyErr_Occurred()) {
+	if (val) *val = v;
+	return SWIG_AddCast(SWIG_AddCast(SWIG_OK));
+      } else {
+	PyErr_Clear();
+      }
+    }
+  }
+#endif
+  return res;
+}
+
+
+#include <float.h>
+
+
+#include <math.h>
+
+
+SWIGINTERNINLINE int
+SWIG_CanCastAsInteger(double *d, double min, double max) {
+  double x = *d;
+  if ((min <= x && x <= max)) {
+   double fx = floor(x);
+   double cx = ceil(x);
+   double rd =  ((x - fx) < 0.5) ? fx : cx; /* simple rint */
+   if ((errno == EDOM) || (errno == ERANGE)) {
+     errno = 0;
+   } else {
+     double summ, reps, diff;
+     if (rd < x) {
+       diff = x - rd;
+     } else if (rd > x) {
+       diff = rd - x;
+     } else {
+       return 1;
+     }
+     summ = rd + x;
+     reps = diff/summ;
+     if (reps < 8*DBL_EPSILON) {
+       *d = rd;
+       return 1;
+     }
+   }
+  }
+  return 0;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_unsigned_SS_long (PyObject *obj, unsigned long *val) 
+{
+#if PY_VERSION_HEX < 0x03000000
+  if (PyInt_Check(obj)) {
+    long v = PyInt_AsLong(obj);
+    if (v >= 0) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      return SWIG_OverflowError;
+    }
+  } else
+#endif
+  if (PyLong_Check(obj)) {
+    unsigned long v = PyLong_AsUnsignedLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      return SWIG_OverflowError;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    int dispatch = 0;
+    unsigned long v = PyLong_AsUnsignedLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_AddCast(SWIG_OK);
+    } else {
+      PyErr_Clear();
+    }
+    if (!dispatch) {
+      double d;
+      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
+      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, 0, ULONG_MAX)) {
+	if (val) *val = (unsigned long)(d);
+	return res;
+      }
+    }
+  }
+#endif
+  return SWIG_TypeError;
+}
+
+
+#include <limits.h>
+#if !defined(SWIG_NO_LLONG_MAX)
+# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
+#   define LLONG_MAX __LONG_LONG_MAX__
+#   define LLONG_MIN (-LLONG_MAX - 1LL)
+#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
+# endif
+#endif
+
+
+#if defined(LLONG_MAX) && !defined(SWIG_LONG_LONG_AVAILABLE)
+#  define SWIG_LONG_LONG_AVAILABLE
+#endif
+
+
+#ifdef SWIG_LONG_LONG_AVAILABLE
+SWIGINTERN int
+SWIG_AsVal_unsigned_SS_long_SS_long (PyObject *obj, unsigned long long *val)
+{
+  int res = SWIG_TypeError;
+  if (PyLong_Check(obj)) {
+    unsigned long long v = PyLong_AsUnsignedLongLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      res = SWIG_OverflowError;
+    }
+  } else {
+    unsigned long v;
+    res = SWIG_AsVal_unsigned_SS_long (obj,&v);
+    if (SWIG_IsOK(res)) {
+      if (val) *val = v;
+      return res;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    const double mant_max = 1LL << DBL_MANT_DIG;
+    double d;
+    res = SWIG_AsVal_double (obj,&d);
+    if (SWIG_IsOK(res) && !SWIG_CanCastAsInteger(&d, 0, mant_max))
+      return SWIG_OverflowError;
+    if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, 0, mant_max)) {
+      if (val) *val = (unsigned long long)(d);
+      return SWIG_AddCast(res);
+    }
+    res = SWIG_TypeError;
+  }
+#endif
+  return res;
+}
+#endif
+
+
+SWIGINTERNINLINE int
+SWIG_AsVal_size_t (PyObject * obj, size_t *val)
+{
+  int res = SWIG_TypeError;
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  if (sizeof(size_t) <= sizeof(unsigned long)) {
+#endif
+    unsigned long v;
+    res = SWIG_AsVal_unsigned_SS_long (obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = static_cast< size_t >(v);
+#ifdef SWIG_LONG_LONG_AVAILABLE
+  } else if (sizeof(size_t) <= sizeof(unsigned long long)) {
+    unsigned long long v;
+    res = SWIG_AsVal_unsigned_SS_long_SS_long (obj, val ? &v : 0);
+    if (SWIG_IsOK(res) && val) *val = static_cast< size_t >(v);
+  }
+#endif
+  return res;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_long (PyObject *obj, long* val)
+{
+#if PY_VERSION_HEX < 0x03000000
+  if (PyInt_Check(obj)) {
+    if (val) *val = PyInt_AsLong(obj);
+    return SWIG_OK;
+  } else
+#endif
+  if (PyLong_Check(obj)) {
+    long v = PyLong_AsLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_OK;
+    } else {
+      PyErr_Clear();
+      return SWIG_OverflowError;
+    }
+  }
+#ifdef SWIG_PYTHON_CAST_MODE
+  {
+    int dispatch = 0;
+    long v = PyInt_AsLong(obj);
+    if (!PyErr_Occurred()) {
+      if (val) *val = v;
+      return SWIG_AddCast(SWIG_OK);
+    } else {
+      PyErr_Clear();
+    }
+    if (!dispatch) {
+      double d;
+      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
+      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
+	if (val) *val = (long)(d);
+	return res;
+      }
+    }
+  }
+#endif
+  return SWIG_TypeError;
+}
+
+
+SWIGINTERN int
+SWIG_AsVal_bool (PyObject *obj, bool *val)
+{
+  int r;
+  if (!PyBool_Check(obj))
+    return SWIG_ERROR;
+  r = PyObject_IsTrue(obj);
+  if (r == -1)
+    return SWIG_ERROR;
+  if (val) *val = r ? true : false;
+  return SWIG_OK;
+}
+
+
 SWIGINTERN swig_type_info*
 SWIG_pchar_descriptor(void)
 {
@@ -3303,141 +3567,6 @@ SWIG_AsPtr_std_string (PyObject * obj, std::string **val)
 }
 
 
-#include <limits.h>
-#if !defined(SWIG_NO_LLONG_MAX)
-# if !defined(LLONG_MAX) && defined(__GNUC__) && defined (__LONG_LONG_MAX__)
-#   define LLONG_MAX __LONG_LONG_MAX__
-#   define LLONG_MIN (-LLONG_MAX - 1LL)
-#   define ULLONG_MAX (LLONG_MAX * 2ULL + 1ULL)
-# endif
-#endif
-
-
-SWIGINTERN int
-SWIG_AsVal_double (PyObject *obj, double *val)
-{
-  int res = SWIG_TypeError;
-  if (PyFloat_Check(obj)) {
-    if (val) *val = PyFloat_AsDouble(obj);
-    return SWIG_OK;
-#if PY_VERSION_HEX < 0x03000000
-  } else if (PyInt_Check(obj)) {
-    if (val) *val = (double) PyInt_AsLong(obj);
-    return SWIG_OK;
-#endif
-  } else if (PyLong_Check(obj)) {
-    double v = PyLong_AsDouble(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_OK;
-    } else {
-      PyErr_Clear();
-    }
-  }
-#ifdef SWIG_PYTHON_CAST_MODE
-  {
-    int dispatch = 0;
-    double d = PyFloat_AsDouble(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = d;
-      return SWIG_AddCast(SWIG_OK);
-    } else {
-      PyErr_Clear();
-    }
-    if (!dispatch) {
-      long v = PyLong_AsLong(obj);
-      if (!PyErr_Occurred()) {
-	if (val) *val = v;
-	return SWIG_AddCast(SWIG_AddCast(SWIG_OK));
-      } else {
-	PyErr_Clear();
-      }
-    }
-  }
-#endif
-  return res;
-}
-
-
-#include <float.h>
-
-
-#include <math.h>
-
-
-SWIGINTERNINLINE int
-SWIG_CanCastAsInteger(double *d, double min, double max) {
-  double x = *d;
-  if ((min <= x && x <= max)) {
-   double fx = floor(x);
-   double cx = ceil(x);
-   double rd =  ((x - fx) < 0.5) ? fx : cx; /* simple rint */
-   if ((errno == EDOM) || (errno == ERANGE)) {
-     errno = 0;
-   } else {
-     double summ, reps, diff;
-     if (rd < x) {
-       diff = x - rd;
-     } else if (rd > x) {
-       diff = rd - x;
-     } else {
-       return 1;
-     }
-     summ = rd + x;
-     reps = diff/summ;
-     if (reps < 8*DBL_EPSILON) {
-       *d = rd;
-       return 1;
-     }
-   }
-  }
-  return 0;
-}
-
-
-SWIGINTERN int
-SWIG_AsVal_long (PyObject *obj, long* val)
-{
-#if PY_VERSION_HEX < 0x03000000
-  if (PyInt_Check(obj)) {
-    if (val) *val = PyInt_AsLong(obj);
-    return SWIG_OK;
-  } else
-#endif
-  if (PyLong_Check(obj)) {
-    long v = PyLong_AsLong(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_OK;
-    } else {
-      PyErr_Clear();
-      return SWIG_OverflowError;
-    }
-  }
-#ifdef SWIG_PYTHON_CAST_MODE
-  {
-    int dispatch = 0;
-    long v = PyInt_AsLong(obj);
-    if (!PyErr_Occurred()) {
-      if (val) *val = v;
-      return SWIG_AddCast(SWIG_OK);
-    } else {
-      PyErr_Clear();
-    }
-    if (!dispatch) {
-      double d;
-      int res = SWIG_AddCast(SWIG_AsVal_double (obj,&d));
-      if (SWIG_IsOK(res) && SWIG_CanCastAsInteger(&d, LONG_MIN, LONG_MAX)) {
-	if (val) *val = (long)(d);
-	return res;
-      }
-    }
-  }
-#endif
-  return SWIG_TypeError;
-}
-
-
 SWIGINTERN int
 SWIG_AsVal_int (PyObject * obj, int *val)
 {
@@ -3545,17 +3674,63 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_InputStream_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_InputStream_read__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   io::InputStream *arg1 = (io::InputStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  bool arg4 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  bool val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  sys::SSize_T result;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:InputStream_read",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__InputStream, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InputStream_read" "', argument " "1"" of type '" "io::InputStream *""'"); 
+  }
+  arg1 = reinterpret_cast< io::InputStream * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InputStream_read" "', argument " "2"" of type '" "void *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "InputStream_read" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  ecode4 = SWIG_AsVal_bool(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "InputStream_read" "', argument " "4"" of type '" "bool""'");
+  } 
+  arg4 = static_cast< bool >(val4);
+  result = (arg1)->read(arg2,arg3,arg4);
+  resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InputStream_read__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  io::InputStream *arg1 = (io::InputStream *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -3567,29 +3742,88 @@ SWIGINTERN PyObject *_wrap_InputStream_read(PyObject *SWIGUNUSEDPARM(self), PyOb
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "InputStream_read" "', argument " "1"" of type '" "io::InputStream *""'"); 
   }
   arg1 = reinterpret_cast< io::InputStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InputStream_read" "', argument " "2"" of type '" "sys::byte *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "InputStream_read" "', argument " "2"" of type '" "void *""'"); 
   }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "InputStream_read" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "InputStream_read" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "InputStream_read" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
   result = (arg1)->read(arg2,arg3);
   resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_InputStream_read(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[5] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 4) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__InputStream, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_InputStream_read__SWIG_1(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__InputStream, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_bool(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_InputStream_read__SWIG_0(self, args);
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'InputStream_read'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    io::InputStream::read(void *,size_t,bool)\n"
+    "    io::InputStream::read(void *,size_t)\n");
+  return 0;
 }
 
 
@@ -3923,14 +4157,13 @@ fail:
 SWIGINTERN PyObject *_wrap_OutputStream_write__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   io::OutputStream *arg1 = (io::OutputStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -3941,25 +4174,16 @@ SWIGINTERN PyObject *_wrap_OutputStream_write__SWIG_2(PyObject *SWIGUNUSEDPARM(s
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "OutputStream_write" "', argument " "1"" of type '" "io::OutputStream *""'"); 
   }
   arg1 = reinterpret_cast< io::OutputStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "OutputStream_write" "', argument " "2"" of type '" "sys::byte const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "OutputStream_write" "', argument " "2"" of type '" "void const *""'"); 
   }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "OutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "OutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  (arg1)->write((sys::byte const *)arg2,arg3);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "OutputStream_write" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  (arg1)->write((void const *)arg2,arg3);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -4011,12 +4235,14 @@ SWIGINTERN PyObject *_wrap_OutputStream_write(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__OutputStream, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_sys__byte, 0);
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_sys__Size_T, 0);
-        _v = SWIG_CheckState(res);
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
         if (_v) {
           return _wrap_OutputStream_write__SWIG_2(self, args);
         }
@@ -4029,7 +4255,7 @@ fail:
     "  Possible C/C++ prototypes are:\n"
     "    io::OutputStream::write(sys::byte)\n"
     "    io::OutputStream::write(std::string const &)\n"
-    "    io::OutputStream::write(sys::byte const *,sys::Size_T)\n");
+    "    io::OutputStream::write(void const *,size_t)\n");
   return 0;
 }
 
@@ -4230,54 +4456,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_SeekableInputStream_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::SeekableInputStream *arg1 = (io::SeekableInputStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  sys::SSize_T result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:SeekableInputStream_read",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__SeekableInputStream, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SeekableInputStream_read" "', argument " "1"" of type '" "io::SeekableInputStream *""'"); 
-  }
-  arg1 = reinterpret_cast< io::SeekableInputStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SeekableInputStream_read" "', argument " "2"" of type '" "sys::byte *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "SeekableInputStream_read" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SeekableInputStream_read" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  result = (arg1)->read(arg2,arg3);
-  resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
 SWIGINTERN PyObject *_wrap_SeekableInputStream_streamTo_SWIG_0_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   io::SeekableInputStream *arg1 = (io::SeekableInputStream *) 0 ;
@@ -4445,53 +4623,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_SeekableOutputStream_write(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::SeekableOutputStream *arg1 = (io::SeekableOutputStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:SeekableOutputStream_write",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__SeekableOutputStream, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SeekableOutputStream_write" "', argument " "1"" of type '" "io::SeekableOutputStream *""'"); 
-  }
-  arg1 = reinterpret_cast< io::SeekableOutputStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SeekableOutputStream_write" "', argument " "2"" of type '" "sys::byte const *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "SeekableOutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SeekableOutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  (arg1)->write((sys::byte const *)arg2,arg3);
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
 SWIGINTERN PyObject *SeekableOutputStream_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *obj;
   if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
@@ -4513,101 +4644,6 @@ SWIGINTERN PyObject *_wrap_delete_SeekableBidirectionalStream(PyObject *SWIGUNUS
   }
   arg1 = reinterpret_cast< io::SeekableBidirectionalStream * >(argp1);
   delete arg1;
-  resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_SeekableBidirectionalStream_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::SeekableBidirectionalStream *arg1 = (io::SeekableBidirectionalStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  sys::SSize_T result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:SeekableBidirectionalStream_read",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__SeekableBidirectionalStream, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SeekableBidirectionalStream_read" "', argument " "1"" of type '" "io::SeekableBidirectionalStream *""'"); 
-  }
-  arg1 = reinterpret_cast< io::SeekableBidirectionalStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SeekableBidirectionalStream_read" "', argument " "2"" of type '" "sys::byte *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "SeekableBidirectionalStream_read" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SeekableBidirectionalStream_read" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  result = (arg1)->read(arg2,arg3);
-  resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_SeekableBidirectionalStream_write(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::SeekableBidirectionalStream *arg1 = (io::SeekableBidirectionalStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:SeekableBidirectionalStream_write",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__SeekableBidirectionalStream, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SeekableBidirectionalStream_write" "', argument " "1"" of type '" "io::SeekableBidirectionalStream *""'"); 
-  }
-  arg1 = reinterpret_cast< io::SeekableBidirectionalStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SeekableBidirectionalStream_write" "', argument " "2"" of type '" "sys::byte const *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "SeekableBidirectionalStream_write" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "SeekableBidirectionalStream_write" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  (arg1)->write((sys::byte const *)arg2,arg3);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -4963,15 +4999,51 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_StringStream_write__SWIG_0_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  io::StringStream *arg1 = (io::StringStream *) 0 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:StringStream_write",&obj0,&obj1,&obj2)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__StringStream, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StringStream_write" "', argument " "1"" of type '" "io::StringStream *""'"); 
+  }
+  arg1 = reinterpret_cast< io::StringStream * >(argp1);
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
+  if (!SWIG_IsOK(res2)) {
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "StringStream_write" "', argument " "2"" of type '" "void const *""'"); 
+  }
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StringStream_write" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  (arg1)->write((void const *)arg2,arg3);
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_StringStream_write__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   io::StringStream *arg1 = (io::StringStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
+  void *arg2 = (void *) 0 ;
   sys::Size_T arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
+  int res2 ;
   void *argp3 ;
   int res3 = 0 ;
   PyObject * obj0 = 0 ;
@@ -4984,11 +5056,10 @@ SWIGINTERN PyObject *_wrap_StringStream_write__SWIG_1(PyObject *SWIGUNUSEDPARM(s
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StringStream_write" "', argument " "1"" of type '" "io::StringStream *""'"); 
   }
   arg1 = reinterpret_cast< io::StringStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "StringStream_write" "', argument " "2"" of type '" "sys::byte const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "StringStream_write" "', argument " "2"" of type '" "void const *""'"); 
   }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
   {
     res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
     if (!SWIG_IsOK(res3)) {
@@ -5002,7 +5073,7 @@ SWIGINTERN PyObject *_wrap_StringStream_write__SWIG_1(PyObject *SWIGUNUSEDPARM(s
       if (SWIG_IsNewObj(res3)) delete temp;
     }
   }
-  (arg1)->write((sys::byte const *)arg2,arg3);
+  (arg1)->write((void const *)arg2,arg3);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -5054,8 +5125,8 @@ SWIGINTERN PyObject *_wrap_StringStream_write(PyObject *self, PyObject *args) {
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__StringStream, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_sys__byte, 0);
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
         int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_sys__Size_T, 0);
@@ -5066,62 +5137,35 @@ SWIGINTERN PyObject *_wrap_StringStream_write(PyObject *self, PyObject *args) {
       }
     }
   }
+  if (argc == 3) {
+    int _v;
+    void *vptr = 0;
+    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__StringStream, 0);
+    _v = SWIG_CheckState(res);
+    if (_v) {
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_StringStream_write__SWIG_0_2(self, args);
+        }
+      }
+    }
+  }
   
 fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'StringStream_write'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    write(sys::byte)\n"
     "    write(std::string const &)\n"
-    "    io::StringStream::write(sys::byte const *,sys::Size_T)\n");
+    "    write(void const *,size_t)\n"
+    "    io::StringStream::write(void const *,sys::Size_T)\n");
   return 0;
-}
-
-
-SWIGINTERN PyObject *_wrap_StringStream_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::StringStream *arg1 = (io::StringStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  sys::SSize_T result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:StringStream_read",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__StringStream, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StringStream_read" "', argument " "1"" of type '" "io::StringStream *""'"); 
-  }
-  arg1 = reinterpret_cast< io::StringStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "StringStream_read" "', argument " "2"" of type '" "sys::byte *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "StringStream_read" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "StringStream_read" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  result = (arg1)->read(arg2,arg3);
-  resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
-  return resultobj;
-fail:
-  return NULL;
 }
 
 
@@ -5325,54 +5369,6 @@ SWIGINTERN PyObject *_wrap_NullInputStream_available(PyObject *SWIGUNUSEDPARM(se
   arg1 = reinterpret_cast< io::NullInputStream * >(argp1);
   result = (arg1)->available();
   resultobj = SWIG_NewPointerObj((new sys::Off_T(static_cast< const sys::Off_T& >(result))), SWIGTYPE_p_sys__Off_T, SWIG_POINTER_OWN |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_NullInputStream_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::NullInputStream *arg1 = (io::NullInputStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  sys::SSize_T result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:NullInputStream_read",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__NullInputStream, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NullInputStream_read" "', argument " "1"" of type '" "io::NullInputStream *""'"); 
-  }
-  arg1 = reinterpret_cast< io::NullInputStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NullInputStream_read" "', argument " "2"" of type '" "sys::byte *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "NullInputStream_read" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NullInputStream_read" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  result = (arg1)->read(arg2,arg3);
-  resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -5722,14 +5718,13 @@ fail:
 SWIGINTERN PyObject *_wrap_NullOutputStream_write__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   io::NullOutputStream *arg1 = (io::NullOutputStream *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -5740,25 +5735,16 @@ SWIGINTERN PyObject *_wrap_NullOutputStream_write__SWIG_2(PyObject *SWIGUNUSEDPA
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "NullOutputStream_write" "', argument " "1"" of type '" "io::NullOutputStream *""'"); 
   }
   arg1 = reinterpret_cast< io::NullOutputStream * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NullOutputStream_write" "', argument " "2"" of type '" "sys::byte const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "NullOutputStream_write" "', argument " "2"" of type '" "void const *""'"); 
   }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "NullOutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "NullOutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  (arg1)->write((sys::byte const *)arg2,arg3);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "NullOutputStream_write" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  (arg1)->write((void const *)arg2,arg3);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -5810,12 +5796,14 @@ SWIGINTERN PyObject *_wrap_NullOutputStream_write(PyObject *self, PyObject *args
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__NullOutputStream, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_sys__byte, 0);
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_sys__Size_T, 0);
-        _v = SWIG_CheckState(res);
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
         if (_v) {
           return _wrap_NullOutputStream_write__SWIG_2(self, args);
         }
@@ -5828,7 +5816,7 @@ fail:
     "  Possible C/C++ prototypes are:\n"
     "    io::NullOutputStream::write(sys::byte)\n"
     "    io::NullOutputStream::write(std::string const &)\n"
-    "    io::NullOutputStream::write(sys::byte const *,sys::Size_T)\n");
+    "    io::NullOutputStream::write(void const *,size_t)\n");
   return 0;
 }
 
@@ -6157,54 +6145,6 @@ SWIGINTERN PyObject *_wrap_FileInputStream_close(PyObject *SWIGUNUSEDPARM(self),
   arg1 = reinterpret_cast< io::FileInputStreamOS * >(argp1);
   (arg1)->close();
   resultobj = SWIG_Py_Void();
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_FileInputStream_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  io::FileInputStreamOS *arg1 = (io::FileInputStreamOS *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  sys::SSize_T result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:FileInputStream_read",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__FileInputStreamOS, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FileInputStream_read" "', argument " "1"" of type '" "io::FileInputStreamOS *""'"); 
-  }
-  arg1 = reinterpret_cast< io::FileInputStreamOS * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FileInputStream_read" "', argument " "2"" of type '" "sys::byte *""'"); 
-  }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "FileInputStream_read" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FileInputStream_read" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  result = (arg1)->read(arg2,arg3);
-  resultobj = SWIG_NewPointerObj((new sys::SSize_T(static_cast< const sys::SSize_T& >(result))), SWIGTYPE_p_sys__SSize_T, SWIG_POINTER_OWN |  0 );
   return resultobj;
 fail:
   return NULL;
@@ -6716,14 +6656,13 @@ fail:
 SWIGINTERN PyObject *_wrap_FileOutputStream_write__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   io::FileOutputStreamOS *arg1 = (io::FileOutputStreamOS *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  sys::Size_T arg3 ;
+  void *arg2 = (void *) 0 ;
+  size_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
-  void *argp2 = 0 ;
-  int res2 = 0 ;
-  void *argp3 ;
-  int res3 = 0 ;
+  int res2 ;
+  size_t val3 ;
+  int ecode3 = 0 ;
   PyObject * obj0 = 0 ;
   PyObject * obj1 = 0 ;
   PyObject * obj2 = 0 ;
@@ -6734,25 +6673,16 @@ SWIGINTERN PyObject *_wrap_FileOutputStream_write__SWIG_1(PyObject *SWIGUNUSEDPA
     SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "FileOutputStream_write" "', argument " "1"" of type '" "io::FileOutputStreamOS *""'"); 
   }
   arg1 = reinterpret_cast< io::FileOutputStreamOS * >(argp1);
-  res2 = SWIG_ConvertPtr(obj1, &argp2,SWIGTYPE_p_sys__byte, 0 |  0 );
+  res2 = SWIG_ConvertPtr(obj1,SWIG_as_voidptrptr(&arg2), 0, 0);
   if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FileOutputStream_write" "', argument " "2"" of type '" "sys::byte const *""'"); 
+    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "FileOutputStream_write" "', argument " "2"" of type '" "void const *""'"); 
   }
-  arg2 = reinterpret_cast< sys::byte * >(argp2);
-  {
-    res3 = SWIG_ConvertPtr(obj2, &argp3, SWIGTYPE_p_sys__Size_T,  0  | 0);
-    if (!SWIG_IsOK(res3)) {
-      SWIG_exception_fail(SWIG_ArgError(res3), "in method '" "FileOutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'"); 
-    }  
-    if (!argp3) {
-      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "FileOutputStream_write" "', argument " "3"" of type '" "sys::Size_T""'");
-    } else {
-      sys::Size_T * temp = reinterpret_cast< sys::Size_T * >(argp3);
-      arg3 = *temp;
-      if (SWIG_IsNewObj(res3)) delete temp;
-    }
-  }
-  (arg1)->write((sys::byte const *)arg2,arg3);
+  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "FileOutputStream_write" "', argument " "3"" of type '" "size_t""'");
+  } 
+  arg3 = static_cast< size_t >(val3);
+  (arg1)->write((void const *)arg2,arg3);
   resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
@@ -6804,12 +6734,14 @@ SWIGINTERN PyObject *_wrap_FileOutputStream_write(PyObject *self, PyObject *args
     int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_io__FileOutputStreamOS, 0);
     _v = SWIG_CheckState(res);
     if (_v) {
-      void *vptr = 0;
-      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_sys__byte, 0);
+      void *ptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &ptr, 0, 0);
       _v = SWIG_CheckState(res);
       if (_v) {
-        int res = SWIG_ConvertPtr(argv[2], 0, SWIGTYPE_p_sys__Size_T, 0);
-        _v = SWIG_CheckState(res);
+        {
+          int res = SWIG_AsVal_size_t(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
         if (_v) {
           return _wrap_FileOutputStream_write__SWIG_1(self, args);
         }
@@ -6822,7 +6754,7 @@ fail:
     "  Possible C/C++ prototypes are:\n"
     "    write(sys::byte)\n"
     "    write(std::string const &)\n"
-    "    io::FileOutputStreamOS::write(sys::byte const *,sys::Size_T)\n");
+    "    io::FileOutputStreamOS::write(void const *,size_t)\n");
   return 0;
 }
 
@@ -6838,7 +6770,10 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
 	 { (char *)"delete_InputStream", _wrap_delete_InputStream, METH_VARARGS, (char *)"delete_InputStream(InputStream self)"},
 	 { (char *)"InputStream_available", _wrap_InputStream_available, METH_VARARGS, (char *)"InputStream_available(InputStream self) -> sys::Off_T"},
-	 { (char *)"InputStream_read", _wrap_InputStream_read, METH_VARARGS, (char *)"InputStream_read(InputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"},
+	 { (char *)"InputStream_read", _wrap_InputStream_read, METH_VARARGS, (char *)"\n"
+		"read(void * b, size_t len, bool verifyFullRead=False) -> sys::SSize_T\n"
+		"InputStream_read(InputStream self, void * b, size_t len) -> sys::SSize_T\n"
+		""},
 	 { (char *)"InputStream_readln", _wrap_InputStream_readln, METH_VARARGS, (char *)"InputStream_readln(InputStream self, sys::byte * cStr, sys::Size_T const strLenPlusNullByte) -> sys::SSize_T"},
 	 { (char *)"InputStream_streamTo", _wrap_InputStream_streamTo, METH_VARARGS, (char *)"\n"
 		"streamTo(OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T\n"
@@ -6850,7 +6785,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"OutputStream_write", _wrap_OutputStream_write, METH_VARARGS, (char *)"\n"
 		"write(sys::byte b)\n"
 		"write(std::string const & str)\n"
-		"OutputStream_write(OutputStream self, sys::byte const * b, sys::Size_T len)\n"
+		"OutputStream_write(OutputStream self, void const * buffer, size_t len)\n"
 		""},
 	 { (char *)"OutputStream_flush", _wrap_OutputStream_flush, METH_VARARGS, (char *)"OutputStream_flush(OutputStream self)"},
 	 { (char *)"OutputStream_close", _wrap_OutputStream_close, METH_VARARGS, (char *)"OutputStream_close(OutputStream self)"},
@@ -6862,18 +6797,14 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"Seekable_tell", _wrap_Seekable_tell, METH_VARARGS, (char *)"Seekable_tell(Seekable self) -> sys::Off_T"},
 	 { (char *)"Seekable_swigregister", Seekable_swigregister, METH_VARARGS, NULL},
 	 { (char *)"delete_SeekableInputStream", _wrap_delete_SeekableInputStream, METH_VARARGS, (char *)"delete_SeekableInputStream(SeekableInputStream self)"},
-	 { (char *)"SeekableInputStream_read", _wrap_SeekableInputStream_read, METH_VARARGS, (char *)"SeekableInputStream_read(SeekableInputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"},
 	 { (char *)"SeekableInputStream_streamTo", _wrap_SeekableInputStream_streamTo, METH_VARARGS, (char *)"\n"
 		"streamTo(OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T\n"
 		"SeekableInputStream_streamTo(SeekableInputStream self, OutputStream & soi) -> sys::SSize_T\n"
 		""},
 	 { (char *)"SeekableInputStream_swigregister", SeekableInputStream_swigregister, METH_VARARGS, NULL},
 	 { (char *)"delete_SeekableOutputStream", _wrap_delete_SeekableOutputStream, METH_VARARGS, (char *)"delete_SeekableOutputStream(SeekableOutputStream self)"},
-	 { (char *)"SeekableOutputStream_write", _wrap_SeekableOutputStream_write, METH_VARARGS, (char *)"SeekableOutputStream_write(SeekableOutputStream self, sys::byte const * b, sys::Size_T len)"},
 	 { (char *)"SeekableOutputStream_swigregister", SeekableOutputStream_swigregister, METH_VARARGS, NULL},
 	 { (char *)"delete_SeekableBidirectionalStream", _wrap_delete_SeekableBidirectionalStream, METH_VARARGS, (char *)"delete_SeekableBidirectionalStream(SeekableBidirectionalStream self)"},
-	 { (char *)"SeekableBidirectionalStream_read", _wrap_SeekableBidirectionalStream_read, METH_VARARGS, (char *)"SeekableBidirectionalStream_read(SeekableBidirectionalStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"},
-	 { (char *)"SeekableBidirectionalStream_write", _wrap_SeekableBidirectionalStream_write, METH_VARARGS, (char *)"SeekableBidirectionalStream_write(SeekableBidirectionalStream self, sys::byte const * b, sys::Size_T len)"},
 	 { (char *)"SeekableBidirectionalStream_streamTo", _wrap_SeekableBidirectionalStream_streamTo, METH_VARARGS, (char *)"\n"
 		"streamTo(OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T\n"
 		"SeekableBidirectionalStream_streamTo(SeekableBidirectionalStream self, OutputStream & soi) -> sys::SSize_T\n"
@@ -6886,9 +6817,9 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"StringStream_write", _wrap_StringStream_write, METH_VARARGS, (char *)"\n"
 		"write(sys::byte b)\n"
 		"write(std::string const & str)\n"
-		"StringStream_write(StringStream self, sys::byte const * b, sys::Size_T size)\n"
+		"write(void const * buffer, size_t len)\n"
+		"StringStream_write(StringStream self, void const * buffer, sys::Size_T size)\n"
 		""},
-	 { (char *)"StringStream_read", _wrap_StringStream_read, METH_VARARGS, (char *)"StringStream_read(StringStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"},
 	 { (char *)"StringStream_stream", _wrap_StringStream_stream, METH_VARARGS, (char *)"\n"
 		"stream() -> std::stringstream const\n"
 		"StringStream_stream(StringStream self) -> std::stringstream &\n"
@@ -6900,7 +6831,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"new_NullInputStream", _wrap_new_NullInputStream, METH_VARARGS, (char *)"new_NullInputStream(sys::SSize_T size) -> NullInputStream"},
 	 { (char *)"delete_NullInputStream", _wrap_delete_NullInputStream, METH_VARARGS, (char *)"delete_NullInputStream(NullInputStream self)"},
 	 { (char *)"NullInputStream_available", _wrap_NullInputStream_available, METH_VARARGS, (char *)"NullInputStream_available(NullInputStream self) -> sys::Off_T"},
-	 { (char *)"NullInputStream_read", _wrap_NullInputStream_read, METH_VARARGS, (char *)"NullInputStream_read(NullInputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"},
 	 { (char *)"NullInputStream_readln", _wrap_NullInputStream_readln, METH_VARARGS, (char *)"NullInputStream_readln(NullInputStream self, sys::byte * cStr, sys::Size_T const strLenPlusNullByte) -> sys::SSize_T"},
 	 { (char *)"NullInputStream_streamTo", _wrap_NullInputStream_streamTo, METH_VARARGS, (char *)"\n"
 		"streamTo(OutputStream soi, sys::SSize_T numBytes) -> sys::SSize_T\n"
@@ -6913,7 +6843,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"NullOutputStream_write", _wrap_NullOutputStream_write, METH_VARARGS, (char *)"\n"
 		"write(sys::byte arg2)\n"
 		"write(std::string const & arg2)\n"
-		"NullOutputStream_write(NullOutputStream self, sys::byte const * arg3, sys::Size_T arg4)\n"
+		"NullOutputStream_write(NullOutputStream self, void const * arg3, size_t arg4)\n"
 		""},
 	 { (char *)"NullOutputStream_flush", _wrap_NullOutputStream_flush, METH_VARARGS, (char *)"NullOutputStream_flush(NullOutputStream self)"},
 	 { (char *)"NullOutputStream_swigregister", NullOutputStream_swigregister, METH_VARARGS, NULL},
@@ -6929,7 +6859,6 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FileInputStream_seek", _wrap_FileInputStream_seek, METH_VARARGS, (char *)"FileInputStream_seek(FileInputStream self, sys::Off_T off, io::Seekable::Whence whence) -> sys::Off_T"},
 	 { (char *)"FileInputStream_tell", _wrap_FileInputStream_tell, METH_VARARGS, (char *)"FileInputStream_tell(FileInputStream self) -> sys::Off_T"},
 	 { (char *)"FileInputStream_close", _wrap_FileInputStream_close, METH_VARARGS, (char *)"FileInputStream_close(FileInputStream self)"},
-	 { (char *)"FileInputStream_read", _wrap_FileInputStream_read, METH_VARARGS, (char *)"FileInputStream_read(FileInputStream self, sys::byte * b, sys::Size_T len) -> sys::SSize_T"},
 	 { (char *)"FileInputStream_swigregister", FileInputStream_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_FileOutputStream", _wrap_new_FileOutputStream, METH_VARARGS, (char *)"\n"
 		"FileOutputStreamOS()\n"
@@ -6949,7 +6878,7 @@ static PyMethodDef SwigMethods[] = {
 	 { (char *)"FileOutputStream_write", _wrap_FileOutputStream_write, METH_VARARGS, (char *)"\n"
 		"write(sys::byte b)\n"
 		"write(std::string const & str)\n"
-		"FileOutputStream_write(FileOutputStream self, sys::byte const * b, sys::Size_T len)\n"
+		"FileOutputStream_write(FileOutputStream self, void const * buffer, size_t len)\n"
 		""},
 	 { (char *)"FileOutputStream_swigregister", FileOutputStream_swigregister, METH_VARARGS, NULL},
 	 { NULL, NULL, 0, NULL }

--- a/modules/python/sio.lite/source/generated/sio_lite.py
+++ b/modules/python/sio.lite/source/generated/sio_lite.py
@@ -351,12 +351,9 @@ class StreamReader(coda.coda_io.InputStream):
         return _sio_lite.StreamReader_available(self)
 
 
-    def read(self, *args):
-        """
-        read(StreamReader self, sys::byte * b, size_t size) -> sys::SSize_T
-        read(StreamReader self, long long data, long long size) -> sys::SSize_T
-        """
-        return _sio_lite.StreamReader_read(self, *args)
+    def read(self, data, size):
+        """read(StreamReader self, long long data, long long size) -> sys::SSize_T"""
+        return _sio_lite.StreamReader_read(self, data, size)
 
 StreamReader_swigregister = _sio_lite.StreamReader_swigregister
 StreamReader_swigregister(StreamReader)
@@ -379,7 +376,7 @@ class FileReader(StreamReader, coda.coda_io.Seekable):
     def __init__(self, *args):
         """
         __init__(sio::lite::FileReader self) -> FileReader
-        __init__(sio::lite::FileReader self, std::string file) -> FileReader
+        __init__(sio::lite::FileReader self, std::string const & file) -> FileReader
         __init__(sio::lite::FileReader self, io::FileInputStream * arg2, bool adopt=False) -> FileReader
         __init__(sio::lite::FileReader self, io::FileInputStream * arg2) -> FileReader
         """

--- a/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
+++ b/modules/python/sio.lite/source/generated/sio_lite_wrap.cxx
@@ -3726,7 +3726,7 @@ SWIGINTERN void sio_lite_FileWriter_write__SWIG_6(sio::lite::FileWriter *self,si
         const void* buffer = reinterpret_cast<const void*>(data);
         self->write(header, buffer);
     }
-SWIGINTERN sys::SSize_T sio_lite_StreamReader_read__SWIG_1(sio::lite::StreamReader *self,long long data,long long size){
+SWIGINTERN sys::SSize_T sio_lite_StreamReader_read(sio::lite::StreamReader *self,long long data,long long size){
         sys::byte* buffer = reinterpret_cast<sys::byte*>(data);
         return self->read(buffer, size);
     }
@@ -7679,86 +7679,7 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
-  PyObject *resultobj = 0;
-  sio::lite::StreamReader *arg1 = (sio::lite::StreamReader *) 0 ;
-  sys::byte *arg2 = (sys::byte *) 0 ;
-  size_t arg3 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  int res2 ;
-  char *buf2 = 0 ;
-  int alloc2 = 0 ;
-  size_t val3 ;
-  int ecode3 = 0 ;
-  PyObject * obj0 = 0 ;
-  PyObject * obj1 = 0 ;
-  PyObject * obj2 = 0 ;
-  sys::SSize_T result;
-  
-  if (!PyArg_ParseTuple(args,(char *)"OOO:StreamReader_read",&obj0,&obj1,&obj2)) SWIG_fail;
-  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_sio__lite__StreamReader, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StreamReader_read" "', argument " "1"" of type '" "sio::lite::StreamReader *""'"); 
-  }
-  arg1 = reinterpret_cast< sio::lite::StreamReader * >(argp1);
-  res2 = SWIG_AsCharPtrAndSize(obj1, &buf2, NULL, &alloc2);
-  if (!SWIG_IsOK(res2)) {
-    SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "StreamReader_read" "', argument " "2"" of type '" "sys::byte *""'");
-  }
-  arg2 = reinterpret_cast< sys::byte * >(buf2);
-  ecode3 = SWIG_AsVal_size_t(obj2, &val3);
-  if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "StreamReader_read" "', argument " "3"" of type '" "size_t""'");
-  } 
-  arg3 = static_cast< size_t >(val3);
-  {
-    try
-    {
-      result = (arg1)->read(arg2,arg3);
-    } 
-    catch (const std::exception& e)
-    {
-      if (!PyErr_Occurred())
-      {
-        PyErr_SetString(PyExc_RuntimeError, e.what());
-      }
-    }
-    catch (const except::Exception& e)
-    {
-      if (!PyErr_Occurred())
-      {
-        PyErr_SetString(PyExc_RuntimeError, e.getMessage().c_str());
-      }
-    }
-    catch (...)
-    {
-      if (!PyErr_Occurred())
-      {
-        PyErr_SetString(PyExc_RuntimeError, "Unknown error");
-      }
-    }
-    if (PyErr_Occurred())
-    {
-      SWIG_fail;
-    }
-  }
-  {
-#if PY_VERSION_HEX >= 0x03000000
-    resultobj = PyLong_FromSsize_t(result);
-#else
-    resultobj = PyInt_FromSsize_t(result);
-#endif
-  }
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return resultobj;
-fail:
-  if (alloc2 == SWIG_NEWOBJ) delete[] buf2;
-  return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+SWIGINTERN PyObject *_wrap_StreamReader_read(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   sio::lite::StreamReader *arg1 = (sio::lite::StreamReader *) 0 ;
   long long arg2 ;
@@ -7793,7 +7714,7 @@ SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(se
   {
     try
     {
-      result = sio_lite_StreamReader_read__SWIG_1(arg1,arg2,arg3);
+      result = sio_lite_StreamReader_read(arg1,arg2,arg3);
     } 
     catch (const std::exception& e)
     {
@@ -7831,68 +7752,6 @@ SWIGINTERN PyObject *_wrap_StreamReader_read__SWIG_1(PyObject *SWIGUNUSEDPARM(se
   return resultobj;
 fail:
   return NULL;
-}
-
-
-SWIGINTERN PyObject *_wrap_StreamReader_read(PyObject *self, PyObject *args) {
-  Py_ssize_t argc;
-  PyObject *argv[4] = {
-    0
-  };
-  Py_ssize_t ii;
-  
-  if (!PyTuple_Check(args)) SWIG_fail;
-  argc = args ? PyObject_Length(args) : 0;
-  for (ii = 0; (ii < 3) && (ii < argc); ii++) {
-    argv[ii] = PyTuple_GET_ITEM(args,ii);
-  }
-  if (argc == 3) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_sio__lite__StreamReader, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      {
-        int res = SWIG_AsVal_long_SS_long(argv[1], NULL);
-        _v = SWIG_CheckState(res);
-      }
-      if (_v) {
-        {
-          int res = SWIG_AsVal_long_SS_long(argv[2], NULL);
-          _v = SWIG_CheckState(res);
-        }
-        if (_v) {
-          return _wrap_StreamReader_read__SWIG_1(self, args);
-        }
-      }
-    }
-  }
-  if (argc == 3) {
-    int _v;
-    void *vptr = 0;
-    int res = SWIG_ConvertPtr(argv[0], &vptr, SWIGTYPE_p_sio__lite__StreamReader, 0);
-    _v = SWIG_CheckState(res);
-    if (_v) {
-      int res = SWIG_AsCharPtrAndSize(argv[1], 0, NULL, 0);
-      _v = SWIG_CheckState(res);
-      if (_v) {
-        {
-          int res = SWIG_AsVal_size_t(argv[2], NULL);
-          _v = SWIG_CheckState(res);
-        }
-        if (_v) {
-          return _wrap_StreamReader_read__SWIG_0(self, args);
-        }
-      }
-    }
-  }
-  
-fail:
-  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'StreamReader_read'.\n"
-    "  Possible C/C++ prototypes are:\n"
-    "    sio::lite::StreamReader::read(sys::byte *,size_t)\n"
-    "    sio::lite::StreamReader::read(long long,long long)\n");
-  return 0;
 }
 
 
@@ -7999,24 +7858,27 @@ fail:
 
 SWIGINTERN PyObject *_wrap_new_FileReader__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
-  std::string arg1 ;
+  std::string *arg1 = 0 ;
+  int res1 = SWIG_OLDOBJ ;
   PyObject * obj0 = 0 ;
   sio::lite::FileReader *result = 0 ;
   
   if (!PyArg_ParseTuple(args,(char *)"O:new_FileReader",&obj0)) SWIG_fail;
   {
     std::string *ptr = (std::string *)0;
-    int res = SWIG_AsPtr_std_string(obj0, &ptr);
-    if (!SWIG_IsOK(res) || !ptr) {
-      SWIG_exception_fail(SWIG_ArgError((ptr ? res : SWIG_TypeError)), "in method '" "new_FileReader" "', argument " "1"" of type '" "std::string""'"); 
+    res1 = SWIG_AsPtr_std_string(obj0, &ptr);
+    if (!SWIG_IsOK(res1)) {
+      SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "new_FileReader" "', argument " "1"" of type '" "std::string const &""'"); 
     }
-    arg1 = *ptr;
-    if (SWIG_IsNewObj(res)) delete ptr;
+    if (!ptr) {
+      SWIG_exception_fail(SWIG_ValueError, "invalid null reference " "in method '" "new_FileReader" "', argument " "1"" of type '" "std::string const &""'"); 
+    }
+    arg1 = ptr;
   }
   {
     try
     {
-      result = (sio::lite::FileReader *)new sio::lite::FileReader(arg1);
+      result = (sio::lite::FileReader *)new sio::lite::FileReader((std::string const &)*arg1);
     } 
     catch (const std::exception& e)
     {
@@ -8045,8 +7907,10 @@ SWIGINTERN PyObject *_wrap_new_FileReader__SWIG_1(PyObject *SWIGUNUSEDPARM(self)
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_sio__lite__FileReader, SWIG_POINTER_NEW |  0 );
+  if (SWIG_IsNewObj(res1)) delete arg1;
   return resultobj;
 fail:
+  if (SWIG_IsNewObj(res1)) delete arg1;
   return NULL;
 }
 
@@ -8216,7 +8080,7 @@ fail:
   SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_FileReader'.\n"
     "  Possible C/C++ prototypes are:\n"
     "    sio::lite::FileReader::FileReader()\n"
-    "    sio::lite::FileReader::FileReader(std::string)\n"
+    "    sio::lite::FileReader::FileReader(std::string const &)\n"
     "    sio::lite::FileReader::FileReader(io::FileInputStream *,bool)\n"
     "    sio::lite::FileReader::FileReader(io::FileInputStream *)\n");
   return 0;
@@ -8488,15 +8352,12 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { (char *)"StreamReader_readHeader", _wrap_StreamReader_readHeader, METH_VARARGS, (char *)"StreamReader_readHeader(StreamReader self) -> FileHeader"},
 	 { (char *)"StreamReader_available", _wrap_StreamReader_available, METH_VARARGS, (char *)"StreamReader_available(StreamReader self) -> sys::Off_T"},
-	 { (char *)"StreamReader_read", _wrap_StreamReader_read, METH_VARARGS, (char *)"\n"
-		"read(sys::byte * b, size_t size) -> sys::SSize_T\n"
-		"StreamReader_read(StreamReader self, long long data, long long size) -> sys::SSize_T\n"
-		""},
+	 { (char *)"StreamReader_read", _wrap_StreamReader_read, METH_VARARGS, (char *)"StreamReader_read(StreamReader self, long long data, long long size) -> sys::SSize_T"},
 	 { (char *)"StreamReader_swigregister", StreamReader_swigregister, METH_VARARGS, NULL},
 	 { (char *)"delete_FileReader", _wrap_delete_FileReader, METH_VARARGS, (char *)"delete_FileReader(FileReader self)"},
 	 { (char *)"new_FileReader", _wrap_new_FileReader, METH_VARARGS, (char *)"\n"
 		"FileReader()\n"
-		"FileReader(std::string file)\n"
+		"FileReader(std::string const & file)\n"
 		"FileReader(io::FileInputStream * arg2, bool adopt=False)\n"
 		"new_FileReader(io::FileInputStream * arg2) -> FileReader\n"
 		""},


### PR DESCRIPTION
1. It is annoying to have to cast every buffer to a `sys::byte*` when reading and writing using `io::InputStream` and `io::OutputStream`.  Made this a `void*`.
2. Usually when you read, you really want all the bytes you asked for.  Added a new optional bool for if you want to throw on a short read.
3. Added some convenience functions to read the contents of a file in one shot.

Unfortunately 1 and 2 required touching a lot of code.