### PR TITLE
SharedPtr C++11 Update

### DIFF
--- a/modules/c++/mem/include/mem/SharedPtr.h
+++ b/modules/c++/mem/include/mem/SharedPtr.h
@@ -2,7 +2,7 @@
  * This file is part of mem-c++
  * =========================================================================
  *
- * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
  *
  * mem-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -23,162 +23,12 @@
 #ifndef __MEM_SHARED_PTR_H__
 #define __MEM_SHARED_PTR_H__
 
-#include <memory>
-#include <cstddef>
+#include <sys/sys_config.h>
 
-#include <sys/AtomicCounter.h>
-
-namespace mem
-{
-/*!
- *  \class SharedPtr
- *  \brief This class provides RAII for object allocations via new.
- *         Additionally, it uses thread-safe reference counting so that the
- *         underlying pointer can be shared among multiple objects.  When the
- *         last SharedPtr goes out of scope, the underlying pointer is
- *         deleted.
- */
-template <class T>
-class SharedPtr
-{
-public:
-    explicit SharedPtr(T* ptr = NULL) :
-        mPtr(ptr)
-    {
-        // Initially we have a reference count of 1
-        // In the constructor, we take ownership of the pointer no matter
-        // what, so temporarily wrap it in an auto_ptr in case creating the
-        // atomic counter throws
-        std::auto_ptr<T> scopedPtr(ptr);
-        mRefCtr = new sys::AtomicCounter(1);
-        scopedPtr.release();
-    }
-
-    explicit SharedPtr(std::auto_ptr<T> ptr) :
-        mPtr(ptr.get())
-    {
-        // Initially we have a reference count of 1
-        // If this throws, the auto_ptr will clean up the input pointer
-        // for us
-        mRefCtr = new sys::AtomicCounter(1);
-
-        // We now own the pointer
-        ptr.release();
-    }
-
-    template <typename OtherT>
-    explicit SharedPtr(std::auto_ptr<OtherT> ptr) :
-        mPtr(ptr.get())
-    {
-        // Initially we have a reference count of 1
-        // If this throws, the auto_ptr will clean up the input pointer
-        // for us
-        mRefCtr = new sys::AtomicCounter(1);
-
-        // We now own the pointer
-        ptr.release();
-    }
-
-    SharedPtr(const SharedPtr& rhs) :
-        mRefCtr(rhs.mRefCtr),
-        mPtr(rhs.mPtr)
-    {
-        mRefCtr->increment();
-    }
-
-    template <typename OtherT>
-    SharedPtr(const SharedPtr<OtherT>& rhs) :
-        mRefCtr(rhs.mRefCtr),
-        mPtr(rhs.mPtr)
-    {
-        mRefCtr->increment();
-    }
-
-    ~SharedPtr()
-    {
-        if (mRefCtr->decrementThenGet() == 0)
-        {
-            delete mRefCtr;
-            delete mPtr;
-        }
-    }
-
-    const SharedPtr&
-    operator=(const SharedPtr& rhs)
-    {
-        if (this != &rhs)
-        {
-            if (mRefCtr->decrementThenGet() == 0)
-            {
-                // We were holding the last copy of this data prior to this
-                // assignment - need to clean it up
-                delete mRefCtr;
-                delete mPtr;
-            }
-
-            mRefCtr = rhs.mRefCtr;
-            mPtr = rhs.mPtr;
-            mRefCtr->increment();
-        }
-
-        return *this;
-    }
-
-    T* get() const
-    {
-        return mPtr;
-    }
-
-    T& operator*() const
-    {
-        return *mPtr;
-    }
-
-    T* operator->() const
-    {
-        return mPtr;
-    }
-
-    sys::AtomicCounter::ValueType getCount() const
-    {
-        return mRefCtr->get();
-    }
-
-    void reset(std::auto_ptr<T> scopedPtr)
-    {
-        // NOTE: We need to create newRefCtr on the side before decrementing
-        //       mRefCtr. This way, we can provide the strong exception
-        //       guarantee (i.e. the operation either succeeds or throws - the
-        //       underlying object is always in a good state).
-        sys::AtomicCounter* const newRefCtr = new sys::AtomicCounter(1);
-
-        if (mRefCtr->decrementThenGet() == 0)
-        {
-            // We were holding the last copy of this data prior to this
-            // reset - need to clean up
-            delete mRefCtr;
-            delete mPtr;
-        }
-
-        mRefCtr = newRefCtr;
-        mPtr = scopedPtr.release();
-    }
-
-    void reset(T* ptr = NULL)
-    {
-        // We take ownership of the pointer no matter what, so
-        // temporarily wrap it in an auto_ptr in case creating
-        // the atomic counter throws in the underlying method.
-        reset(std::auto_ptr<T>(ptr));
-    }
-
-    // This allows derived classes to be used for construction/assignment
-    template <class OtherT> friend class SharedPtr;
-
-private:
-    sys::AtomicCounter* mRefCtr;
-    T*                  mPtr;
-};
-}
+#ifdef __CODA_CPP11
+#include <mem/SharedPtrCpp11.h>
+#else
+#include <mem/SharedPtrLegacy.h>
+#endif
 
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -1,0 +1,78 @@
+/* =========================================================================
+ * This file is part of mem-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ *
+ * mem-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __MEM_SHARED_PTR_CPP_11_H__
+#define __MEM_SHARED_PTR_CPP_11_H__
+
+#include <memory>
+
+namespace mem
+{
+/*!
+ *  \class SharedPtr
+ *  \brief This is a derived class of std::shared_ptr. The purpose of this
+ *         class is to provide backwards compatibility in systems that do
+ *         not have C++11 support.
+ *         Because this inherits from std::shared_ptr it can be directly
+ *         passed into interfaces requiring std::shared_ptr or legacy
+ *         interfaces.
+ *         For future work, prefer std::shared_ptr when possible.
+ *
+ *         WARNING: std::shared_ptr<T>* foo = new SharedPtr<T> will leak!
+ */
+template <class T>
+class SharedPtr : public std::shared_ptr<T>
+{
+public:
+    SharedPtr() = default;
+
+    using std::shared_ptr<T>::shared_ptr;
+
+    using std::shared_ptr<T>::reset;
+
+    // The base class only handles auto_ptr<T>&&
+    explicit SharedPtr(std::auto_ptr<T> ptr) :
+        std::shared_ptr<T>(ptr.release())
+    {
+    }
+
+    // The base class only handles auto_ptr<T>&&
+    template <typename OtherT>
+    explicit SharedPtr(std::auto_ptr<OtherT> ptr) :
+        std::shared_ptr<T>(ptr.release())
+    {
+    }
+
+    void reset(std::auto_ptr<T> scopedPtr)
+    {
+        std::shared_ptr<T>::reset(scopedPtr.release());
+    }
+
+    // Implemented to support the legacy SharedPtr. Prefer use_count.
+    long getCount() const
+    {
+        return std::shared_ptr<T>::use_count();
+    }
+};
+}
+
+#endif

--- a/modules/c++/mem/include/mem/SharedPtrLegacy.h
+++ b/modules/c++/mem/include/mem/SharedPtrLegacy.h
@@ -1,0 +1,184 @@
+/* =========================================================================
+ * This file is part of mem-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * mem-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __MEM_SHARED_PTR_LEGACY_H__
+#define __MEM_SHARED_PTR_LEGACY_H__
+
+#include <memory>
+#include <cstddef>
+
+#include <sys/AtomicCounter.h>
+
+namespace mem
+{
+/*!
+ *  \class SharedPtr
+ *  \brief This class provides RAII for object allocations via new.
+ *         Additionally, it uses thread-safe reference counting so that the
+ *         underlying pointer can be shared among multiple objects.  When the
+ *         last SharedPtr goes out of scope, the underlying pointer is
+ *         deleted.
+ */
+template <class T>
+class SharedPtr
+{
+public:
+    explicit SharedPtr(T* ptr = NULL) :
+        mPtr(ptr)
+    {
+        // Initially we have a reference count of 1
+        // In the constructor, we take ownership of the pointer no matter
+        // what, so temporarily wrap it in an auto_ptr in case creating the
+        // atomic counter throws
+        std::auto_ptr<T> scopedPtr(ptr);
+        mRefCtr = new sys::AtomicCounter(1);
+        scopedPtr.release();
+    }
+
+    explicit SharedPtr(std::auto_ptr<T> ptr) :
+        mPtr(ptr.get())
+    {
+        // Initially we have a reference count of 1
+        // If this throws, the auto_ptr will clean up the input pointer
+        // for us
+        mRefCtr = new sys::AtomicCounter(1);
+
+        // We now own the pointer
+        ptr.release();
+    }
+
+    template <typename OtherT>
+    explicit SharedPtr(std::auto_ptr<OtherT> ptr) :
+        mPtr(ptr.get())
+    {
+        // Initially we have a reference count of 1
+        // If this throws, the auto_ptr will clean up the input pointer
+        // for us
+        mRefCtr = new sys::AtomicCounter(1);
+
+        // We now own the pointer
+        ptr.release();
+    }
+
+    SharedPtr(const SharedPtr& rhs) :
+        mRefCtr(rhs.mRefCtr),
+        mPtr(rhs.mPtr)
+    {
+        mRefCtr->increment();
+    }
+
+    template <typename OtherT>
+    SharedPtr(const SharedPtr<OtherT>& rhs) :
+        mRefCtr(rhs.mRefCtr),
+        mPtr(rhs.mPtr)
+    {
+        mRefCtr->increment();
+    }
+
+    ~SharedPtr()
+    {
+        if (mRefCtr->decrementThenGet() == 0)
+        {
+            delete mRefCtr;
+            delete mPtr;
+        }
+    }
+
+    const SharedPtr&
+    operator=(const SharedPtr& rhs)
+    {
+        if (this != &rhs)
+        {
+            if (mRefCtr->decrementThenGet() == 0)
+            {
+                // We were holding the last copy of this data prior to this
+                // assignment - need to clean it up
+                delete mRefCtr;
+                delete mPtr;
+            }
+
+            mRefCtr = rhs.mRefCtr;
+            mPtr = rhs.mPtr;
+            mRefCtr->increment();
+        }
+
+        return *this;
+    }
+
+    T* get() const
+    {
+        return mPtr;
+    }
+
+    T& operator*() const
+    {
+        return *mPtr;
+    }
+
+    T* operator->() const
+    {
+        return mPtr;
+    }
+
+    sys::AtomicCounter::ValueType getCount() const
+    {
+        return mRefCtr->get();
+    }
+
+    void reset(std::auto_ptr<T> scopedPtr)
+    {
+        // NOTE: We need to create newRefCtr on the side before decrementing
+        //       mRefCtr. This way, we can provide the strong exception
+        //       guarantee (i.e. the operation either succeeds or throws - the
+        //       underlying object is always in a good state).
+        sys::AtomicCounter* const newRefCtr = new sys::AtomicCounter(1);
+
+        if (mRefCtr->decrementThenGet() == 0)
+        {
+            // We were holding the last copy of this data prior to this
+            // reset - need to clean up
+            delete mRefCtr;
+            delete mPtr;
+        }
+
+        mRefCtr = newRefCtr;
+        mPtr = scopedPtr.release();
+    }
+
+    void reset(T* ptr = NULL)
+    {
+        // We take ownership of the pointer no matter what, so
+        // temporarily wrap it in an auto_ptr in case creating
+        // the atomic counter throws in the underlying method.
+        reset(std::auto_ptr<T>(ptr));
+    }
+
+    // This allows derived classes to be used for construction/assignment
+    template <class OtherT> friend class SharedPtr;
+
+private:
+    sys::AtomicCounter* mRefCtr;
+    T*                  mPtr;
+};
+}
+
+#endif

--- a/modules/c++/mem/unittests/test_shared_ptr.cpp
+++ b/modules/c++/mem/unittests/test_shared_ptr.cpp
@@ -20,6 +20,7 @@
  *
  */
 
+#include <sys/sys_config.h>
 #include <mem/SharedPtr.h>
 
 #include "TestCase.h"
@@ -62,6 +63,13 @@ struct BarPtrTest : public FooPtrTest
 
     mem::SharedPtr<Bar> mBarPtr;
 };
+
+#ifdef __CODA_CPP11
+size_t cpp11Function(std::shared_ptr<Foo> foo)
+{
+    return foo->mVal;
+}
+#endif
 
 TEST_CASE(testNullCopying)
 {
@@ -249,6 +257,21 @@ TEST_CASE(testCasting)
         TEST_ASSERT_EQ(barPtr.getCount(), 3);
     }
 }
+
+#ifdef __CODA_CPP11
+TEST_CASE(testStdSharedPtr)
+{
+    const mem::SharedPtr<Foo> fooLegacy(new Foo(123));
+    std::shared_ptr<Foo> fooCtor(fooLegacy);
+    TEST_ASSERT_EQ(fooLegacy.get(), fooCtor.get());
+
+    std::shared_ptr<Foo> fooAssign = fooLegacy;
+    TEST_ASSERT_EQ(fooLegacy.get(), fooAssign.get());
+
+    TEST_ASSERT_EQ(cpp11Function(fooLegacy), 123);
+}
+#endif
+
 }
 
 int main(int, char**)
@@ -260,6 +283,9 @@ int main(int, char**)
    TEST_CHECK(testAssigning);
    TEST_CHECK(testSyntax);
    TEST_CHECK(testCasting);
+#ifdef __CODA_CPP11
+   TEST_CHECK(testStdSharedPtr);
+#endif
 
    return 0;
 }

--- a/modules/c++/mt/include/mt/BalancedRunnable1D.h
+++ b/modules/c++/mt/include/mt/BalancedRunnable1D.h
@@ -27,6 +27,7 @@
 
 #include <sys/Conf.h>
 #include <sys/Runnable.h>
+#include <sys/AtomicCounter.h>
 #include <except/Exception.h>
 #include <mt/ThreadPlanner.h>
 #include <mt/ThreadGroup.h>

--- a/modules/c++/mt/include/mt/WorkSharingBalancedRunnable1D.h
+++ b/modules/c++/mt/include/mt/WorkSharingBalancedRunnable1D.h
@@ -27,6 +27,7 @@
 
 #include <sys/Conf.h>
 #include <sys/Runnable.h>
+#include <sys/AtomicCounter.h>
 #include <except/Exception.h>
 #include <mt/ThreadPlanner.h>
 #include <mt/ThreadGroup.h>


### PR DESCRIPTION
C++11 mem::SharedPtr now inherits from std::shared_ptr.
The unittest has been updated to test C++11 support.