### PR TITLE
Fix memory leak on error reading

### DIFF
--- a/modules/c++/xml.lite/source/XMLReaderXerces.cpp
+++ b/modules/c++/xml.lite/source/XMLReaderXerces.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "xml/lite/XMLReader.h"
+#include <mem/ScopedArray.h>
 
 #if defined(USE_XERCES)
 
@@ -39,18 +40,16 @@ void xml::lite::XMLReaderXerces::parse(io::InputStream & is, int size)
     {
         throw xml::lite::XMLParseException(Ctxt("No stream available"));
     }
-    sys::byte* buffer = new sys::byte[available];
-    oss.read(buffer, available);
+    mem::ScopedArray<sys::byte> buffer(new sys::byte[available]);
+    oss.read(buffer.get(), available);
 
     // Adopt my buffer, and delete it for me
-    MemBufInputSource memBuffer((const unsigned char *)buffer,
+    MemBufInputSource memBuffer((const unsigned char *)buffer.get(),
                                 available,
                                 XMLReaderXerces::MEM_BUFFER_ID(),
                                 false);
 
     mNative->parse(memBuffer);
-
-    delete [] buffer;
 }
 
 // This function creates the parser

--- a/modules/c++/xml.lite/source/XMLReaderXerces.cpp
+++ b/modules/c++/xml.lite/source/XMLReaderXerces.cpp
@@ -43,7 +43,7 @@ void xml::lite::XMLReaderXerces::parse(io::InputStream & is, int size)
     mem::ScopedArray<sys::byte> buffer(new sys::byte[available]);
     oss.read(buffer.get(), available);
 
-    // Adopt my buffer, and delete it for me
+    // Does not take ownership
     MemBufInputSource memBuffer((const unsigned char *)buffer.get(),
                                 available,
                                 XMLReaderXerces::MEM_BUFFER_ID(),

--- a/modules/c++/xml.lite/wscript
+++ b/modules/c++/xml.lite/wscript
@@ -1,7 +1,7 @@
 NAME            = 'xml.lite'
 MAINTAINER      = 'jmrandol@users.sourceforge.net'
 VERSION         = '1.2'
-MODULE_DEPS     = 'io mt logging'
+MODULE_DEPS     = 'io mem mt logging'
 USELIB_CHECK    = 'XML'
 TEST_FILTER     = 'MMParserTest1.cpp MinidomParserTest2.cpp'
 TEST_DEPS       = 'cli'
@@ -20,8 +20,8 @@ def configure(conf):
             conf.define('USE_LIBXML', '', quote=False)
         elif Options.options.xml_layer == 'xerces':
             conf.define('USE_XERCES', '', quote=False)
-        
+
     writeConfig(conf, xml_lite_callback, NAME)
-    
+
 def build(bld):
     bld.module(**globals())


### PR DESCRIPTION
This memory leak triggers when `MinidomParser.parse()` throws, which I forced by giving it non-xml data. I'm uncertain if it's the same one they were seeing.

I agree that the destructor logic looks correct...