### PR TITLE
Allow io to read from bytes object in Python3

### DIFF
--- a/modules/python/except/source/generated/coda_except.py
+++ b/modules/python/except/source/generated/coda_except.py
@@ -104,7 +104,7 @@ class Context(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, Context, name)
     __repr__ = _swig_repr
 
-    def __init__(self, file, line, func, time, message):
+    def __init__(self, file: 'std::string const &', line: 'int', func: 'std::string const &', time: 'std::string const &', message: 'std::string const &'):
         """__init__(except::Context self, std::string const & file, int line, std::string const & func, std::string const & time, std::string const & message) -> Context"""
         this = _coda_except.new_Context(file, line, func, time, message)
         try:
@@ -112,27 +112,27 @@ class Context(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def getMessage(self):
+    def getMessage(self) -> "std::string const &":
         """getMessage(Context self) -> std::string const &"""
         return _coda_except.Context_getMessage(self)
 
 
-    def getTime(self):
+    def getTime(self) -> "std::string const &":
         """getTime(Context self) -> std::string const &"""
         return _coda_except.Context_getTime(self)
 
 
-    def getFunction(self):
+    def getFunction(self) -> "std::string const &":
         """getFunction(Context self) -> std::string const &"""
         return _coda_except.Context_getFunction(self)
 
 
-    def getFile(self):
+    def getFile(self) -> "std::string const &":
         """getFile(Context self) -> std::string const &"""
         return _coda_except.Context_getFile(self)
 
 
-    def getLine(self):
+    def getLine(self) -> "int":
         """getLine(Context self) -> int"""
         return _coda_except.Context_getLine(self)
 
@@ -162,7 +162,7 @@ Context_swigregister = _coda_except.Context_swigregister
 Context_swigregister(Context)
 
 
-def __lshift__(os, c):
+def __lshift__(os: 'std::ostream &', c: 'Context') -> "std::ostream &":
     """__lshift__(std::ostream & os, Context c) -> std::ostream &"""
     return _coda_except.__lshift__(os, c)
 class Throwable(_object):
@@ -189,12 +189,12 @@ class Throwable(_object):
     __swig_destroy__ = _coda_except.delete_Throwable
     __del__ = lambda self: None
 
-    def getMessage(self):
+    def getMessage(self) -> "std::string":
         """getMessage(Throwable self) -> std::string"""
         return _coda_except.Throwable_getMessage(self)
 
 
-    def getTrace(self, *args):
+    def getTrace(self, *args) -> "Trace &":
         """
         getTrace(Throwable self) -> Trace const
         getTrace(Throwable self) -> Trace &
@@ -202,12 +202,12 @@ class Throwable(_object):
         return _coda_except.Throwable_getTrace(self, *args)
 
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(Throwable self) -> std::string"""
         return _coda_except.Throwable_getType(self)
 
 
-    def toString(self):
+    def toString(self) -> "std::string":
         """toString(Throwable self) -> std::string"""
         return _coda_except.Throwable_toString(self)
 
@@ -242,7 +242,7 @@ class Exception(Throwable):
     __swig_destroy__ = _coda_except.delete_Exception
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(Exception self) -> std::string"""
         return _coda_except.Exception_getType(self)
 
@@ -277,7 +277,7 @@ class IOException(Exception):
     __swig_destroy__ = _coda_except.delete_IOException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(IOException self) -> std::string"""
         return _coda_except.IOException_getType(self)
 
@@ -312,7 +312,7 @@ class FileNotFoundException(IOException):
     __swig_destroy__ = _coda_except.delete_FileNotFoundException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(FileNotFoundException self) -> std::string"""
         return _coda_except.FileNotFoundException_getType(self)
 
@@ -347,7 +347,7 @@ class BadCastException(Exception):
     __swig_destroy__ = _coda_except.delete_BadCastException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(BadCastException self) -> std::string"""
         return _coda_except.BadCastException_getType(self)
 
@@ -382,7 +382,7 @@ class InvalidFormatException(Exception):
     __swig_destroy__ = _coda_except.delete_InvalidFormatException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(InvalidFormatException self) -> std::string"""
         return _coda_except.InvalidFormatException_getType(self)
 
@@ -417,7 +417,7 @@ class IndexOutOfRangeException(Exception):
     __swig_destroy__ = _coda_except.delete_IndexOutOfRangeException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(IndexOutOfRangeException self) -> std::string"""
         return _coda_except.IndexOutOfRangeException_getType(self)
 
@@ -452,7 +452,7 @@ class OutOfMemoryException(Exception):
     __swig_destroy__ = _coda_except.delete_OutOfMemoryException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(OutOfMemoryException self) -> std::string"""
         return _coda_except.OutOfMemoryException_getType(self)
 
@@ -487,7 +487,7 @@ class NullPointerReferenceException(Exception):
     __swig_destroy__ = _coda_except.delete_NullPointerReferenceException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(NullPointerReferenceException self) -> std::string"""
         return _coda_except.NullPointerReferenceException_getType(self)
 
@@ -522,7 +522,7 @@ class NoSuchKeyException(Exception):
     __swig_destroy__ = _coda_except.delete_NoSuchKeyException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(NoSuchKeyException self) -> std::string"""
         return _coda_except.NoSuchKeyException_getType(self)
 
@@ -557,7 +557,7 @@ class NoSuchReferenceException(Exception):
     __swig_destroy__ = _coda_except.delete_NoSuchReferenceException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(NoSuchReferenceException self) -> std::string"""
         return _coda_except.NoSuchReferenceException_getType(self)
 
@@ -592,7 +592,7 @@ class KeyAlreadyExistsException(Exception):
     __swig_destroy__ = _coda_except.delete_KeyAlreadyExistsException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(KeyAlreadyExistsException self) -> std::string"""
         return _coda_except.KeyAlreadyExistsException_getType(self)
 
@@ -627,7 +627,7 @@ class NotImplementedException(Exception):
     __swig_destroy__ = _coda_except.delete_NotImplementedException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(NotImplementedException self) -> std::string"""
         return _coda_except.NotImplementedException_getType(self)
 
@@ -662,7 +662,7 @@ class InvalidArgumentException(Exception):
     __swig_destroy__ = _coda_except.delete_InvalidArgumentException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(InvalidArgumentException self) -> std::string"""
         return _coda_except.InvalidArgumentException_getType(self)
 
@@ -697,7 +697,7 @@ class SerializationException(IOException):
     __swig_destroy__ = _coda_except.delete_SerializationException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(SerializationException self) -> std::string"""
         return _coda_except.SerializationException_getType(self)
 
@@ -732,7 +732,7 @@ class ParseException(IOException):
     __swig_destroy__ = _coda_except.delete_ParseException
     __del__ = lambda self: None
 
-    def getType(self):
+    def getType(self) -> "std::string":
         """getType(ParseException self) -> std::string"""
         return _coda_except.ParseException_getType(self)
 

--- a/modules/python/io/source/generated/coda_io.py
+++ b/modules/python/io/source/generated/coda_io.py
@@ -112,12 +112,12 @@ class InputStream(_object):
     __swig_destroy__ = _coda_io.delete_InputStream
     __del__ = lambda self: None
 
-    def available(self):
+    def available(self) -> "sys::Off_T":
         """available(InputStream self) -> sys::Off_T"""
         return _coda_io.InputStream_available(self)
 
 
-    def read(self, buffer, len, verifyFullRead=False):
+    def read(self, buffer: 'void *', len: 'size_t', verifyFullRead: 'bool'=False) -> "sys::SSize_T":
         """
         read(InputStream self, void * buffer, size_t len, bool verifyFullRead=False) -> sys::SSize_T
         read(InputStream self, void * buffer, size_t len) -> sys::SSize_T
@@ -125,12 +125,12 @@ class InputStream(_object):
         return _coda_io.InputStream_read(self, buffer, len, verifyFullRead)
 
 
-    def readln(self, cStr, strLenPlusNullByte):
+    def readln(self, cStr: 'sys::byte *', strLenPlusNullByte: 'sys::Size_T const') -> "sys::SSize_T":
         """readln(InputStream self, sys::byte * cStr, sys::Size_T const strLenPlusNullByte) -> sys::SSize_T"""
         return _coda_io.InputStream_readln(self, cStr, strLenPlusNullByte)
 
 
-    def streamTo(self, *args):
+    def streamTo(self, *args) -> "sys::SSize_T":
         """
         streamTo(InputStream self, OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T
         streamTo(InputStream self, OutputStream & soi) -> sys::SSize_T
@@ -154,12 +154,12 @@ class OutputStream(_object):
     __swig_destroy__ = _coda_io.delete_OutputStream
     __del__ = lambda self: None
 
-    def writeln(self, str):
+    def writeln(self, str: 'std::string const &') -> "void":
         """writeln(OutputStream self, std::string const & str)"""
         return _coda_io.OutputStream_writeln(self, str)
 
 
-    def write(self, *args):
+    def write(self, *args) -> "void":
         """
         write(OutputStream self, sys::byte b)
         write(OutputStream self, std::string const & str)
@@ -168,12 +168,12 @@ class OutputStream(_object):
         return _coda_io.OutputStream_write(self, *args)
 
 
-    def flush(self):
+    def flush(self) -> "void":
         """flush(OutputStream self)"""
         return _coda_io.OutputStream_flush(self)
 
 
-    def close(self):
+    def close(self) -> "void":
         """close(OutputStream self)"""
         return _coda_io.OutputStream_close(self)
 
@@ -217,12 +217,12 @@ class Seekable(_object):
     START = _coda_io.Seekable_START
     END = _coda_io.Seekable_END
 
-    def seek(self, offset, whence):
+    def seek(self, offset: 'sys::Off_T', whence: 'io::Seekable::Whence') -> "sys::Off_T":
         """seek(Seekable self, sys::Off_T offset, io::Seekable::Whence whence) -> sys::Off_T"""
         return _coda_io.Seekable_seek(self, offset, whence)
 
 
-    def tell(self):
+    def tell(self) -> "sys::Off_T":
         """tell(Seekable self) -> sys::Off_T"""
         return _coda_io.Seekable_tell(self)
 
@@ -247,7 +247,7 @@ class SeekableInputStream(InputStream, Seekable):
     __swig_destroy__ = _coda_io.delete_SeekableInputStream
     __del__ = lambda self: None
 
-    def streamTo(self, *args):
+    def streamTo(self, *args) -> "sys::SSize_T":
         """
         streamTo(SeekableInputStream self, OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T
         streamTo(SeekableInputStream self, OutputStream & soi) -> sys::SSize_T
@@ -295,7 +295,7 @@ class SeekableBidirectionalStream(BidirectionalStream, Seekable):
     __swig_destroy__ = _coda_io.delete_SeekableBidirectionalStream
     __del__ = lambda self: None
 
-    def streamTo(self, *args):
+    def streamTo(self, *args) -> "sys::SSize_T":
         """
         streamTo(SeekableBidirectionalStream self, OutputStream & soi, sys::SSize_T numBytes) -> sys::SSize_T
         streamTo(SeekableBidirectionalStream self, OutputStream & soi) -> sys::SSize_T
@@ -326,22 +326,22 @@ class StringStream(SeekableBidirectionalStream):
         except __builtin__.Exception:
             self.this = this
 
-    def tell(self):
+    def tell(self) -> "sys::Off_T":
         """tell(StringStream self) -> sys::Off_T"""
         return _coda_io.StringStream_tell(self)
 
 
-    def seek(self, offset, whence):
+    def seek(self, offset: 'sys::Off_T', whence: 'io::Seekable::Whence') -> "sys::Off_T":
         """seek(StringStream self, sys::Off_T offset, io::Seekable::Whence whence) -> sys::Off_T"""
         return _coda_io.StringStream_seek(self, offset, whence)
 
 
-    def available(self):
+    def available(self) -> "sys::Off_T":
         """available(StringStream self) -> sys::Off_T"""
         return _coda_io.StringStream_available(self)
 
 
-    def write(self, *args):
+    def write(self, *args) -> "void":
         """
         write(StringStream self, sys::byte b)
         write(StringStream self, std::string const & str)
@@ -351,7 +351,7 @@ class StringStream(SeekableBidirectionalStream):
         return _coda_io.StringStream_write(self, *args)
 
 
-    def stream(self, *args):
+    def stream(self, *args) -> "std::stringstream &":
         """
         stream(StringStream self) -> std::stringstream const
         stream(StringStream self) -> std::stringstream &
@@ -359,12 +359,12 @@ class StringStream(SeekableBidirectionalStream):
         return _coda_io.StringStream_stream(self, *args)
 
 
-    def reset(self):
+    def reset(self) -> "void":
         """reset(StringStream self)"""
         return _coda_io.StringStream_reset(self)
 
 
-    def str(self):
+    def str(self) -> "std::string":
         """str(StringStream self) -> std::string"""
         return _coda_io.StringStream_str(self)
 
@@ -386,7 +386,7 @@ class NullInputStream(InputStream):
     __getattr__ = lambda self, name: _swig_getattr(self, NullInputStream, name)
     __repr__ = _swig_repr
 
-    def __init__(self, size):
+    def __init__(self, size: 'sys::SSize_T'):
         """__init__(io::NullInputStream self, sys::SSize_T size) -> NullInputStream"""
         this = _coda_io.new_NullInputStream(size)
         try:
@@ -396,17 +396,17 @@ class NullInputStream(InputStream):
     __swig_destroy__ = _coda_io.delete_NullInputStream
     __del__ = lambda self: None
 
-    def available(self):
+    def available(self) -> "sys::Off_T":
         """available(NullInputStream self) -> sys::Off_T"""
         return _coda_io.NullInputStream_available(self)
 
 
-    def readln(self, cStr, strLenPlusNullByte):
+    def readln(self, cStr: 'sys::byte *', strLenPlusNullByte: 'sys::Size_T const') -> "sys::SSize_T":
         """readln(NullInputStream self, sys::byte * cStr, sys::Size_T const strLenPlusNullByte) -> sys::SSize_T"""
         return _coda_io.NullInputStream_readln(self, cStr, strLenPlusNullByte)
 
 
-    def streamTo(self, *args):
+    def streamTo(self, *args) -> "sys::SSize_T":
         """
         streamTo(NullInputStream self, OutputStream soi, sys::SSize_T numBytes) -> sys::SSize_T
         streamTo(NullInputStream self, OutputStream soi) -> sys::SSize_T
@@ -439,12 +439,12 @@ class NullOutputStream(OutputStream):
     __swig_destroy__ = _coda_io.delete_NullOutputStream
     __del__ = lambda self: None
 
-    def writeln(self, arg2):
+    def writeln(self, arg2: 'std::string const &') -> "void":
         """writeln(NullOutputStream self, std::string const & arg2)"""
         return _coda_io.NullOutputStream_writeln(self, arg2)
 
 
-    def write(self, *args):
+    def write(self, *args) -> "void":
         """
         write(NullOutputStream self, sys::byte arg2)
         write(NullOutputStream self, std::string const & arg2)
@@ -453,7 +453,7 @@ class NullOutputStream(OutputStream):
         return _coda_io.NullOutputStream_write(self, *args)
 
 
-    def flush(self):
+    def flush(self) -> "void":
         """flush(NullOutputStream self)"""
         return _coda_io.NullOutputStream_flush(self)
 
@@ -487,32 +487,32 @@ class FileInputStream(SeekableInputStream):
     __swig_destroy__ = _coda_io.delete_FileInputStream
     __del__ = lambda self: None
 
-    def available(self):
+    def available(self) -> "sys::Off_T":
         """available(FileInputStream self) -> sys::Off_T"""
         return _coda_io.FileInputStream_available(self)
 
 
-    def isOpen(self):
+    def isOpen(self) -> "bool":
         """isOpen(FileInputStream self) -> bool"""
         return _coda_io.FileInputStream_isOpen(self)
 
 
-    def create(self, str):
+    def create(self, str: 'std::string const &') -> "void":
         """create(FileInputStream self, std::string const & str)"""
         return _coda_io.FileInputStream_create(self, str)
 
 
-    def seek(self, off, whence):
+    def seek(self, off: 'sys::Off_T', whence: 'io::Seekable::Whence') -> "sys::Off_T":
         """seek(FileInputStream self, sys::Off_T off, io::Seekable::Whence whence) -> sys::Off_T"""
         return _coda_io.FileInputStream_seek(self, off, whence)
 
 
-    def tell(self):
+    def tell(self) -> "sys::Off_T":
         """tell(FileInputStream self) -> sys::Off_T"""
         return _coda_io.FileInputStream_tell(self)
 
 
-    def close(self):
+    def close(self) -> "void":
         """close(FileInputStream self)"""
         return _coda_io.FileInputStream_close(self)
 
@@ -546,12 +546,12 @@ class FileOutputStream(SeekableOutputStream):
     __swig_destroy__ = _coda_io.delete_FileOutputStream
     __del__ = lambda self: None
 
-    def isOpen(self):
+    def isOpen(self) -> "bool":
         """isOpen(FileOutputStream self) -> bool"""
         return _coda_io.FileOutputStream_isOpen(self)
 
 
-    def create(self, *args):
+    def create(self, *args) -> "void":
         """
         create(FileOutputStream self, std::string const & str, int creationFlags)
         create(FileOutputStream self, std::string const & str)
@@ -559,27 +559,27 @@ class FileOutputStream(SeekableOutputStream):
         return _coda_io.FileOutputStream_create(self, *args)
 
 
-    def close(self):
+    def close(self) -> "void":
         """close(FileOutputStream self)"""
         return _coda_io.FileOutputStream_close(self)
 
 
-    def flush(self):
+    def flush(self) -> "void":
         """flush(FileOutputStream self)"""
         return _coda_io.FileOutputStream_flush(self)
 
 
-    def seek(self, offset, whence):
+    def seek(self, offset: 'sys::Off_T', whence: 'io::Seekable::Whence') -> "sys::Off_T":
         """seek(FileOutputStream self, sys::Off_T offset, io::Seekable::Whence whence) -> sys::Off_T"""
         return _coda_io.FileOutputStream_seek(self, offset, whence)
 
 
-    def tell(self):
+    def tell(self) -> "sys::Off_T":
         """tell(FileOutputStream self) -> sys::Off_T"""
         return _coda_io.FileOutputStream_tell(self)
 
 
-    def write(self, *args):
+    def write(self, *args) -> "void":
         """
         write(FileOutputStream self, sys::byte b)
         write(FileOutputStream self, std::string const & str)

--- a/modules/python/io/source/generated/coda_io_wrap.cxx
+++ b/modules/python/io/source/generated/coda_io_wrap.cxx
@@ -3137,6 +3137,7 @@ namespace swig {
   #include "import/sys.h"
   #include "import/io.h"
   using namespace io;
+  #define SWIG_PYTHON_STRICT_BYTE_CHAR
 
 
 SWIGINTERNINLINE PyObject*

--- a/modules/python/io/source/io.i
+++ b/modules/python/io/source/io.i
@@ -1,8 +1,8 @@
 /*
  * =========================================================================
- * This file is part of coda_io-python 
+ * This file is part of coda_io-python
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2015, MDA Information Systems LLC
  *
  * coda_io-python is free software; you can redistribute it and/or modify
@@ -15,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  */
 
@@ -30,6 +30,7 @@
   #include "import/sys.h"
   #include "import/io.h"
   using namespace io;
+  #define SWIG_PYTHON_STRICT_BYTE_CHAR
 %}
 
 %include "io/InputStream.h"

--- a/modules/python/logging/source/generated/coda_logging.py
+++ b/modules/python/logging/source/generated/coda_logging.py
@@ -109,17 +109,17 @@ class Formatter(_object):
     __swig_destroy__ = _coda_logging.delete_Formatter
     __del__ = lambda self: None
 
-    def format(self, record, os):
+    def format(self, record: 'LogRecord const *', os: 'io::OutputStream &') -> "void":
         """format(Formatter self, LogRecord const * record, io::OutputStream & os)"""
         return _coda_logging.Formatter_format(self, record, os)
 
 
-    def getPrologue(self):
+    def getPrologue(self) -> "std::string":
         """getPrologue(Formatter self) -> std::string"""
         return _coda_logging.Formatter_getPrologue(self)
 
 
-    def getEpilogue(self):
+    def getEpilogue(self) -> "std::string":
         """getEpilogue(Formatter self) -> std::string"""
         return _coda_logging.Formatter_getEpilogue(self)
 
@@ -154,7 +154,7 @@ class StandardFormatter(Formatter):
     __swig_destroy__ = _coda_logging.delete_StandardFormatter
     __del__ = lambda self: None
 
-    def format(self, record, os):
+    def format(self, record: 'LogRecord const *', os: 'io::OutputStream &') -> "void":
         """format(StandardFormatter self, LogRecord const * record, io::OutputStream & os)"""
         return _coda_logging.StandardFormatter_format(self, record, os)
 
@@ -182,17 +182,17 @@ class Filterer(_object):
     __swig_destroy__ = _coda_logging.delete_Filterer
     __del__ = lambda self: None
 
-    def addFilter(self, filter):
+    def addFilter(self, filter: 'Filter *') -> "void":
         """addFilter(Filterer self, Filter * filter)"""
         return _coda_logging.Filterer_addFilter(self, filter)
 
 
-    def filter(self, record):
+    def filter(self, record: 'LogRecord const *') -> "bool":
         """filter(Filterer self, LogRecord const * record) -> bool"""
         return _coda_logging.Filterer_filter(self, record)
 
 
-    def removeFilter(self, filter):
+    def removeFilter(self, filter: 'Filter *') -> "void":
         """removeFilter(Filterer self, Filter * filter)"""
         return _coda_logging.Filterer_removeFilter(self, filter)
 
@@ -217,27 +217,27 @@ class Handler(Filterer):
     __swig_destroy__ = _coda_logging.delete_Handler
     __del__ = lambda self: None
 
-    def setLevel(self, level):
+    def setLevel(self, level: 'LogLevel') -> "void":
         """setLevel(Handler self, LogLevel level)"""
         return _coda_logging.Handler_setLevel(self, level)
 
 
-    def getLevel(self):
+    def getLevel(self) -> "LogLevel":
         """getLevel(Handler self) -> LogLevel"""
         return _coda_logging.Handler_getLevel(self)
 
 
-    def handle(self, record):
+    def handle(self, record: 'LogRecord const *') -> "bool":
         """handle(Handler self, LogRecord const * record) -> bool"""
         return _coda_logging.Handler_handle(self, record)
 
 
-    def close(self):
+    def close(self) -> "void":
         """close(Handler self)"""
         return _coda_logging.Handler_close(self)
 
 
-    def setFormatter(self, formatter):
+    def setFormatter(self, formatter: 'Formatter') -> "void":
         """setFormatter(Handler self, Formatter formatter)"""
         return _coda_logging.Handler_setFormatter(self, formatter)
 
@@ -272,7 +272,7 @@ class StreamHandler(Handler):
     __swig_destroy__ = _coda_logging.delete_StreamHandler
     __del__ = lambda self: None
 
-    def close(self):
+    def close(self) -> "void":
         """close(StreamHandler self)"""
         return _coda_logging.StreamHandler_close(self)
 
@@ -330,12 +330,12 @@ class Filter(_object):
     __swig_destroy__ = _coda_logging.delete_Filter
     __del__ = lambda self: None
 
-    def filter(self, record):
+    def filter(self, record: 'LogRecord const *') -> "bool":
         """filter(Filter self, LogRecord const * record) -> bool"""
         return _coda_logging.Filter_filter(self, record)
 
 
-    def getName(self):
+    def getName(self) -> "std::string":
         """getName(Filter self) -> std::string"""
         return _coda_logging.Filter_getName(self)
 
@@ -368,7 +368,7 @@ class Logger(Filterer):
     __swig_destroy__ = _coda_logging.delete_Logger
     __del__ = lambda self: None
 
-    def log(self, *args):
+    def log(self, *args) -> "void":
         """
         log(Logger self, LogLevel level, std::string const & msg)
         log(Logger self, LogLevel level, except::Context const & ctxt)
@@ -377,7 +377,7 @@ class Logger(Filterer):
         return _coda_logging.Logger_log(self, *args)
 
 
-    def debug(self, *args):
+    def debug(self, *args) -> "void":
         """
         debug(Logger self, std::string const & msg)
         debug(Logger self, except::Context const & ctxt)
@@ -386,7 +386,7 @@ class Logger(Filterer):
         return _coda_logging.Logger_debug(self, *args)
 
 
-    def info(self, *args):
+    def info(self, *args) -> "void":
         """
         info(Logger self, std::string const & msg)
         info(Logger self, except::Context const & ctxt)
@@ -395,7 +395,7 @@ class Logger(Filterer):
         return _coda_logging.Logger_info(self, *args)
 
 
-    def warn(self, *args):
+    def warn(self, *args) -> "void":
         """
         warn(Logger self, std::string const & msg)
         warn(Logger self, except::Context const & ctxt)
@@ -404,7 +404,7 @@ class Logger(Filterer):
         return _coda_logging.Logger_warn(self, *args)
 
 
-    def error(self, *args):
+    def error(self, *args) -> "void":
         """
         error(Logger self, std::string const & msg)
         error(Logger self, except::Context const & ctxt)
@@ -413,7 +413,7 @@ class Logger(Filterer):
         return _coda_logging.Logger_error(self, *args)
 
 
-    def critical(self, *args):
+    def critical(self, *args) -> "void":
         """
         critical(Logger self, std::string const & msg)
         critical(Logger self, except::Context const & ctxt)
@@ -422,7 +422,7 @@ class Logger(Filterer):
         return _coda_logging.Logger_critical(self, *args)
 
 
-    def addHandler(self, handler, own=False):
+    def addHandler(self, handler: 'Handler', own: 'bool'=False) -> "void":
         """
         addHandler(Logger self, Handler handler, bool own=False)
         addHandler(Logger self, Handler handler)
@@ -430,27 +430,27 @@ class Logger(Filterer):
         return _coda_logging.Logger_addHandler(self, handler, own)
 
 
-    def removeHandler(self, handler):
+    def removeHandler(self, handler: 'Handler') -> "void":
         """removeHandler(Logger self, Handler handler)"""
         return _coda_logging.Logger_removeHandler(self, handler)
 
 
-    def setLevel(self, level):
+    def setLevel(self, level: 'LogLevel') -> "void":
         """setLevel(Logger self, LogLevel level)"""
         return _coda_logging.Logger_setLevel(self, level)
 
 
-    def setName(self, name):
+    def setName(self, name: 'std::string const &') -> "void":
         """setName(Logger self, std::string const & name)"""
         return _coda_logging.Logger_setName(self, name)
 
 
-    def getName(self):
+    def getName(self) -> "std::string":
         """getName(Logger self) -> std::string"""
         return _coda_logging.Logger_getName(self)
 
 
-    def reset(self):
+    def reset(self) -> "void":
         """reset(Logger self)"""
         return _coda_logging.Logger_reset(self)
 
@@ -530,7 +530,7 @@ class LoggerManager(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def getLoggerSharedPtr(self, *args):
+    def getLoggerSharedPtr(self, *args) -> "mem::SharedPtr< logging::Logger >":
         """
         getLoggerSharedPtr(LoggerManager self, std::string const & name) -> mem::SharedPtr< logging::Logger >
         getLoggerSharedPtr(LoggerManager self) -> mem::SharedPtr< logging::Logger >
@@ -538,7 +538,7 @@ class LoggerManager(_object):
         return _coda_logging.LoggerManager_getLoggerSharedPtr(self, *args)
 
 
-    def getLogger(self, *args):
+    def getLogger(self, *args) -> "logging::Logger *":
         """
         getLogger(LoggerManager self, std::string const & name) -> Logger
         getLogger(LoggerManager self) -> Logger
@@ -551,7 +551,7 @@ LoggerManager_swigregister = _coda_logging.LoggerManager_swigregister
 LoggerManager_swigregister(LoggerManager)
 
 
-def debug(*args):
+def debug(*args) -> "void":
     """
     debug(std::string const & msg)
     debug(except::Context const & ctxt)
@@ -559,7 +559,7 @@ def debug(*args):
     """
     return _coda_logging.debug(*args)
 
-def info(*args):
+def info(*args) -> "void":
     """
     info(std::string const & msg)
     info(except::Context const & ctxt)
@@ -567,7 +567,7 @@ def info(*args):
     """
     return _coda_logging.info(*args)
 
-def warn(*args):
+def warn(*args) -> "void":
     """
     warn(std::string const & msg)
     warn(except::Context const & ctxt)
@@ -575,7 +575,7 @@ def warn(*args):
     """
     return _coda_logging.warn(*args)
 
-def error(*args):
+def error(*args) -> "void":
     """
     error(std::string const & msg)
     error(except::Context const & ctxt)
@@ -583,7 +583,7 @@ def error(*args):
     """
     return _coda_logging.error(*args)
 
-def critical(*args):
+def critical(*args) -> "void":
     """
     critical(std::string const & msg)
     critical(except::Context const & ctxt)
@@ -591,11 +591,11 @@ def critical(*args):
     """
     return _coda_logging.critical(*args)
 
-def getLogger(*args):
+def getLogger(*args) -> "logging::Logger *":
     """getLogger() -> Logger"""
     return _coda_logging.getLogger(*args)
 
-def getLoggerSharedPtr(*args):
+def getLoggerSharedPtr(*args) -> "mem::SharedPtr< logging::Logger >":
     """getLoggerSharedPtr() -> mem::SharedPtr< logging::Logger >"""
     return _coda_logging.getLoggerSharedPtr(*args)
 # This file is compatible with both classic and new-style classes.

--- a/modules/python/math.linear/source/generated/math_linear.py
+++ b/modules/python/math.linear/source/generated/math_linear.py
@@ -110,12 +110,12 @@ class SwigPyIterator(_object):
     __swig_destroy__ = _math_linear.delete_SwigPyIterator
     __del__ = lambda self: None
 
-    def value(self):
+    def value(self) -> "PyObject *":
         """value(SwigPyIterator self) -> PyObject *"""
         return _math_linear.SwigPyIterator_value(self)
 
 
-    def incr(self, n=1):
+    def incr(self, n: 'size_t'=1) -> "swig::SwigPyIterator *":
         """
         incr(SwigPyIterator self, size_t n=1) -> SwigPyIterator
         incr(SwigPyIterator self) -> SwigPyIterator
@@ -123,7 +123,7 @@ class SwigPyIterator(_object):
         return _math_linear.SwigPyIterator_incr(self, n)
 
 
-    def decr(self, n=1):
+    def decr(self, n: 'size_t'=1) -> "swig::SwigPyIterator *":
         """
         decr(SwigPyIterator self, size_t n=1) -> SwigPyIterator
         decr(SwigPyIterator self) -> SwigPyIterator
@@ -131,67 +131,67 @@ class SwigPyIterator(_object):
         return _math_linear.SwigPyIterator_decr(self, n)
 
 
-    def distance(self, x):
+    def distance(self, x: 'SwigPyIterator') -> "ptrdiff_t":
         """distance(SwigPyIterator self, SwigPyIterator x) -> ptrdiff_t"""
         return _math_linear.SwigPyIterator_distance(self, x)
 
 
-    def equal(self, x):
+    def equal(self, x: 'SwigPyIterator') -> "bool":
         """equal(SwigPyIterator self, SwigPyIterator x) -> bool"""
         return _math_linear.SwigPyIterator_equal(self, x)
 
 
-    def copy(self):
+    def copy(self) -> "swig::SwigPyIterator *":
         """copy(SwigPyIterator self) -> SwigPyIterator"""
         return _math_linear.SwigPyIterator_copy(self)
 
 
-    def next(self):
+    def next(self) -> "PyObject *":
         """next(SwigPyIterator self) -> PyObject *"""
         return _math_linear.SwigPyIterator_next(self)
 
 
-    def __next__(self):
+    def __next__(self) -> "PyObject *":
         """__next__(SwigPyIterator self) -> PyObject *"""
         return _math_linear.SwigPyIterator___next__(self)
 
 
-    def previous(self):
+    def previous(self) -> "PyObject *":
         """previous(SwigPyIterator self) -> PyObject *"""
         return _math_linear.SwigPyIterator_previous(self)
 
 
-    def advance(self, n):
+    def advance(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator *":
         """advance(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _math_linear.SwigPyIterator_advance(self, n)
 
 
-    def __eq__(self, x):
+    def __eq__(self, x: 'SwigPyIterator') -> "bool":
         """__eq__(SwigPyIterator self, SwigPyIterator x) -> bool"""
         return _math_linear.SwigPyIterator___eq__(self, x)
 
 
-    def __ne__(self, x):
+    def __ne__(self, x: 'SwigPyIterator') -> "bool":
         """__ne__(SwigPyIterator self, SwigPyIterator x) -> bool"""
         return _math_linear.SwigPyIterator___ne__(self, x)
 
 
-    def __iadd__(self, n):
+    def __iadd__(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator &":
         """__iadd__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _math_linear.SwigPyIterator___iadd__(self, n)
 
 
-    def __isub__(self, n):
+    def __isub__(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator &":
         """__isub__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _math_linear.SwigPyIterator___isub__(self, n)
 
 
-    def __add__(self, n):
+    def __add__(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator *":
         """__add__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _math_linear.SwigPyIterator___add__(self, n)
 
 
-    def __sub__(self, *args):
+    def __sub__(self, *args) -> "ptrdiff_t":
         """
         __sub__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator
         __sub__(SwigPyIterator self, SwigPyIterator x) -> ptrdiff_t
@@ -217,34 +217,34 @@ class std_vector_double(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, std_vector_double, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(std_vector_double self) -> SwigPyIterator"""
         return _math_linear.std_vector_double_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(std_vector_double self) -> bool"""
         return _math_linear.std_vector_double___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(std_vector_double self) -> bool"""
         return _math_linear.std_vector_double___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< double >::size_type":
         """__len__(std_vector_double self) -> std::vector< double >::size_type"""
         return _math_linear.std_vector_double___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< double >::difference_type', j: 'std::vector< double >::difference_type') -> "std::vector< double,std::allocator< double > > *":
         """__getslice__(std_vector_double self, std::vector< double >::difference_type i, std::vector< double >::difference_type j) -> std_vector_double"""
         return _math_linear.std_vector_double___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(std_vector_double self, std::vector< double >::difference_type i, std::vector< double >::difference_type j)
         __setslice__(std_vector_double self, std::vector< double >::difference_type i, std::vector< double >::difference_type j, std_vector_double v)
@@ -252,12 +252,12 @@ class std_vector_double(_object):
         return _math_linear.std_vector_double___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< double >::difference_type', j: 'std::vector< double >::difference_type') -> "void":
         """__delslice__(std_vector_double self, std::vector< double >::difference_type i, std::vector< double >::difference_type j)"""
         return _math_linear.std_vector_double___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(std_vector_double self, std::vector< double >::difference_type i)
         __delitem__(std_vector_double self, PySliceObject * slice)
@@ -265,7 +265,7 @@ class std_vector_double(_object):
         return _math_linear.std_vector_double___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< double >::value_type const &":
         """
         __getitem__(std_vector_double self, PySliceObject * slice) -> std_vector_double
         __getitem__(std_vector_double self, std::vector< double >::difference_type i) -> std::vector< double >::value_type const &
@@ -273,7 +273,7 @@ class std_vector_double(_object):
         return _math_linear.std_vector_double___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(std_vector_double self, PySliceObject * slice, std_vector_double v)
         __setitem__(std_vector_double self, PySliceObject * slice)
@@ -282,67 +282,67 @@ class std_vector_double(_object):
         return _math_linear.std_vector_double___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< double >::value_type":
         """pop(std_vector_double self) -> std::vector< double >::value_type"""
         return _math_linear.std_vector_double_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'std::vector< double >::value_type const &') -> "void":
         """append(std_vector_double self, std::vector< double >::value_type const & x)"""
         return _math_linear.std_vector_double_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(std_vector_double self) -> bool"""
         return _math_linear.std_vector_double_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< double >::size_type":
         """size(std_vector_double self) -> std::vector< double >::size_type"""
         return _math_linear.std_vector_double_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'std_vector_double') -> "void":
         """swap(std_vector_double self, std_vector_double v)"""
         return _math_linear.std_vector_double_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< double >::iterator":
         """begin(std_vector_double self) -> std::vector< double >::iterator"""
         return _math_linear.std_vector_double_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< double >::iterator":
         """end(std_vector_double self) -> std::vector< double >::iterator"""
         return _math_linear.std_vector_double_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< double >::reverse_iterator":
         """rbegin(std_vector_double self) -> std::vector< double >::reverse_iterator"""
         return _math_linear.std_vector_double_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< double >::reverse_iterator":
         """rend(std_vector_double self) -> std::vector< double >::reverse_iterator"""
         return _math_linear.std_vector_double_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(std_vector_double self)"""
         return _math_linear.std_vector_double_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< double >::allocator_type":
         """get_allocator(std_vector_double self) -> std::vector< double >::allocator_type"""
         return _math_linear.std_vector_double_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(std_vector_double self)"""
         return _math_linear.std_vector_double_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< double >::iterator":
         """
         erase(std_vector_double self, std::vector< double >::iterator pos) -> std::vector< double >::iterator
         erase(std_vector_double self, std::vector< double >::iterator first, std::vector< double >::iterator last) -> std::vector< double >::iterator
@@ -363,27 +363,27 @@ class std_vector_double(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'std::vector< double >::value_type const &') -> "void":
         """push_back(std_vector_double self, std::vector< double >::value_type const & x)"""
         return _math_linear.std_vector_double_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< double >::value_type const &":
         """front(std_vector_double self) -> std::vector< double >::value_type const &"""
         return _math_linear.std_vector_double_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< double >::value_type const &":
         """back(std_vector_double self) -> std::vector< double >::value_type const &"""
         return _math_linear.std_vector_double_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< double >::size_type', x: 'std::vector< double >::value_type const &') -> "void":
         """assign(std_vector_double self, std::vector< double >::size_type n, std::vector< double >::value_type const & x)"""
         return _math_linear.std_vector_double_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(std_vector_double self, std::vector< double >::size_type new_size)
         resize(std_vector_double self, std::vector< double >::size_type new_size, std::vector< double >::value_type const & x)
@@ -391,7 +391,7 @@ class std_vector_double(_object):
         return _math_linear.std_vector_double_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(std_vector_double self, std::vector< double >::iterator pos, std::vector< double >::value_type const & x) -> std::vector< double >::iterator
         insert(std_vector_double self, std::vector< double >::iterator pos, std::vector< double >::size_type n, std::vector< double >::value_type const & x)
@@ -399,12 +399,12 @@ class std_vector_double(_object):
         return _math_linear.std_vector_double_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< double >::size_type') -> "void":
         """reserve(std_vector_double self, std::vector< double >::size_type n)"""
         return _math_linear.std_vector_double_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< double >::size_type":
         """capacity(std_vector_double self) -> std::vector< double >::size_type"""
         return _math_linear.std_vector_double_capacity(self)
 
@@ -433,34 +433,34 @@ class std_vector_vector_double(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, std_vector_vector_double, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(std_vector_vector_double self) -> SwigPyIterator"""
         return _math_linear.std_vector_vector_double_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(std_vector_vector_double self) -> bool"""
         return _math_linear.std_vector_vector_double___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(std_vector_vector_double self) -> bool"""
         return _math_linear.std_vector_vector_double___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< std::vector< double > >::size_type":
         """__len__(std_vector_vector_double self) -> std::vector< std::vector< double > >::size_type"""
         return _math_linear.std_vector_vector_double___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< std::vector< double > >::difference_type', j: 'std::vector< std::vector< double > >::difference_type') -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > > *":
         """__getslice__(std_vector_vector_double self, std::vector< std::vector< double > >::difference_type i, std::vector< std::vector< double > >::difference_type j) -> std_vector_vector_double"""
         return _math_linear.std_vector_vector_double___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(std_vector_vector_double self, std::vector< std::vector< double > >::difference_type i, std::vector< std::vector< double > >::difference_type j)
         __setslice__(std_vector_vector_double self, std::vector< std::vector< double > >::difference_type i, std::vector< std::vector< double > >::difference_type j, std_vector_vector_double v)
@@ -468,12 +468,12 @@ class std_vector_vector_double(_object):
         return _math_linear.std_vector_vector_double___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< std::vector< double > >::difference_type', j: 'std::vector< std::vector< double > >::difference_type') -> "void":
         """__delslice__(std_vector_vector_double self, std::vector< std::vector< double > >::difference_type i, std::vector< std::vector< double > >::difference_type j)"""
         return _math_linear.std_vector_vector_double___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(std_vector_vector_double self, std::vector< std::vector< double > >::difference_type i)
         __delitem__(std_vector_vector_double self, PySliceObject * slice)
@@ -481,7 +481,7 @@ class std_vector_vector_double(_object):
         return _math_linear.std_vector_vector_double___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< std::vector< double > >::value_type const &":
         """
         __getitem__(std_vector_vector_double self, PySliceObject * slice) -> std_vector_vector_double
         __getitem__(std_vector_vector_double self, std::vector< std::vector< double > >::difference_type i) -> std_vector_double
@@ -489,7 +489,7 @@ class std_vector_vector_double(_object):
         return _math_linear.std_vector_vector_double___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(std_vector_vector_double self, PySliceObject * slice, std_vector_vector_double v)
         __setitem__(std_vector_vector_double self, PySliceObject * slice)
@@ -498,67 +498,67 @@ class std_vector_vector_double(_object):
         return _math_linear.std_vector_vector_double___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< std::vector< double > >::value_type":
         """pop(std_vector_vector_double self) -> std_vector_double"""
         return _math_linear.std_vector_vector_double_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'std_vector_double') -> "void":
         """append(std_vector_vector_double self, std_vector_double x)"""
         return _math_linear.std_vector_vector_double_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(std_vector_vector_double self) -> bool"""
         return _math_linear.std_vector_vector_double_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< std::vector< double > >::size_type":
         """size(std_vector_vector_double self) -> std::vector< std::vector< double > >::size_type"""
         return _math_linear.std_vector_vector_double_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'std_vector_vector_double') -> "void":
         """swap(std_vector_vector_double self, std_vector_vector_double v)"""
         return _math_linear.std_vector_vector_double_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< std::vector< double > >::iterator":
         """begin(std_vector_vector_double self) -> std::vector< std::vector< double > >::iterator"""
         return _math_linear.std_vector_vector_double_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< std::vector< double > >::iterator":
         """end(std_vector_vector_double self) -> std::vector< std::vector< double > >::iterator"""
         return _math_linear.std_vector_vector_double_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< std::vector< double > >::reverse_iterator":
         """rbegin(std_vector_vector_double self) -> std::vector< std::vector< double > >::reverse_iterator"""
         return _math_linear.std_vector_vector_double_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< std::vector< double > >::reverse_iterator":
         """rend(std_vector_vector_double self) -> std::vector< std::vector< double > >::reverse_iterator"""
         return _math_linear.std_vector_vector_double_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(std_vector_vector_double self)"""
         return _math_linear.std_vector_vector_double_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< std::vector< double > >::allocator_type":
         """get_allocator(std_vector_vector_double self) -> std::vector< std::vector< double > >::allocator_type"""
         return _math_linear.std_vector_vector_double_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(std_vector_vector_double self)"""
         return _math_linear.std_vector_vector_double_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< std::vector< double > >::iterator":
         """
         erase(std_vector_vector_double self, std::vector< std::vector< double > >::iterator pos) -> std::vector< std::vector< double > >::iterator
         erase(std_vector_vector_double self, std::vector< std::vector< double > >::iterator first, std::vector< std::vector< double > >::iterator last) -> std::vector< std::vector< double > >::iterator
@@ -579,27 +579,27 @@ class std_vector_vector_double(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'std_vector_double') -> "void":
         """push_back(std_vector_vector_double self, std_vector_double x)"""
         return _math_linear.std_vector_vector_double_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< std::vector< double > >::value_type const &":
         """front(std_vector_vector_double self) -> std_vector_double"""
         return _math_linear.std_vector_vector_double_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< std::vector< double > >::value_type const &":
         """back(std_vector_vector_double self) -> std_vector_double"""
         return _math_linear.std_vector_vector_double_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< std::vector< double > >::size_type', x: 'std_vector_double') -> "void":
         """assign(std_vector_vector_double self, std::vector< std::vector< double > >::size_type n, std_vector_double x)"""
         return _math_linear.std_vector_vector_double_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(std_vector_vector_double self, std::vector< std::vector< double > >::size_type new_size)
         resize(std_vector_vector_double self, std::vector< std::vector< double > >::size_type new_size, std_vector_double x)
@@ -607,7 +607,7 @@ class std_vector_vector_double(_object):
         return _math_linear.std_vector_vector_double_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(std_vector_vector_double self, std::vector< std::vector< double > >::iterator pos, std_vector_double x) -> std::vector< std::vector< double > >::iterator
         insert(std_vector_vector_double self, std::vector< std::vector< double > >::iterator pos, std::vector< std::vector< double > >::size_type n, std_vector_double x)
@@ -615,12 +615,12 @@ class std_vector_vector_double(_object):
         return _math_linear.std_vector_vector_double_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< std::vector< double > >::size_type') -> "void":
         """reserve(std_vector_vector_double self, std::vector< std::vector< double > >::size_type n)"""
         return _math_linear.std_vector_vector_double_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< std::vector< double > >::size_type":
         """capacity(std_vector_vector_double self) -> std::vector< std::vector< double > >::size_type"""
         return _math_linear.std_vector_vector_double_capacity(self)
 
@@ -669,7 +669,7 @@ class Matrix1x1(_object):
     __swig_destroy__ = _math_linear.delete_Matrix1x1
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix1x1 self, size_t i, size_t j) -> double
         __call__(Matrix1x1 self, size_t i, size_t j) -> double &
@@ -677,7 +677,7 @@ class Matrix1x1(_object):
         return _math_linear.Matrix1x1___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix1x1 self, size_t i) -> double const
         row(Matrix1x1 self, size_t i) -> double
@@ -687,7 +687,7 @@ class Matrix1x1(_object):
         return _math_linear.Matrix1x1_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix1x1 self, size_t j) -> std_vector_double
         col(Matrix1x1 self, size_t j, double const * vec)
@@ -697,72 +697,72 @@ class Matrix1x1(_object):
         return _math_linear.Matrix1x1_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix1x1 self) -> size_t"""
         return _math_linear.Matrix1x1_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix1x1 self) -> size_t"""
         return _math_linear.Matrix1x1_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix1x1 self) -> size_t"""
         return _math_linear.Matrix1x1_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,1,double > &":
         """scale(Matrix1x1 self, double scalar) -> Matrix1x1"""
         return _math_linear.Matrix1x1_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,1 >":
         """multiply(Matrix1x1 self, double scalar) -> Matrix1x1"""
         return _math_linear.Matrix1x1_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double > &":
         """scaleDiagonal(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >":
         """multiplyDiagonal(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >::Like_T &":
         """__iadd__(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >::Like_T &":
         """__isub__(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """add(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """subtract(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 1,1,double >":
         """transpose(Matrix1x1 self) -> Matrix1x1"""
         return _math_linear.Matrix1x1_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """decomposeLU(Matrix1x1 self, VectorSizeT pivotsM) -> Matrix1x1"""
         return _math_linear.Matrix1x1_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=1):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=1) -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """
         permute(Matrix1x1 self, VectorSizeT pivotsM, size_t n=1) -> Matrix1x1
         permute(Matrix1x1 self, VectorSizeT pivotsM) -> Matrix1x1
@@ -770,37 +770,37 @@ class Matrix1x1(_object):
         return _math_linear.Matrix1x1_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix1x1 self) -> double"""
         return _math_linear.Matrix1x1_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix1x1 self) -> double"""
         return _math_linear.Matrix1x1_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 1,1,double > &":
         """normalize(Matrix1x1 self) -> Matrix1x1"""
         return _math_linear.Matrix1x1_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """unit(Matrix1x1 self) -> Matrix1x1"""
         return _math_linear.Matrix1x1_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """__add__(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """__sub__(Matrix1x1 self, Matrix1x1 mx) -> Matrix1x1"""
         return _math_linear.Matrix1x1___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """__mul__(Matrix1x1 self, double scalar) -> Matrix1x1"""
         return _math_linear.Matrix1x1___mul__(self, scalar)
 
@@ -811,27 +811,27 @@ class Matrix1x1(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 1,1,double >::Like_T":
         """__neg__(Matrix1x1 self) -> Matrix1x1"""
         return _math_linear.Matrix1x1___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix1x1 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix1x1___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix1x1 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix1x1___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix1x1 self) -> std::string"""
         return _math_linear.Matrix1x1___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix1x1 self) -> std_vector_vector_double"""
         return _math_linear.Matrix1x1_vals(self)
 
@@ -867,7 +867,7 @@ class Matrix1x2(_object):
     __swig_destroy__ = _math_linear.delete_Matrix1x2
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix1x2 self, size_t i, size_t j) -> double
         __call__(Matrix1x2 self, size_t i, size_t j) -> double &
@@ -875,7 +875,7 @@ class Matrix1x2(_object):
         return _math_linear.Matrix1x2___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix1x2 self, size_t i) -> double const
         row(Matrix1x2 self, size_t i) -> double
@@ -885,7 +885,7 @@ class Matrix1x2(_object):
         return _math_linear.Matrix1x2_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix1x2 self, size_t j) -> std_vector_double
         col(Matrix1x2 self, size_t j, double const * vec)
@@ -895,72 +895,72 @@ class Matrix1x2(_object):
         return _math_linear.Matrix1x2_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix1x2 self) -> size_t"""
         return _math_linear.Matrix1x2_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix1x2 self) -> size_t"""
         return _math_linear.Matrix1x2_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix1x2 self) -> size_t"""
         return _math_linear.Matrix1x2_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,2,double > &":
         """scale(Matrix1x2 self, double scalar) -> Matrix1x2"""
         return _math_linear.Matrix1x2_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,2 >":
         """multiply(Matrix1x2 self, double scalar) -> Matrix1x2"""
         return _math_linear.Matrix1x2_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 1,2,double > &":
         """scaleDiagonal(Matrix1x2 self, Matrix2x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 1,2,double >":
         """multiplyDiagonal(Matrix1x2 self, Matrix2x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix1x2') -> "math::linear::MatrixMxN< 1,2,double >::Like_T &":
         """__iadd__(Matrix1x2 self, Matrix1x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix1x2') -> "math::linear::MatrixMxN< 1,2,double >::Like_T &":
         """__isub__(Matrix1x2 self, Matrix1x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix1x2') -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """add(Matrix1x2 self, Matrix1x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix1x2') -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """subtract(Matrix1x2 self, Matrix1x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 2,1,double >":
         """transpose(Matrix1x2 self) -> Matrix2x1"""
         return _math_linear.Matrix1x2_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """decomposeLU(Matrix1x2 self, VectorSizeT pivotsM) -> Matrix1x2"""
         return _math_linear.Matrix1x2_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=2):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=2) -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """
         permute(Matrix1x2 self, VectorSizeT pivotsM, size_t n=2) -> Matrix1x2
         permute(Matrix1x2 self, VectorSizeT pivotsM) -> Matrix1x2
@@ -968,37 +968,37 @@ class Matrix1x2(_object):
         return _math_linear.Matrix1x2_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix1x2 self) -> double"""
         return _math_linear.Matrix1x2_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix1x2 self) -> double"""
         return _math_linear.Matrix1x2_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 1,2,double > &":
         """normalize(Matrix1x2 self) -> Matrix1x2"""
         return _math_linear.Matrix1x2_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """unit(Matrix1x2 self) -> Matrix1x2"""
         return _math_linear.Matrix1x2_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix1x2') -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """__add__(Matrix1x2 self, Matrix1x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix1x2') -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """__sub__(Matrix1x2 self, Matrix1x2 mx) -> Matrix1x2"""
         return _math_linear.Matrix1x2___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """__mul__(Matrix1x2 self, double scalar) -> Matrix1x2"""
         return _math_linear.Matrix1x2___mul__(self, scalar)
 
@@ -1009,27 +1009,27 @@ class Matrix1x2(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 1,2,double >::Like_T":
         """__neg__(Matrix1x2 self) -> Matrix1x2"""
         return _math_linear.Matrix1x2___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix1x2 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix1x2___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix1x2 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix1x2___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix1x2 self) -> std::string"""
         return _math_linear.Matrix1x2___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix1x2 self) -> std_vector_vector_double"""
         return _math_linear.Matrix1x2_vals(self)
 
@@ -1065,7 +1065,7 @@ class Matrix1x3(_object):
     __swig_destroy__ = _math_linear.delete_Matrix1x3
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix1x3 self, size_t i, size_t j) -> double
         __call__(Matrix1x3 self, size_t i, size_t j) -> double &
@@ -1073,7 +1073,7 @@ class Matrix1x3(_object):
         return _math_linear.Matrix1x3___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix1x3 self, size_t i) -> double const
         row(Matrix1x3 self, size_t i) -> double
@@ -1083,7 +1083,7 @@ class Matrix1x3(_object):
         return _math_linear.Matrix1x3_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix1x3 self, size_t j) -> std_vector_double
         col(Matrix1x3 self, size_t j, double const * vec)
@@ -1093,72 +1093,72 @@ class Matrix1x3(_object):
         return _math_linear.Matrix1x3_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix1x3 self) -> size_t"""
         return _math_linear.Matrix1x3_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix1x3 self) -> size_t"""
         return _math_linear.Matrix1x3_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix1x3 self) -> size_t"""
         return _math_linear.Matrix1x3_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,3,double > &":
         """scale(Matrix1x3 self, double scalar) -> Matrix1x3"""
         return _math_linear.Matrix1x3_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,3 >":
         """multiply(Matrix1x3 self, double scalar) -> Matrix1x3"""
         return _math_linear.Matrix1x3_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 1,3,double > &":
         """scaleDiagonal(Matrix1x3 self, Matrix3x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 1,3,double >":
         """multiplyDiagonal(Matrix1x3 self, Matrix3x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix1x3') -> "math::linear::MatrixMxN< 1,3,double >::Like_T &":
         """__iadd__(Matrix1x3 self, Matrix1x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix1x3') -> "math::linear::MatrixMxN< 1,3,double >::Like_T &":
         """__isub__(Matrix1x3 self, Matrix1x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix1x3') -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """add(Matrix1x3 self, Matrix1x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix1x3') -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """subtract(Matrix1x3 self, Matrix1x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 3,1,double >":
         """transpose(Matrix1x3 self) -> Matrix3x1"""
         return _math_linear.Matrix1x3_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """decomposeLU(Matrix1x3 self, VectorSizeT pivotsM) -> Matrix1x3"""
         return _math_linear.Matrix1x3_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=3):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=3) -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """
         permute(Matrix1x3 self, VectorSizeT pivotsM, size_t n=3) -> Matrix1x3
         permute(Matrix1x3 self, VectorSizeT pivotsM) -> Matrix1x3
@@ -1166,37 +1166,37 @@ class Matrix1x3(_object):
         return _math_linear.Matrix1x3_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix1x3 self) -> double"""
         return _math_linear.Matrix1x3_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix1x3 self) -> double"""
         return _math_linear.Matrix1x3_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 1,3,double > &":
         """normalize(Matrix1x3 self) -> Matrix1x3"""
         return _math_linear.Matrix1x3_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """unit(Matrix1x3 self) -> Matrix1x3"""
         return _math_linear.Matrix1x3_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix1x3') -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """__add__(Matrix1x3 self, Matrix1x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix1x3') -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """__sub__(Matrix1x3 self, Matrix1x3 mx) -> Matrix1x3"""
         return _math_linear.Matrix1x3___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """__mul__(Matrix1x3 self, double scalar) -> Matrix1x3"""
         return _math_linear.Matrix1x3___mul__(self, scalar)
 
@@ -1207,27 +1207,27 @@ class Matrix1x3(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 1,3,double >::Like_T":
         """__neg__(Matrix1x3 self) -> Matrix1x3"""
         return _math_linear.Matrix1x3___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix1x3 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix1x3___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix1x3 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix1x3___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix1x3 self) -> std::string"""
         return _math_linear.Matrix1x3___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix1x3 self) -> std_vector_vector_double"""
         return _math_linear.Matrix1x3_vals(self)
 
@@ -1263,7 +1263,7 @@ class Matrix2x1(_object):
     __swig_destroy__ = _math_linear.delete_Matrix2x1
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix2x1 self, size_t i, size_t j) -> double
         __call__(Matrix2x1 self, size_t i, size_t j) -> double &
@@ -1271,7 +1271,7 @@ class Matrix2x1(_object):
         return _math_linear.Matrix2x1___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix2x1 self, size_t i) -> double const
         row(Matrix2x1 self, size_t i) -> double
@@ -1281,7 +1281,7 @@ class Matrix2x1(_object):
         return _math_linear.Matrix2x1_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix2x1 self, size_t j) -> std_vector_double
         col(Matrix2x1 self, size_t j, double const * vec)
@@ -1291,72 +1291,72 @@ class Matrix2x1(_object):
         return _math_linear.Matrix2x1_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix2x1 self) -> size_t"""
         return _math_linear.Matrix2x1_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix2x1 self) -> size_t"""
         return _math_linear.Matrix2x1_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix2x1 self) -> size_t"""
         return _math_linear.Matrix2x1_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,1,double > &":
         """scale(Matrix2x1 self, double scalar) -> Matrix2x1"""
         return _math_linear.Matrix2x1_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,1 >":
         """multiply(Matrix2x1 self, double scalar) -> Matrix2x1"""
         return _math_linear.Matrix2x1_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 2,1,double > &":
         """scaleDiagonal(Matrix2x1 self, Matrix1x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 2,1,double >":
         """multiplyDiagonal(Matrix2x1 self, Matrix1x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix2x1') -> "math::linear::MatrixMxN< 2,1,double >::Like_T &":
         """__iadd__(Matrix2x1 self, Matrix2x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix2x1') -> "math::linear::MatrixMxN< 2,1,double >::Like_T &":
         """__isub__(Matrix2x1 self, Matrix2x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix2x1') -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """add(Matrix2x1 self, Matrix2x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix2x1') -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """subtract(Matrix2x1 self, Matrix2x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 1,2,double >":
         """transpose(Matrix2x1 self) -> Matrix1x2"""
         return _math_linear.Matrix2x1_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """decomposeLU(Matrix2x1 self, VectorSizeT pivotsM) -> Matrix2x1"""
         return _math_linear.Matrix2x1_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=1):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=1) -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """
         permute(Matrix2x1 self, VectorSizeT pivotsM, size_t n=1) -> Matrix2x1
         permute(Matrix2x1 self, VectorSizeT pivotsM) -> Matrix2x1
@@ -1364,37 +1364,37 @@ class Matrix2x1(_object):
         return _math_linear.Matrix2x1_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix2x1 self) -> double"""
         return _math_linear.Matrix2x1_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix2x1 self) -> double"""
         return _math_linear.Matrix2x1_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 2,1,double > &":
         """normalize(Matrix2x1 self) -> Matrix2x1"""
         return _math_linear.Matrix2x1_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """unit(Matrix2x1 self) -> Matrix2x1"""
         return _math_linear.Matrix2x1_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix2x1') -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """__add__(Matrix2x1 self, Matrix2x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix2x1') -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """__sub__(Matrix2x1 self, Matrix2x1 mx) -> Matrix2x1"""
         return _math_linear.Matrix2x1___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """__mul__(Matrix2x1 self, double scalar) -> Matrix2x1"""
         return _math_linear.Matrix2x1___mul__(self, scalar)
 
@@ -1405,27 +1405,27 @@ class Matrix2x1(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 2,1,double >::Like_T":
         """__neg__(Matrix2x1 self) -> Matrix2x1"""
         return _math_linear.Matrix2x1___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix2x1 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix2x1___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix2x1 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix2x1___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix2x1 self) -> std::string"""
         return _math_linear.Matrix2x1___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix2x1 self) -> std_vector_vector_double"""
         return _math_linear.Matrix2x1_vals(self)
 
@@ -1461,7 +1461,7 @@ class Matrix2x2(_object):
     __swig_destroy__ = _math_linear.delete_Matrix2x2
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix2x2 self, size_t i, size_t j) -> double
         __call__(Matrix2x2 self, size_t i, size_t j) -> double &
@@ -1469,7 +1469,7 @@ class Matrix2x2(_object):
         return _math_linear.Matrix2x2___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix2x2 self, size_t i) -> double const
         row(Matrix2x2 self, size_t i) -> double
@@ -1479,7 +1479,7 @@ class Matrix2x2(_object):
         return _math_linear.Matrix2x2_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix2x2 self, size_t j) -> std_vector_double
         col(Matrix2x2 self, size_t j, double const * vec)
@@ -1489,72 +1489,72 @@ class Matrix2x2(_object):
         return _math_linear.Matrix2x2_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix2x2 self) -> size_t"""
         return _math_linear.Matrix2x2_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix2x2 self) -> size_t"""
         return _math_linear.Matrix2x2_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix2x2 self) -> size_t"""
         return _math_linear.Matrix2x2_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,2,double > &":
         """scale(Matrix2x2 self, double scalar) -> Matrix2x2"""
         return _math_linear.Matrix2x2_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,2 >":
         """multiply(Matrix2x2 self, double scalar) -> Matrix2x2"""
         return _math_linear.Matrix2x2_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double > &":
         """scaleDiagonal(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >":
         """multiplyDiagonal(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >::Like_T &":
         """__iadd__(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >::Like_T &":
         """__isub__(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """add(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """subtract(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 2,2,double >":
         """transpose(Matrix2x2 self) -> Matrix2x2"""
         return _math_linear.Matrix2x2_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """decomposeLU(Matrix2x2 self, VectorSizeT pivotsM) -> Matrix2x2"""
         return _math_linear.Matrix2x2_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=2):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=2) -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """
         permute(Matrix2x2 self, VectorSizeT pivotsM, size_t n=2) -> Matrix2x2
         permute(Matrix2x2 self, VectorSizeT pivotsM) -> Matrix2x2
@@ -1562,37 +1562,37 @@ class Matrix2x2(_object):
         return _math_linear.Matrix2x2_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix2x2 self) -> double"""
         return _math_linear.Matrix2x2_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix2x2 self) -> double"""
         return _math_linear.Matrix2x2_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 2,2,double > &":
         """normalize(Matrix2x2 self) -> Matrix2x2"""
         return _math_linear.Matrix2x2_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """unit(Matrix2x2 self) -> Matrix2x2"""
         return _math_linear.Matrix2x2_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """__add__(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """__sub__(Matrix2x2 self, Matrix2x2 mx) -> Matrix2x2"""
         return _math_linear.Matrix2x2___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """__mul__(Matrix2x2 self, double scalar) -> Matrix2x2"""
         return _math_linear.Matrix2x2___mul__(self, scalar)
 
@@ -1603,27 +1603,27 @@ class Matrix2x2(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 2,2,double >::Like_T":
         """__neg__(Matrix2x2 self) -> Matrix2x2"""
         return _math_linear.Matrix2x2___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix2x2 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix2x2___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix2x2 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix2x2___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix2x2 self) -> std::string"""
         return _math_linear.Matrix2x2___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix2x2 self) -> std_vector_vector_double"""
         return _math_linear.Matrix2x2_vals(self)
 
@@ -1659,7 +1659,7 @@ class Matrix2x3(_object):
     __swig_destroy__ = _math_linear.delete_Matrix2x3
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix2x3 self, size_t i, size_t j) -> double
         __call__(Matrix2x3 self, size_t i, size_t j) -> double &
@@ -1667,7 +1667,7 @@ class Matrix2x3(_object):
         return _math_linear.Matrix2x3___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix2x3 self, size_t i) -> double const
         row(Matrix2x3 self, size_t i) -> double
@@ -1677,7 +1677,7 @@ class Matrix2x3(_object):
         return _math_linear.Matrix2x3_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix2x3 self, size_t j) -> std_vector_double
         col(Matrix2x3 self, size_t j, double const * vec)
@@ -1687,72 +1687,72 @@ class Matrix2x3(_object):
         return _math_linear.Matrix2x3_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix2x3 self) -> size_t"""
         return _math_linear.Matrix2x3_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix2x3 self) -> size_t"""
         return _math_linear.Matrix2x3_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix2x3 self) -> size_t"""
         return _math_linear.Matrix2x3_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,3,double > &":
         """scale(Matrix2x3 self, double scalar) -> Matrix2x3"""
         return _math_linear.Matrix2x3_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,3 >":
         """multiply(Matrix2x3 self, double scalar) -> Matrix2x3"""
         return _math_linear.Matrix2x3_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 2,3,double > &":
         """scaleDiagonal(Matrix2x3 self, Matrix3x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 2,3,double >":
         """multiplyDiagonal(Matrix2x3 self, Matrix3x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix2x3') -> "math::linear::MatrixMxN< 2,3,double >::Like_T &":
         """__iadd__(Matrix2x3 self, Matrix2x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix2x3') -> "math::linear::MatrixMxN< 2,3,double >::Like_T &":
         """__isub__(Matrix2x3 self, Matrix2x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix2x3') -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """add(Matrix2x3 self, Matrix2x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix2x3') -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """subtract(Matrix2x3 self, Matrix2x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 3,2,double >":
         """transpose(Matrix2x3 self) -> Matrix3x2"""
         return _math_linear.Matrix2x3_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """decomposeLU(Matrix2x3 self, VectorSizeT pivotsM) -> Matrix2x3"""
         return _math_linear.Matrix2x3_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=3):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=3) -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """
         permute(Matrix2x3 self, VectorSizeT pivotsM, size_t n=3) -> Matrix2x3
         permute(Matrix2x3 self, VectorSizeT pivotsM) -> Matrix2x3
@@ -1760,37 +1760,37 @@ class Matrix2x3(_object):
         return _math_linear.Matrix2x3_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix2x3 self) -> double"""
         return _math_linear.Matrix2x3_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix2x3 self) -> double"""
         return _math_linear.Matrix2x3_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 2,3,double > &":
         """normalize(Matrix2x3 self) -> Matrix2x3"""
         return _math_linear.Matrix2x3_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """unit(Matrix2x3 self) -> Matrix2x3"""
         return _math_linear.Matrix2x3_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix2x3') -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """__add__(Matrix2x3 self, Matrix2x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix2x3') -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """__sub__(Matrix2x3 self, Matrix2x3 mx) -> Matrix2x3"""
         return _math_linear.Matrix2x3___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """__mul__(Matrix2x3 self, double scalar) -> Matrix2x3"""
         return _math_linear.Matrix2x3___mul__(self, scalar)
 
@@ -1801,27 +1801,27 @@ class Matrix2x3(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 2,3,double >::Like_T":
         """__neg__(Matrix2x3 self) -> Matrix2x3"""
         return _math_linear.Matrix2x3___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix2x3 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix2x3___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix2x3 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix2x3___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix2x3 self) -> std::string"""
         return _math_linear.Matrix2x3___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix2x3 self) -> std_vector_vector_double"""
         return _math_linear.Matrix2x3_vals(self)
 
@@ -1857,7 +1857,7 @@ class Matrix2x7(_object):
     __swig_destroy__ = _math_linear.delete_Matrix2x7
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix2x7 self, size_t i, size_t j) -> double
         __call__(Matrix2x7 self, size_t i, size_t j) -> double &
@@ -1865,7 +1865,7 @@ class Matrix2x7(_object):
         return _math_linear.Matrix2x7___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix2x7 self, size_t i) -> double const
         row(Matrix2x7 self, size_t i) -> double
@@ -1875,7 +1875,7 @@ class Matrix2x7(_object):
         return _math_linear.Matrix2x7_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix2x7 self, size_t j) -> std_vector_double
         col(Matrix2x7 self, size_t j, double const * vec)
@@ -1885,72 +1885,72 @@ class Matrix2x7(_object):
         return _math_linear.Matrix2x7_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix2x7 self) -> size_t"""
         return _math_linear.Matrix2x7_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix2x7 self) -> size_t"""
         return _math_linear.Matrix2x7_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix2x7 self) -> size_t"""
         return _math_linear.Matrix2x7_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,7,double > &":
         """scale(Matrix2x7 self, double scalar) -> Matrix2x7"""
         return _math_linear.Matrix2x7_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,7 >":
         """multiply(Matrix2x7 self, double scalar) -> Matrix2x7"""
         return _math_linear.Matrix2x7_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 2,7,double > &":
         """scaleDiagonal(Matrix2x7 self, Matrix7x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 2,7,double >":
         """multiplyDiagonal(Matrix2x7 self, Matrix7x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix2x7') -> "math::linear::MatrixMxN< 2,7,double >::Like_T &":
         """__iadd__(Matrix2x7 self, Matrix2x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix2x7') -> "math::linear::MatrixMxN< 2,7,double >::Like_T &":
         """__isub__(Matrix2x7 self, Matrix2x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix2x7') -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """add(Matrix2x7 self, Matrix2x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix2x7') -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """subtract(Matrix2x7 self, Matrix2x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 7,2,double >":
         """transpose(Matrix2x7 self) -> Matrix7x2"""
         return _math_linear.Matrix2x7_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """decomposeLU(Matrix2x7 self, VectorSizeT pivotsM) -> Matrix2x7"""
         return _math_linear.Matrix2x7_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=7):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=7) -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """
         permute(Matrix2x7 self, VectorSizeT pivotsM, size_t n=7) -> Matrix2x7
         permute(Matrix2x7 self, VectorSizeT pivotsM) -> Matrix2x7
@@ -1958,37 +1958,37 @@ class Matrix2x7(_object):
         return _math_linear.Matrix2x7_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix2x7 self) -> double"""
         return _math_linear.Matrix2x7_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix2x7 self) -> double"""
         return _math_linear.Matrix2x7_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 2,7,double > &":
         """normalize(Matrix2x7 self) -> Matrix2x7"""
         return _math_linear.Matrix2x7_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """unit(Matrix2x7 self) -> Matrix2x7"""
         return _math_linear.Matrix2x7_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix2x7') -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """__add__(Matrix2x7 self, Matrix2x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix2x7') -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """__sub__(Matrix2x7 self, Matrix2x7 mx) -> Matrix2x7"""
         return _math_linear.Matrix2x7___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """__mul__(Matrix2x7 self, double scalar) -> Matrix2x7"""
         return _math_linear.Matrix2x7___mul__(self, scalar)
 
@@ -1999,27 +1999,27 @@ class Matrix2x7(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 2,7,double >::Like_T":
         """__neg__(Matrix2x7 self) -> Matrix2x7"""
         return _math_linear.Matrix2x7___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix2x7 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix2x7___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix2x7 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix2x7___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix2x7 self) -> std::string"""
         return _math_linear.Matrix2x7___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix2x7 self) -> std_vector_vector_double"""
         return _math_linear.Matrix2x7_vals(self)
 
@@ -2055,7 +2055,7 @@ class Matrix3x1(_object):
     __swig_destroy__ = _math_linear.delete_Matrix3x1
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix3x1 self, size_t i, size_t j) -> double
         __call__(Matrix3x1 self, size_t i, size_t j) -> double &
@@ -2063,7 +2063,7 @@ class Matrix3x1(_object):
         return _math_linear.Matrix3x1___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix3x1 self, size_t i) -> double const
         row(Matrix3x1 self, size_t i) -> double
@@ -2073,7 +2073,7 @@ class Matrix3x1(_object):
         return _math_linear.Matrix3x1_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix3x1 self, size_t j) -> std_vector_double
         col(Matrix3x1 self, size_t j, double const * vec)
@@ -2083,72 +2083,72 @@ class Matrix3x1(_object):
         return _math_linear.Matrix3x1_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix3x1 self) -> size_t"""
         return _math_linear.Matrix3x1_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix3x1 self) -> size_t"""
         return _math_linear.Matrix3x1_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix3x1 self) -> size_t"""
         return _math_linear.Matrix3x1_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,1,double > &":
         """scale(Matrix3x1 self, double scalar) -> Matrix3x1"""
         return _math_linear.Matrix3x1_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,1 >":
         """multiply(Matrix3x1 self, double scalar) -> Matrix3x1"""
         return _math_linear.Matrix3x1_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 3,1,double > &":
         """scaleDiagonal(Matrix3x1 self, Matrix1x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix1x1') -> "math::linear::MatrixMxN< 3,1,double >":
         """multiplyDiagonal(Matrix3x1 self, Matrix1x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix3x1') -> "math::linear::MatrixMxN< 3,1,double >::Like_T &":
         """__iadd__(Matrix3x1 self, Matrix3x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix3x1') -> "math::linear::MatrixMxN< 3,1,double >::Like_T &":
         """__isub__(Matrix3x1 self, Matrix3x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix3x1') -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """add(Matrix3x1 self, Matrix3x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix3x1') -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """subtract(Matrix3x1 self, Matrix3x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 1,3,double >":
         """transpose(Matrix3x1 self) -> Matrix1x3"""
         return _math_linear.Matrix3x1_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """decomposeLU(Matrix3x1 self, VectorSizeT pivotsM) -> Matrix3x1"""
         return _math_linear.Matrix3x1_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=1):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=1) -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """
         permute(Matrix3x1 self, VectorSizeT pivotsM, size_t n=1) -> Matrix3x1
         permute(Matrix3x1 self, VectorSizeT pivotsM) -> Matrix3x1
@@ -2156,37 +2156,37 @@ class Matrix3x1(_object):
         return _math_linear.Matrix3x1_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix3x1 self) -> double"""
         return _math_linear.Matrix3x1_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix3x1 self) -> double"""
         return _math_linear.Matrix3x1_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 3,1,double > &":
         """normalize(Matrix3x1 self) -> Matrix3x1"""
         return _math_linear.Matrix3x1_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """unit(Matrix3x1 self) -> Matrix3x1"""
         return _math_linear.Matrix3x1_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix3x1') -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """__add__(Matrix3x1 self, Matrix3x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix3x1') -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """__sub__(Matrix3x1 self, Matrix3x1 mx) -> Matrix3x1"""
         return _math_linear.Matrix3x1___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """__mul__(Matrix3x1 self, double scalar) -> Matrix3x1"""
         return _math_linear.Matrix3x1___mul__(self, scalar)
 
@@ -2197,27 +2197,27 @@ class Matrix3x1(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 3,1,double >::Like_T":
         """__neg__(Matrix3x1 self) -> Matrix3x1"""
         return _math_linear.Matrix3x1___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix3x1 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix3x1___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix3x1 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix3x1___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix3x1 self) -> std::string"""
         return _math_linear.Matrix3x1___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix3x1 self) -> std_vector_vector_double"""
         return _math_linear.Matrix3x1_vals(self)
 
@@ -2253,7 +2253,7 @@ class Matrix3x2(_object):
     __swig_destroy__ = _math_linear.delete_Matrix3x2
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix3x2 self, size_t i, size_t j) -> double
         __call__(Matrix3x2 self, size_t i, size_t j) -> double &
@@ -2261,7 +2261,7 @@ class Matrix3x2(_object):
         return _math_linear.Matrix3x2___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix3x2 self, size_t i) -> double const
         row(Matrix3x2 self, size_t i) -> double
@@ -2271,7 +2271,7 @@ class Matrix3x2(_object):
         return _math_linear.Matrix3x2_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix3x2 self, size_t j) -> std_vector_double
         col(Matrix3x2 self, size_t j, double const * vec)
@@ -2281,72 +2281,72 @@ class Matrix3x2(_object):
         return _math_linear.Matrix3x2_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix3x2 self) -> size_t"""
         return _math_linear.Matrix3x2_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix3x2 self) -> size_t"""
         return _math_linear.Matrix3x2_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix3x2 self) -> size_t"""
         return _math_linear.Matrix3x2_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,2,double > &":
         """scale(Matrix3x2 self, double scalar) -> Matrix3x2"""
         return _math_linear.Matrix3x2_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,2 >":
         """multiply(Matrix3x2 self, double scalar) -> Matrix3x2"""
         return _math_linear.Matrix3x2_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 3,2,double > &":
         """scaleDiagonal(Matrix3x2 self, Matrix2x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 3,2,double >":
         """multiplyDiagonal(Matrix3x2 self, Matrix2x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix3x2') -> "math::linear::MatrixMxN< 3,2,double >::Like_T &":
         """__iadd__(Matrix3x2 self, Matrix3x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix3x2') -> "math::linear::MatrixMxN< 3,2,double >::Like_T &":
         """__isub__(Matrix3x2 self, Matrix3x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix3x2') -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """add(Matrix3x2 self, Matrix3x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix3x2') -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """subtract(Matrix3x2 self, Matrix3x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 2,3,double >":
         """transpose(Matrix3x2 self) -> Matrix2x3"""
         return _math_linear.Matrix3x2_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """decomposeLU(Matrix3x2 self, VectorSizeT pivotsM) -> Matrix3x2"""
         return _math_linear.Matrix3x2_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=2):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=2) -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """
         permute(Matrix3x2 self, VectorSizeT pivotsM, size_t n=2) -> Matrix3x2
         permute(Matrix3x2 self, VectorSizeT pivotsM) -> Matrix3x2
@@ -2354,37 +2354,37 @@ class Matrix3x2(_object):
         return _math_linear.Matrix3x2_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix3x2 self) -> double"""
         return _math_linear.Matrix3x2_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix3x2 self) -> double"""
         return _math_linear.Matrix3x2_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 3,2,double > &":
         """normalize(Matrix3x2 self) -> Matrix3x2"""
         return _math_linear.Matrix3x2_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """unit(Matrix3x2 self) -> Matrix3x2"""
         return _math_linear.Matrix3x2_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix3x2') -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """__add__(Matrix3x2 self, Matrix3x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix3x2') -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """__sub__(Matrix3x2 self, Matrix3x2 mx) -> Matrix3x2"""
         return _math_linear.Matrix3x2___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """__mul__(Matrix3x2 self, double scalar) -> Matrix3x2"""
         return _math_linear.Matrix3x2___mul__(self, scalar)
 
@@ -2395,27 +2395,27 @@ class Matrix3x2(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 3,2,double >::Like_T":
         """__neg__(Matrix3x2 self) -> Matrix3x2"""
         return _math_linear.Matrix3x2___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix3x2 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix3x2___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix3x2 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix3x2___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix3x2 self) -> std::string"""
         return _math_linear.Matrix3x2___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix3x2 self) -> std_vector_vector_double"""
         return _math_linear.Matrix3x2_vals(self)
 
@@ -2451,7 +2451,7 @@ class Matrix3x3(_object):
     __swig_destroy__ = _math_linear.delete_Matrix3x3
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix3x3 self, size_t i, size_t j) -> double
         __call__(Matrix3x3 self, size_t i, size_t j) -> double &
@@ -2459,7 +2459,7 @@ class Matrix3x3(_object):
         return _math_linear.Matrix3x3___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix3x3 self, size_t i) -> double const
         row(Matrix3x3 self, size_t i) -> double
@@ -2469,7 +2469,7 @@ class Matrix3x3(_object):
         return _math_linear.Matrix3x3_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix3x3 self, size_t j) -> std_vector_double
         col(Matrix3x3 self, size_t j, double const * vec)
@@ -2479,72 +2479,72 @@ class Matrix3x3(_object):
         return _math_linear.Matrix3x3_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix3x3 self) -> size_t"""
         return _math_linear.Matrix3x3_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix3x3 self) -> size_t"""
         return _math_linear.Matrix3x3_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix3x3 self) -> size_t"""
         return _math_linear.Matrix3x3_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,3,double > &":
         """scale(Matrix3x3 self, double scalar) -> Matrix3x3"""
         return _math_linear.Matrix3x3_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,3 >":
         """multiply(Matrix3x3 self, double scalar) -> Matrix3x3"""
         return _math_linear.Matrix3x3_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double > &":
         """scaleDiagonal(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >":
         """multiplyDiagonal(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >::Like_T &":
         """__iadd__(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >::Like_T &":
         """__isub__(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """add(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """subtract(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 3,3,double >":
         """transpose(Matrix3x3 self) -> Matrix3x3"""
         return _math_linear.Matrix3x3_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """decomposeLU(Matrix3x3 self, VectorSizeT pivotsM) -> Matrix3x3"""
         return _math_linear.Matrix3x3_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=3):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=3) -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """
         permute(Matrix3x3 self, VectorSizeT pivotsM, size_t n=3) -> Matrix3x3
         permute(Matrix3x3 self, VectorSizeT pivotsM) -> Matrix3x3
@@ -2552,37 +2552,37 @@ class Matrix3x3(_object):
         return _math_linear.Matrix3x3_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix3x3 self) -> double"""
         return _math_linear.Matrix3x3_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix3x3 self) -> double"""
         return _math_linear.Matrix3x3_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 3,3,double > &":
         """normalize(Matrix3x3 self) -> Matrix3x3"""
         return _math_linear.Matrix3x3_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """unit(Matrix3x3 self) -> Matrix3x3"""
         return _math_linear.Matrix3x3_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """__add__(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """__sub__(Matrix3x3 self, Matrix3x3 mx) -> Matrix3x3"""
         return _math_linear.Matrix3x3___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """__mul__(Matrix3x3 self, double scalar) -> Matrix3x3"""
         return _math_linear.Matrix3x3___mul__(self, scalar)
 
@@ -2593,27 +2593,27 @@ class Matrix3x3(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 3,3,double >::Like_T":
         """__neg__(Matrix3x3 self) -> Matrix3x3"""
         return _math_linear.Matrix3x3___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix3x3 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix3x3___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix3x3 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix3x3___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix3x3 self) -> std::string"""
         return _math_linear.Matrix3x3___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix3x3 self) -> std_vector_vector_double"""
         return _math_linear.Matrix3x3_vals(self)
 
@@ -2649,7 +2649,7 @@ class Matrix3x7(_object):
     __swig_destroy__ = _math_linear.delete_Matrix3x7
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix3x7 self, size_t i, size_t j) -> double
         __call__(Matrix3x7 self, size_t i, size_t j) -> double &
@@ -2657,7 +2657,7 @@ class Matrix3x7(_object):
         return _math_linear.Matrix3x7___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix3x7 self, size_t i) -> double const
         row(Matrix3x7 self, size_t i) -> double
@@ -2667,7 +2667,7 @@ class Matrix3x7(_object):
         return _math_linear.Matrix3x7_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix3x7 self, size_t j) -> std_vector_double
         col(Matrix3x7 self, size_t j, double const * vec)
@@ -2677,72 +2677,72 @@ class Matrix3x7(_object):
         return _math_linear.Matrix3x7_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix3x7 self) -> size_t"""
         return _math_linear.Matrix3x7_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix3x7 self) -> size_t"""
         return _math_linear.Matrix3x7_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix3x7 self) -> size_t"""
         return _math_linear.Matrix3x7_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,7,double > &":
         """scale(Matrix3x7 self, double scalar) -> Matrix3x7"""
         return _math_linear.Matrix3x7_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,7 >":
         """multiply(Matrix3x7 self, double scalar) -> Matrix3x7"""
         return _math_linear.Matrix3x7_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 3,7,double > &":
         """scaleDiagonal(Matrix3x7 self, Matrix7x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 3,7,double >":
         """multiplyDiagonal(Matrix3x7 self, Matrix7x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix3x7') -> "math::linear::MatrixMxN< 3,7,double >::Like_T &":
         """__iadd__(Matrix3x7 self, Matrix3x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix3x7') -> "math::linear::MatrixMxN< 3,7,double >::Like_T &":
         """__isub__(Matrix3x7 self, Matrix3x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix3x7') -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """add(Matrix3x7 self, Matrix3x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix3x7') -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """subtract(Matrix3x7 self, Matrix3x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 7,3,double >":
         """transpose(Matrix3x7 self) -> Matrix7x3"""
         return _math_linear.Matrix3x7_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """decomposeLU(Matrix3x7 self, VectorSizeT pivotsM) -> Matrix3x7"""
         return _math_linear.Matrix3x7_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=7):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=7) -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """
         permute(Matrix3x7 self, VectorSizeT pivotsM, size_t n=7) -> Matrix3x7
         permute(Matrix3x7 self, VectorSizeT pivotsM) -> Matrix3x7
@@ -2750,37 +2750,37 @@ class Matrix3x7(_object):
         return _math_linear.Matrix3x7_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix3x7 self) -> double"""
         return _math_linear.Matrix3x7_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix3x7 self) -> double"""
         return _math_linear.Matrix3x7_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 3,7,double > &":
         """normalize(Matrix3x7 self) -> Matrix3x7"""
         return _math_linear.Matrix3x7_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """unit(Matrix3x7 self) -> Matrix3x7"""
         return _math_linear.Matrix3x7_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix3x7') -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """__add__(Matrix3x7 self, Matrix3x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix3x7') -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """__sub__(Matrix3x7 self, Matrix3x7 mx) -> Matrix3x7"""
         return _math_linear.Matrix3x7___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """__mul__(Matrix3x7 self, double scalar) -> Matrix3x7"""
         return _math_linear.Matrix3x7___mul__(self, scalar)
 
@@ -2791,27 +2791,27 @@ class Matrix3x7(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 3,7,double >::Like_T":
         """__neg__(Matrix3x7 self) -> Matrix3x7"""
         return _math_linear.Matrix3x7___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix3x7 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix3x7___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix3x7 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix3x7___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix3x7 self) -> std::string"""
         return _math_linear.Matrix3x7___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix3x7 self) -> std_vector_vector_double"""
         return _math_linear.Matrix3x7_vals(self)
 
@@ -2847,7 +2847,7 @@ class Matrix7x2(_object):
     __swig_destroy__ = _math_linear.delete_Matrix7x2
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix7x2 self, size_t i, size_t j) -> double
         __call__(Matrix7x2 self, size_t i, size_t j) -> double &
@@ -2855,7 +2855,7 @@ class Matrix7x2(_object):
         return _math_linear.Matrix7x2___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix7x2 self, size_t i) -> double const
         row(Matrix7x2 self, size_t i) -> double
@@ -2865,7 +2865,7 @@ class Matrix7x2(_object):
         return _math_linear.Matrix7x2_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix7x2 self, size_t j) -> std_vector_double
         col(Matrix7x2 self, size_t j, double const * vec)
@@ -2875,72 +2875,72 @@ class Matrix7x2(_object):
         return _math_linear.Matrix7x2_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix7x2 self) -> size_t"""
         return _math_linear.Matrix7x2_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix7x2 self) -> size_t"""
         return _math_linear.Matrix7x2_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix7x2 self) -> size_t"""
         return _math_linear.Matrix7x2_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,2,double > &":
         """scale(Matrix7x2 self, double scalar) -> Matrix7x2"""
         return _math_linear.Matrix7x2_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,2 >":
         """multiply(Matrix7x2 self, double scalar) -> Matrix7x2"""
         return _math_linear.Matrix7x2_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 7,2,double > &":
         """scaleDiagonal(Matrix7x2 self, Matrix2x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix2x2') -> "math::linear::MatrixMxN< 7,2,double >":
         """multiplyDiagonal(Matrix7x2 self, Matrix2x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix7x2') -> "math::linear::MatrixMxN< 7,2,double >::Like_T &":
         """__iadd__(Matrix7x2 self, Matrix7x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix7x2') -> "math::linear::MatrixMxN< 7,2,double >::Like_T &":
         """__isub__(Matrix7x2 self, Matrix7x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix7x2') -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """add(Matrix7x2 self, Matrix7x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix7x2') -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """subtract(Matrix7x2 self, Matrix7x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 2,7,double >":
         """transpose(Matrix7x2 self) -> Matrix2x7"""
         return _math_linear.Matrix7x2_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """decomposeLU(Matrix7x2 self, VectorSizeT pivotsM) -> Matrix7x2"""
         return _math_linear.Matrix7x2_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=2):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=2) -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """
         permute(Matrix7x2 self, VectorSizeT pivotsM, size_t n=2) -> Matrix7x2
         permute(Matrix7x2 self, VectorSizeT pivotsM) -> Matrix7x2
@@ -2948,37 +2948,37 @@ class Matrix7x2(_object):
         return _math_linear.Matrix7x2_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix7x2 self) -> double"""
         return _math_linear.Matrix7x2_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix7x2 self) -> double"""
         return _math_linear.Matrix7x2_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 7,2,double > &":
         """normalize(Matrix7x2 self) -> Matrix7x2"""
         return _math_linear.Matrix7x2_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """unit(Matrix7x2 self) -> Matrix7x2"""
         return _math_linear.Matrix7x2_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix7x2') -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """__add__(Matrix7x2 self, Matrix7x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix7x2') -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """__sub__(Matrix7x2 self, Matrix7x2 mx) -> Matrix7x2"""
         return _math_linear.Matrix7x2___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """__mul__(Matrix7x2 self, double scalar) -> Matrix7x2"""
         return _math_linear.Matrix7x2___mul__(self, scalar)
 
@@ -2989,27 +2989,27 @@ class Matrix7x2(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 7,2,double >::Like_T":
         """__neg__(Matrix7x2 self) -> Matrix7x2"""
         return _math_linear.Matrix7x2___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix7x2 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix7x2___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix7x2 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix7x2___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix7x2 self) -> std::string"""
         return _math_linear.Matrix7x2___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix7x2 self) -> std_vector_vector_double"""
         return _math_linear.Matrix7x2_vals(self)
 
@@ -3045,7 +3045,7 @@ class Matrix7x3(_object):
     __swig_destroy__ = _math_linear.delete_Matrix7x3
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix7x3 self, size_t i, size_t j) -> double
         __call__(Matrix7x3 self, size_t i, size_t j) -> double &
@@ -3053,7 +3053,7 @@ class Matrix7x3(_object):
         return _math_linear.Matrix7x3___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix7x3 self, size_t i) -> double const
         row(Matrix7x3 self, size_t i) -> double
@@ -3063,7 +3063,7 @@ class Matrix7x3(_object):
         return _math_linear.Matrix7x3_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix7x3 self, size_t j) -> std_vector_double
         col(Matrix7x3 self, size_t j, double const * vec)
@@ -3073,72 +3073,72 @@ class Matrix7x3(_object):
         return _math_linear.Matrix7x3_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix7x3 self) -> size_t"""
         return _math_linear.Matrix7x3_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix7x3 self) -> size_t"""
         return _math_linear.Matrix7x3_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix7x3 self) -> size_t"""
         return _math_linear.Matrix7x3_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,3,double > &":
         """scale(Matrix7x3 self, double scalar) -> Matrix7x3"""
         return _math_linear.Matrix7x3_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,3 >":
         """multiply(Matrix7x3 self, double scalar) -> Matrix7x3"""
         return _math_linear.Matrix7x3_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 7,3,double > &":
         """scaleDiagonal(Matrix7x3 self, Matrix3x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix3x3') -> "math::linear::MatrixMxN< 7,3,double >":
         """multiplyDiagonal(Matrix7x3 self, Matrix3x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix7x3') -> "math::linear::MatrixMxN< 7,3,double >::Like_T &":
         """__iadd__(Matrix7x3 self, Matrix7x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix7x3') -> "math::linear::MatrixMxN< 7,3,double >::Like_T &":
         """__isub__(Matrix7x3 self, Matrix7x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix7x3') -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """add(Matrix7x3 self, Matrix7x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix7x3') -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """subtract(Matrix7x3 self, Matrix7x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 3,7,double >":
         """transpose(Matrix7x3 self) -> Matrix3x7"""
         return _math_linear.Matrix7x3_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """decomposeLU(Matrix7x3 self, VectorSizeT pivotsM) -> Matrix7x3"""
         return _math_linear.Matrix7x3_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=3):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=3) -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """
         permute(Matrix7x3 self, VectorSizeT pivotsM, size_t n=3) -> Matrix7x3
         permute(Matrix7x3 self, VectorSizeT pivotsM) -> Matrix7x3
@@ -3146,37 +3146,37 @@ class Matrix7x3(_object):
         return _math_linear.Matrix7x3_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix7x3 self) -> double"""
         return _math_linear.Matrix7x3_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix7x3 self) -> double"""
         return _math_linear.Matrix7x3_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 7,3,double > &":
         """normalize(Matrix7x3 self) -> Matrix7x3"""
         return _math_linear.Matrix7x3_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """unit(Matrix7x3 self) -> Matrix7x3"""
         return _math_linear.Matrix7x3_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix7x3') -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """__add__(Matrix7x3 self, Matrix7x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix7x3') -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """__sub__(Matrix7x3 self, Matrix7x3 mx) -> Matrix7x3"""
         return _math_linear.Matrix7x3___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """__mul__(Matrix7x3 self, double scalar) -> Matrix7x3"""
         return _math_linear.Matrix7x3___mul__(self, scalar)
 
@@ -3187,27 +3187,27 @@ class Matrix7x3(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 7,3,double >::Like_T":
         """__neg__(Matrix7x3 self) -> Matrix7x3"""
         return _math_linear.Matrix7x3___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix7x3 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix7x3___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix7x3 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix7x3___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix7x3 self) -> std::string"""
         return _math_linear.Matrix7x3___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix7x3 self) -> std_vector_vector_double"""
         return _math_linear.Matrix7x3_vals(self)
 
@@ -3243,7 +3243,7 @@ class Matrix7x7(_object):
     __swig_destroy__ = _math_linear.delete_Matrix7x7
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(Matrix7x7 self, size_t i, size_t j) -> double
         __call__(Matrix7x7 self, size_t i, size_t j) -> double &
@@ -3251,7 +3251,7 @@ class Matrix7x7(_object):
         return _math_linear.Matrix7x7___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(Matrix7x7 self, size_t i) -> double const
         row(Matrix7x7 self, size_t i) -> double
@@ -3261,7 +3261,7 @@ class Matrix7x7(_object):
         return _math_linear.Matrix7x7_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(Matrix7x7 self, size_t j) -> std_vector_double
         col(Matrix7x7 self, size_t j, double const * vec)
@@ -3271,72 +3271,72 @@ class Matrix7x7(_object):
         return _math_linear.Matrix7x7_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(Matrix7x7 self) -> size_t"""
         return _math_linear.Matrix7x7_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(Matrix7x7 self) -> size_t"""
         return _math_linear.Matrix7x7_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Matrix7x7 self) -> size_t"""
         return _math_linear.Matrix7x7_size(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,7,double > &":
         """scale(Matrix7x7 self, double scalar) -> Matrix7x7"""
         return _math_linear.Matrix7x7_scale(self, scalar)
 
 
-    def multiply(self, scalar):
+    def multiply(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,7 >":
         """multiply(Matrix7x7 self, double scalar) -> Matrix7x7"""
         return _math_linear.Matrix7x7_multiply(self, scalar)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double > &":
         """scaleDiagonal(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7_scaleDiagonal(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >":
         """multiplyDiagonal(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7_multiplyDiagonal(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >::Like_T &":
         """__iadd__(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >::Like_T &":
         """__isub__(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """add(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """subtract(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::MatrixMxN< 7,7,double >":
         """transpose(Matrix7x7 self) -> Matrix7x7"""
         return _math_linear.Matrix7x7_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """decomposeLU(Matrix7x7 self, VectorSizeT pivotsM) -> Matrix7x7"""
         return _math_linear.Matrix7x7_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=7):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=7) -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """
         permute(Matrix7x7 self, VectorSizeT pivotsM, size_t n=7) -> Matrix7x7
         permute(Matrix7x7 self, VectorSizeT pivotsM) -> Matrix7x7
@@ -3344,37 +3344,37 @@ class Matrix7x7(_object):
         return _math_linear.Matrix7x7_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Matrix7x7 self) -> double"""
         return _math_linear.Matrix7x7_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Matrix7x7 self) -> double"""
         return _math_linear.Matrix7x7_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::MatrixMxN< 7,7,double > &":
         """normalize(Matrix7x7 self) -> Matrix7x7"""
         return _math_linear.Matrix7x7_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """unit(Matrix7x7 self) -> Matrix7x7"""
         return _math_linear.Matrix7x7_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """__add__(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'Matrix7x7') -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """__sub__(Matrix7x7 self, Matrix7x7 mx) -> Matrix7x7"""
         return _math_linear.Matrix7x7___sub__(self, mx)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """__mul__(Matrix7x7 self, double scalar) -> Matrix7x7"""
         return _math_linear.Matrix7x7___mul__(self, scalar)
 
@@ -3385,27 +3385,27 @@ class Matrix7x7(_object):
 
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::MatrixMxN< 7,7,double >::Like_T":
         """__neg__(Matrix7x7 self) -> Matrix7x7"""
         return _math_linear.Matrix7x7___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Matrix7x7 self, PyObject * inObj) -> double"""
         return _math_linear.Matrix7x7___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Matrix7x7 self, PyObject * inObj, double val)"""
         return _math_linear.Matrix7x7___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Matrix7x7 self) -> std::string"""
         return _math_linear.Matrix7x7___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(Matrix7x7 self) -> std_vector_vector_double"""
         return _math_linear.Matrix7x7_vals(self)
 
@@ -3438,7 +3438,7 @@ class Vector2(_object):
     __swig_destroy__ = _math_linear.delete_Vector2
     __del__ = lambda self: None
 
-    def matrix(self, *args):
+    def matrix(self, *args) -> "math::linear::MatrixMxN< 2,1,double > const &":
         """
         matrix(Vector2 self) -> Matrix2x1
         matrix(Vector2 self) -> Matrix2x1
@@ -3446,87 +3446,87 @@ class Vector2(_object):
         return _math_linear.Vector2_matrix(self, *args)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Vector2 self) -> size_t"""
         return _math_linear.Vector2_size(self)
 
 
-    def dot(self, vec):
+    def dot(self, vec: 'Vector2') -> "double":
         """dot(Vector2 self, Vector2 vec) -> double"""
         return _math_linear.Vector2_dot(self, vec)
 
 
-    def normDot(self, vec):
+    def normDot(self, vec: 'Vector2') -> "double":
         """normDot(Vector2 self, Vector2 vec) -> double"""
         return _math_linear.Vector2_normDot(self, vec)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Vector2 self) -> double"""
         return _math_linear.Vector2_norm(self)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Vector2 self) -> double"""
         return _math_linear.Vector2_normSq(self)
 
 
-    def angle(self, v):
+    def angle(self, v: 'Vector2') -> "double":
         """angle(Vector2 self, Vector2 v) -> double"""
         return _math_linear.Vector2_angle(self, v)
 
 
-    def normalize(self):
+    def normalize(self) -> "void":
         """normalize(Vector2 self)"""
         return _math_linear.Vector2_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::VectorN< 2,double >::Like_T":
         """unit(Vector2 self) -> Vector2"""
         return _math_linear.Vector2_unit(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "void":
         """scale(Vector2 self, double scalar)"""
         return _math_linear.Vector2_scale(self, scalar)
 
 
-    def __iadd__(self, v):
+    def __iadd__(self, v: 'Vector2') -> "math::linear::VectorN< 2,double >::Like_T &":
         """__iadd__(Vector2 self, Vector2 v) -> Vector2"""
         return _math_linear.Vector2___iadd__(self, v)
 
 
-    def __isub__(self, v):
+    def __isub__(self, v: 'Vector2') -> "math::linear::VectorN< 2,double >::Like_T &":
         """__isub__(Vector2 self, Vector2 v) -> Vector2"""
         return _math_linear.Vector2___isub__(self, v)
 
 
-    def add(self, v):
+    def add(self, v: 'Vector2') -> "math::linear::VectorN< 2,double >::Like_T":
         """add(Vector2 self, Vector2 v) -> Vector2"""
         return _math_linear.Vector2_add(self, v)
 
 
-    def subtract(self, v):
+    def subtract(self, v: 'Vector2') -> "math::linear::VectorN< 2,double >::Like_T":
         """subtract(Vector2 self, Vector2 v) -> Vector2"""
         return _math_linear.Vector2_subtract(self, v)
 
 
-    def __add__(self, v):
+    def __add__(self, v: 'Vector2') -> "math::linear::VectorN< 2,double >::Like_T":
         """__add__(Vector2 self, Vector2 v) -> Vector2"""
         return _math_linear.Vector2___add__(self, v)
 
 
-    def __sub__(self, v):
+    def __sub__(self, v: 'Vector2') -> "math::linear::VectorN< 2,double >::Like_T":
         """__sub__(Vector2 self, Vector2 v) -> Vector2"""
         return _math_linear.Vector2___sub__(self, v)
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::VectorN< 2,double >::Like_T":
         """__neg__(Vector2 self) -> Vector2"""
         return _math_linear.Vector2___neg__(self)
 
 
-    def __imul__(self, *args):
+    def __imul__(self, *args) -> "math::linear::VectorN< 2,double >::Like_T &":
         """
         __imul__(Vector2 self, Vector2 v) -> Vector2
         __imul__(Vector2 self, double sv) -> Vector2
@@ -3540,7 +3540,7 @@ class Vector2(_object):
 
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::linear::VectorN< 2,double >::Like_T":
         """
         __mul__(Vector2 self, double sv) -> Vector2
         __mul__(Vector2 self, Vector2 v) -> Vector2
@@ -3560,27 +3560,27 @@ class Vector2(_object):
         self.__init__(pickle.loads(state))
 
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: 'long') -> "double":
         """__getitem__(Vector2 self, long i) -> double"""
         return _math_linear.Vector2___getitem__(self, i)
 
 
-    def __setitem__(self, i, val):
+    def __setitem__(self, i: 'long', val: 'double') -> "void":
         """__setitem__(Vector2 self, long i, double val)"""
         return _math_linear.Vector2___setitem__(self, i, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Vector2 self) -> std::string"""
         return _math_linear.Vector2___str__(self)
 
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: 'PyObject *') -> "math::linear::VectorN< 2,double >":
         """__deepcopy__(Vector2 self, PyObject * memo) -> Vector2"""
         return _math_linear.Vector2___deepcopy__(self, memo)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< double,std::allocator< double > >":
         """vals(Vector2 self) -> std_vector_double"""
         return _math_linear.Vector2_vals(self)
 
@@ -3613,7 +3613,7 @@ class Vector3(_object):
     __swig_destroy__ = _math_linear.delete_Vector3
     __del__ = lambda self: None
 
-    def matrix(self, *args):
+    def matrix(self, *args) -> "math::linear::MatrixMxN< 3,1,double > const &":
         """
         matrix(Vector3 self) -> Matrix3x1
         matrix(Vector3 self) -> Matrix3x1
@@ -3621,87 +3621,87 @@ class Vector3(_object):
         return _math_linear.Vector3_matrix(self, *args)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Vector3 self) -> size_t"""
         return _math_linear.Vector3_size(self)
 
 
-    def dot(self, vec):
+    def dot(self, vec: 'Vector3') -> "double":
         """dot(Vector3 self, Vector3 vec) -> double"""
         return _math_linear.Vector3_dot(self, vec)
 
 
-    def normDot(self, vec):
+    def normDot(self, vec: 'Vector3') -> "double":
         """normDot(Vector3 self, Vector3 vec) -> double"""
         return _math_linear.Vector3_normDot(self, vec)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(Vector3 self) -> double"""
         return _math_linear.Vector3_norm(self)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(Vector3 self) -> double"""
         return _math_linear.Vector3_normSq(self)
 
 
-    def angle(self, v):
+    def angle(self, v: 'Vector3') -> "double":
         """angle(Vector3 self, Vector3 v) -> double"""
         return _math_linear.Vector3_angle(self, v)
 
 
-    def normalize(self):
+    def normalize(self) -> "void":
         """normalize(Vector3 self)"""
         return _math_linear.Vector3_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::VectorN< 3,double >::Like_T":
         """unit(Vector3 self) -> Vector3"""
         return _math_linear.Vector3_unit(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "void":
         """scale(Vector3 self, double scalar)"""
         return _math_linear.Vector3_scale(self, scalar)
 
 
-    def __iadd__(self, v):
+    def __iadd__(self, v: 'Vector3') -> "math::linear::VectorN< 3,double >::Like_T &":
         """__iadd__(Vector3 self, Vector3 v) -> Vector3"""
         return _math_linear.Vector3___iadd__(self, v)
 
 
-    def __isub__(self, v):
+    def __isub__(self, v: 'Vector3') -> "math::linear::VectorN< 3,double >::Like_T &":
         """__isub__(Vector3 self, Vector3 v) -> Vector3"""
         return _math_linear.Vector3___isub__(self, v)
 
 
-    def add(self, v):
+    def add(self, v: 'Vector3') -> "math::linear::VectorN< 3,double >::Like_T":
         """add(Vector3 self, Vector3 v) -> Vector3"""
         return _math_linear.Vector3_add(self, v)
 
 
-    def subtract(self, v):
+    def subtract(self, v: 'Vector3') -> "math::linear::VectorN< 3,double >::Like_T":
         """subtract(Vector3 self, Vector3 v) -> Vector3"""
         return _math_linear.Vector3_subtract(self, v)
 
 
-    def __add__(self, v):
+    def __add__(self, v: 'Vector3') -> "math::linear::VectorN< 3,double >::Like_T":
         """__add__(Vector3 self, Vector3 v) -> Vector3"""
         return _math_linear.Vector3___add__(self, v)
 
 
-    def __sub__(self, v):
+    def __sub__(self, v: 'Vector3') -> "math::linear::VectorN< 3,double >::Like_T":
         """__sub__(Vector3 self, Vector3 v) -> Vector3"""
         return _math_linear.Vector3___sub__(self, v)
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::VectorN< 3,double >::Like_T":
         """__neg__(Vector3 self) -> Vector3"""
         return _math_linear.Vector3___neg__(self)
 
 
-    def __imul__(self, *args):
+    def __imul__(self, *args) -> "math::linear::VectorN< 3,double >::Like_T &":
         """
         __imul__(Vector3 self, Vector3 v) -> Vector3
         __imul__(Vector3 self, double sv) -> Vector3
@@ -3715,7 +3715,7 @@ class Vector3(_object):
 
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::linear::VectorN< 3,double >::Like_T":
         """
         __mul__(Vector3 self, double sv) -> Vector3
         __mul__(Vector3 self, Vector3 v) -> Vector3
@@ -3735,27 +3735,27 @@ class Vector3(_object):
         self.__init__(pickle.loads(state))
 
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: 'long') -> "double":
         """__getitem__(Vector3 self, long i) -> double"""
         return _math_linear.Vector3___getitem__(self, i)
 
 
-    def __setitem__(self, i, val):
+    def __setitem__(self, i: 'long', val: 'double') -> "void":
         """__setitem__(Vector3 self, long i, double val)"""
         return _math_linear.Vector3___setitem__(self, i, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Vector3 self) -> std::string"""
         return _math_linear.Vector3___str__(self)
 
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: 'PyObject *') -> "math::linear::VectorN< 3,double >":
         """__deepcopy__(Vector3 self, PyObject * memo) -> Vector3"""
         return _math_linear.Vector3___deepcopy__(self, memo)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< double,std::allocator< double > >":
         """vals(Vector3 self) -> std_vector_double"""
         return _math_linear.Vector3_vals(self)
 
@@ -3763,7 +3763,7 @@ Vector3_swigregister = _math_linear.Vector3_swigregister
 Vector3_swigregister(Vector3)
 
 
-def cross(*args):
+def cross(*args) -> "math::linear::Vector< double >":
     """
     cross(Vector3 u, Vector3 v) -> Vector3
     cross(VectorDouble u, VectorDouble v) -> VectorDouble
@@ -3796,12 +3796,12 @@ class VectorDouble(_object):
     __swig_destroy__ = _math_linear.delete_VectorDouble
     __del__ = lambda self: None
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(VectorDouble self) -> size_t"""
         return _math_linear.VectorDouble_size(self)
 
 
-    def matrix(self, *args):
+    def matrix(self, *args) -> "math::linear::Matrix2D< double > const &":
         """
         matrix(VectorDouble self) -> MatrixDouble
         matrix(VectorDouble self) -> MatrixDouble
@@ -3809,82 +3809,82 @@ class VectorDouble(_object):
         return _math_linear.VectorDouble_matrix(self, *args)
 
 
-    def get(self):
+    def get(self) -> "double const *":
         """get(VectorDouble self) -> double const *"""
         return _math_linear.VectorDouble_get(self)
 
 
-    def dot(self, vec_):
+    def dot(self, vec_: 'VectorDouble') -> "double":
         """dot(VectorDouble self, VectorDouble vec_) -> double"""
         return _math_linear.VectorDouble_dot(self, vec_)
 
 
-    def angle(self, v):
+    def angle(self, v: 'VectorDouble') -> "double":
         """angle(VectorDouble self, VectorDouble v) -> double"""
         return _math_linear.VectorDouble_angle(self, v)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(VectorDouble self) -> double"""
         return _math_linear.VectorDouble_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(VectorDouble self) -> double"""
         return _math_linear.VectorDouble_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "void":
         """normalize(VectorDouble self)"""
         return _math_linear.VectorDouble_normalize(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "void":
         """scale(VectorDouble self, double scalar)"""
         return _math_linear.VectorDouble_scale(self, scalar)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::Vector< double >":
         """unit(VectorDouble self) -> VectorDouble"""
         return _math_linear.VectorDouble_unit(self)
 
 
-    def __iadd__(self, v):
+    def __iadd__(self, v: 'VectorDouble') -> "math::linear::Vector< double > &":
         """__iadd__(VectorDouble self, VectorDouble v) -> VectorDouble"""
         return _math_linear.VectorDouble___iadd__(self, v)
 
 
-    def __isub__(self, v):
+    def __isub__(self, v: 'VectorDouble') -> "math::linear::Vector< double > &":
         """__isub__(VectorDouble self, VectorDouble v) -> VectorDouble"""
         return _math_linear.VectorDouble___isub__(self, v)
 
 
-    def add(self, v):
+    def add(self, v: 'VectorDouble') -> "math::linear::Vector< double >":
         """add(VectorDouble self, VectorDouble v) -> VectorDouble"""
         return _math_linear.VectorDouble_add(self, v)
 
 
-    def subtract(self, v):
+    def subtract(self, v: 'VectorDouble') -> "math::linear::Vector< double >":
         """subtract(VectorDouble self, VectorDouble v) -> VectorDouble"""
         return _math_linear.VectorDouble_subtract(self, v)
 
 
-    def __add__(self, v):
+    def __add__(self, v: 'VectorDouble') -> "math::linear::Vector< double >":
         """__add__(VectorDouble self, VectorDouble v) -> VectorDouble"""
         return _math_linear.VectorDouble___add__(self, v)
 
 
-    def __sub__(self, v):
+    def __sub__(self, v: 'VectorDouble') -> "math::linear::Vector< double >":
         """__sub__(VectorDouble self, VectorDouble v) -> VectorDouble"""
         return _math_linear.VectorDouble___sub__(self, v)
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::Vector< double >":
         """__neg__(VectorDouble self) -> VectorDouble"""
         return _math_linear.VectorDouble___neg__(self)
 
 
-    def __imul__(self, *args):
+    def __imul__(self, *args) -> "math::linear::Vector< double > &":
         """
         __imul__(VectorDouble self, VectorDouble v) -> VectorDouble
         __imul__(VectorDouble self, double sv) -> VectorDouble
@@ -3898,7 +3898,7 @@ class VectorDouble(_object):
 
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::linear::Vector< double >":
         """
         __mul__(VectorDouble self, double sv) -> VectorDouble
         __mul__(VectorDouble self, VectorDouble v) -> VectorDouble
@@ -3912,22 +3912,22 @@ class VectorDouble(_object):
 
 
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: 'long') -> "double":
         """__getitem__(VectorDouble self, long i) -> double"""
         return _math_linear.VectorDouble___getitem__(self, i)
 
 
-    def __setitem__(self, i, val):
+    def __setitem__(self, i: 'long', val: 'double') -> "void":
         """__setitem__(VectorDouble self, long i, double val)"""
         return _math_linear.VectorDouble___setitem__(self, i, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(VectorDouble self) -> std::string"""
         return _math_linear.VectorDouble___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< double,std::allocator< double > >":
         """vals(VectorDouble self) -> std_vector_double"""
         return _math_linear.VectorDouble_vals(self)
 
@@ -3961,7 +3961,7 @@ class MatrixDouble(_object):
     __swig_destroy__ = _math_linear.delete_MatrixDouble
     __del__ = lambda self: None
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "double &":
         """
         __call__(MatrixDouble self, size_t i, size_t j) -> double
         __call__(MatrixDouble self, size_t i, size_t j) -> double &
@@ -3969,7 +3969,7 @@ class MatrixDouble(_object):
         return _math_linear.MatrixDouble___call__(self, *args)
 
 
-    def row(self, *args):
+    def row(self, *args) -> "void":
         """
         row(MatrixDouble self, size_t i) -> double const
         row(MatrixDouble self, size_t i) -> double
@@ -3979,7 +3979,7 @@ class MatrixDouble(_object):
         return _math_linear.MatrixDouble_row(self, *args)
 
 
-    def col(self, *args):
+    def col(self, *args) -> "void":
         """
         col(MatrixDouble self, size_t j) -> std_vector_double
         col(MatrixDouble self, size_t j, double const * vec_)
@@ -3988,32 +3988,32 @@ class MatrixDouble(_object):
         return _math_linear.MatrixDouble_col(self, *args)
 
 
-    def rows(self):
+    def rows(self) -> "size_t":
         """rows(MatrixDouble self) -> size_t"""
         return _math_linear.MatrixDouble_rows(self)
 
 
-    def cols(self):
+    def cols(self) -> "size_t":
         """cols(MatrixDouble self) -> size_t"""
         return _math_linear.MatrixDouble_cols(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(MatrixDouble self) -> size_t"""
         return _math_linear.MatrixDouble_size(self)
 
 
-    def get(self):
+    def get(self) -> "double const *":
         """get(MatrixDouble self) -> double const *"""
         return _math_linear.MatrixDouble_get(self)
 
 
-    def scale(self, scalar):
+    def scale(self, scalar: 'double') -> "math::linear::Matrix2D< double > &":
         """scale(MatrixDouble self, double scalar) -> MatrixDouble"""
         return _math_linear.MatrixDouble_scale(self, scalar)
 
 
-    def multiply(self, *args):
+    def multiply(self, *args) -> "void":
         """
         multiply(MatrixDouble self, double scalar) -> MatrixDouble
         multiply(MatrixDouble self, MatrixDouble mx) -> MatrixDouble
@@ -4022,57 +4022,57 @@ class MatrixDouble(_object):
         return _math_linear.MatrixDouble_multiply(self, *args)
 
 
-    def scaleDiagonal(self, mx):
+    def scaleDiagonal(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double > &":
         """scaleDiagonal(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble_scaleDiagonal(self, mx)
 
 
-    def scaleDiagonalRowVector(self, mx):
+    def scaleDiagonalRowVector(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double > &":
         """scaleDiagonalRowVector(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble_scaleDiagonalRowVector(self, mx)
 
 
-    def multiplyDiagonal(self, mx):
+    def multiplyDiagonal(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double >":
         """multiplyDiagonal(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble_multiplyDiagonal(self, mx)
 
 
-    def multiplyDiagonalRowVector(self, mx):
+    def multiplyDiagonalRowVector(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double >":
         """multiplyDiagonalRowVector(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble_multiplyDiagonalRowVector(self, mx)
 
 
-    def __iadd__(self, mx):
+    def __iadd__(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double > &":
         """__iadd__(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble___iadd__(self, mx)
 
 
-    def __isub__(self, mx):
+    def __isub__(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double > &":
         """__isub__(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble___isub__(self, mx)
 
 
-    def add(self, mx):
+    def add(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double >":
         """add(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble_add(self, mx)
 
 
-    def subtract(self, mx):
+    def subtract(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double >":
         """subtract(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble_subtract(self, mx)
 
 
-    def transpose(self):
+    def transpose(self) -> "math::linear::Matrix2D< double >":
         """transpose(MatrixDouble self) -> MatrixDouble"""
         return _math_linear.MatrixDouble_transpose(self)
 
 
-    def decomposeLU(self, pivotsM):
+    def decomposeLU(self, pivotsM: 'VectorSizeT') -> "math::linear::Matrix2D< double >":
         """decomposeLU(MatrixDouble self, VectorSizeT pivotsM) -> MatrixDouble"""
         return _math_linear.MatrixDouble_decomposeLU(self, pivotsM)
 
 
-    def permute(self, pivotsM, n=0):
+    def permute(self, pivotsM: 'VectorSizeT', n: 'size_t'=0) -> "math::linear::Matrix2D< double >":
         """
         permute(MatrixDouble self, VectorSizeT pivotsM, size_t n=0) -> MatrixDouble
         permute(MatrixDouble self, VectorSizeT pivotsM) -> MatrixDouble
@@ -4080,32 +4080,32 @@ class MatrixDouble(_object):
         return _math_linear.MatrixDouble_permute(self, pivotsM, n)
 
 
-    def normSq(self):
+    def normSq(self) -> "double":
         """normSq(MatrixDouble self) -> double"""
         return _math_linear.MatrixDouble_normSq(self)
 
 
-    def norm(self):
+    def norm(self) -> "double":
         """norm(MatrixDouble self) -> double"""
         return _math_linear.MatrixDouble_norm(self)
 
 
-    def normalize(self):
+    def normalize(self) -> "math::linear::Matrix2D< double > &":
         """normalize(MatrixDouble self) -> MatrixDouble"""
         return _math_linear.MatrixDouble_normalize(self)
 
 
-    def unit(self):
+    def unit(self) -> "math::linear::Matrix2D< double >":
         """unit(MatrixDouble self) -> MatrixDouble"""
         return _math_linear.MatrixDouble_unit(self)
 
 
-    def __add__(self, mx):
+    def __add__(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double >":
         """__add__(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble___add__(self, mx)
 
 
-    def __sub__(self, mx):
+    def __sub__(self, mx: 'MatrixDouble') -> "math::linear::Matrix2D< double >":
         """__sub__(MatrixDouble self, MatrixDouble mx) -> MatrixDouble"""
         return _math_linear.MatrixDouble___sub__(self, mx)
 
@@ -4116,7 +4116,7 @@ class MatrixDouble(_object):
 
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::linear::Matrix2D< double >":
         """
         __mul__(MatrixDouble self, double scalar) -> MatrixDouble
         __mul__(MatrixDouble self, MatrixDouble mx) -> MatrixDouble
@@ -4124,27 +4124,27 @@ class MatrixDouble(_object):
         return _math_linear.MatrixDouble___mul__(self, *args)
 
 
-    def __neg__(self):
+    def __neg__(self) -> "math::linear::Matrix2D< double >":
         """__neg__(MatrixDouble self) -> MatrixDouble"""
         return _math_linear.MatrixDouble___neg__(self)
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(MatrixDouble self, PyObject * inObj) -> double"""
         return _math_linear.MatrixDouble___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(MatrixDouble self, PyObject * inObj, double val)"""
         return _math_linear.MatrixDouble___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(MatrixDouble self) -> std::string"""
         return _math_linear.MatrixDouble___str__(self)
 
 
-    def vals(self):
+    def vals(self) -> "std::vector< std::vector< double,std::allocator< double > >,std::allocator< std::vector< double,std::allocator< double > > > >":
         """vals(MatrixDouble self) -> std_vector_vector_double"""
         return _math_linear.MatrixDouble_vals(self)
 

--- a/modules/python/math.poly/source/generated/math_poly.py
+++ b/modules/python/math.poly/source/generated/math_poly.py
@@ -100,19 +100,19 @@ import coda.coda_except
 import coda.coda_types
 import coda.coda_sys
 
-def new_doubleArray(nelements):
+def new_doubleArray(nelements: 'size_t') -> "double *":
     """new_doubleArray(size_t nelements) -> double *"""
     return _math_poly.new_doubleArray(nelements)
 
-def delete_doubleArray(ary):
+def delete_doubleArray(ary: 'double *') -> "void":
     """delete_doubleArray(double * ary)"""
     return _math_poly.delete_doubleArray(ary)
 
-def doubleArray_getitem(ary, index):
+def doubleArray_getitem(ary: 'double *', index: 'size_t') -> "double":
     """doubleArray_getitem(double * ary, size_t index) -> double"""
     return _math_poly.doubleArray_getitem(ary, index)
 
-def doubleArray_setitem(ary, index, value):
+def doubleArray_setitem(ary: 'double *', index: 'size_t', value: 'double') -> "void":
     """doubleArray_setitem(double * ary, size_t index, double value)"""
     return _math_poly.doubleArray_setitem(ary, index, value)
 
@@ -140,37 +140,37 @@ class Poly1D(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def order(self):
+    def order(self) -> "size_t":
         """order(Poly1D self) -> size_t"""
         return _math_poly.Poly1D_order(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(Poly1D self) -> size_t"""
         return _math_poly.Poly1D_size(self)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(Poly1D self) -> bool"""
         return _math_poly.Poly1D_empty(self)
 
 
-    def coeffs(self):
+    def coeffs(self) -> "std::vector< double,std::allocator< double > > const &":
         """coeffs(Poly1D self) -> std_vector_double"""
         return _math_poly.Poly1D_coeffs(self)
 
 
-    def scaleVariable(self, scale):
+    def scaleVariable(self, scale: 'double') -> "math::poly::OneD< double >":
         """scaleVariable(Poly1D self, double scale) -> Poly1D"""
         return _math_poly.Poly1D_scaleVariable(self, scale)
 
 
-    def truncateTo(self, order):
+    def truncateTo(self, order: 'size_t') -> "math::poly::OneD< double >":
         """truncateTo(Poly1D self, size_t order) -> Poly1D"""
         return _math_poly.Poly1D_truncateTo(self, order)
 
 
-    def truncateToNonZeros(self, zeroEpsilon=0.0):
+    def truncateToNonZeros(self, zeroEpsilon: 'double'=0.0) -> "math::poly::OneD< double >":
         """
         truncateToNonZeros(Poly1D self, double zeroEpsilon=0.0) -> Poly1D
         truncateToNonZeros(Poly1D self) -> Poly1D
@@ -178,7 +178,7 @@ class Poly1D(_object):
         return _math_poly.Poly1D_truncateToNonZeros(self, zeroEpsilon)
 
 
-    def transformInput(self, gx, zeroEpsilon=0.0):
+    def transformInput(self, gx: 'Poly1D', zeroEpsilon: 'double'=0.0) -> "math::poly::OneD< double >":
         """
         transformInput(Poly1D self, Poly1D gx, double zeroEpsilon=0.0) -> Poly1D
         transformInput(Poly1D self, Poly1D gx) -> Poly1D
@@ -186,32 +186,32 @@ class Poly1D(_object):
         return _math_poly.Poly1D_transformInput(self, gx, zeroEpsilon)
 
 
-    def copyFrom(self, p):
+    def copyFrom(self, p: 'Poly1D') -> "void":
         """copyFrom(Poly1D self, Poly1D p)"""
         return _math_poly.Poly1D_copyFrom(self, p)
 
 
-    def integrate(self, start, end):
+    def integrate(self, start: 'double', end: 'double') -> "double":
         """integrate(Poly1D self, double start, double end) -> double"""
         return _math_poly.Poly1D_integrate(self, start, end)
 
 
-    def derivative(self):
+    def derivative(self) -> "math::poly::OneD< double >":
         """derivative(Poly1D self) -> Poly1D"""
         return _math_poly.Poly1D_derivative(self)
 
 
-    def velocity(self, x):
+    def velocity(self, x: 'double') -> "double":
         """velocity(Poly1D self, double x) -> double"""
         return _math_poly.Poly1D_velocity(self, x)
 
 
-    def acceleration(self, x):
+    def acceleration(self, x: 'double') -> "double":
         """acceleration(Poly1D self, double x) -> double"""
         return _math_poly.Poly1D_acceleration(self, x)
 
 
-    def __imul__(self, *args):
+    def __imul__(self, *args) -> "math::poly::OneD< double > &":
         """
         __imul__(Poly1D self, double cv) -> Poly1D
         __imul__(Poly1D self, Poly1D p) -> Poly1D
@@ -219,7 +219,7 @@ class Poly1D(_object):
         return _math_poly.Poly1D___imul__(self, *args)
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::poly::OneD< double >":
         """
         __mul__(Poly1D self, double cv) -> Poly1D
         __mul__(Poly1D self, Poly1D p) -> Poly1D
@@ -227,22 +227,22 @@ class Poly1D(_object):
         return _math_poly.Poly1D___mul__(self, *args)
 
 
-    def __iadd__(self, p):
+    def __iadd__(self, p: 'Poly1D') -> "math::poly::OneD< double > &":
         """__iadd__(Poly1D self, Poly1D p) -> Poly1D"""
         return _math_poly.Poly1D___iadd__(self, p)
 
 
-    def __add__(self, p):
+    def __add__(self, p: 'Poly1D') -> "math::poly::OneD< double >":
         """__add__(Poly1D self, Poly1D p) -> Poly1D"""
         return _math_poly.Poly1D___add__(self, p)
 
 
-    def __isub__(self, p):
+    def __isub__(self, p: 'Poly1D') -> "math::poly::OneD< double > &":
         """__isub__(Poly1D self, Poly1D p) -> Poly1D"""
         return _math_poly.Poly1D___isub__(self, p)
 
 
-    def __sub__(self, p):
+    def __sub__(self, p: 'Poly1D') -> "math::poly::OneD< double >":
         """__sub__(Poly1D self, Poly1D p) -> Poly1D"""
         return _math_poly.Poly1D___sub__(self, p)
 
@@ -259,17 +259,17 @@ class Poly1D(_object):
 
 
 
-    def power(self, toThe):
+    def power(self, toThe: 'size_t') -> "math::poly::OneD< double >":
         """power(Poly1D self, size_t toThe) -> Poly1D"""
         return _math_poly.Poly1D_power(self, toThe)
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'Poly1D') -> "bool":
         """__eq__(Poly1D self, Poly1D p) -> bool"""
         return _math_poly.Poly1D___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'Poly1D') -> "bool":
         """__ne__(Poly1D self, Poly1D p) -> bool"""
         return _math_poly.Poly1D___ne__(self, p)
 
@@ -289,27 +289,27 @@ class Poly1D(_object):
 
 
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: 'long') -> "double":
         """__getitem__(Poly1D self, long i) -> double"""
         return _math_poly.Poly1D___getitem__(self, i)
 
 
-    def __setitem__(self, i, val):
+    def __setitem__(self, i: 'long', val: 'double') -> "void":
         """__setitem__(Poly1D self, long i, double val)"""
         return _math_poly.Poly1D___setitem__(self, i, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Poly1D self) -> std::string"""
         return _math_poly.Poly1D___str__(self)
 
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: 'PyObject *') -> "math::poly::OneD< double >":
         """__deepcopy__(Poly1D self, PyObject * memo) -> Poly1D"""
         return _math_poly.Poly1D___deepcopy__(self, memo)
 
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "PyObject *":
         """
         __call__(Poly1D self, double at) -> double
         __call__(Poly1D self, PyObject * input) -> PyObject *
@@ -317,7 +317,7 @@ class Poly1D(_object):
         return _math_poly.Poly1D___call__(self, *args)
 
 
-    def asArray(self):
+    def asArray(self) -> "PyObject *":
         """asArray(Poly1D self) -> PyObject *"""
         return _math_poly.Poly1D_asArray(self)
 
@@ -342,34 +342,34 @@ class Vector3Coefficients(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, Vector3Coefficients, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(Vector3Coefficients self) -> SwigPyIterator"""
         return _math_poly.Vector3Coefficients_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(Vector3Coefficients self) -> bool"""
         return _math_poly.Vector3Coefficients___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(Vector3Coefficients self) -> bool"""
         return _math_poly.Vector3Coefficients___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< math::linear::VectorN< 3,double > >::size_type":
         """__len__(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::size_type"""
         return _math_poly.Vector3Coefficients___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< math::linear::VectorN< 3,double > >::difference_type', j: 'std::vector< math::linear::VectorN< 3,double > >::difference_type') -> "std::vector< math::linear::VectorN< 3,double >,std::allocator< math::linear::VectorN< 3,double > > > *":
         """__getslice__(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::difference_type i, std::vector< math::linear::VectorN< 3,double > >::difference_type j) -> Vector3Coefficients"""
         return _math_poly.Vector3Coefficients___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::difference_type i, std::vector< math::linear::VectorN< 3,double > >::difference_type j)
         __setslice__(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::difference_type i, std::vector< math::linear::VectorN< 3,double > >::difference_type j, Vector3Coefficients v)
@@ -377,12 +377,12 @@ class Vector3Coefficients(_object):
         return _math_poly.Vector3Coefficients___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< math::linear::VectorN< 3,double > >::difference_type', j: 'std::vector< math::linear::VectorN< 3,double > >::difference_type') -> "void":
         """__delslice__(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::difference_type i, std::vector< math::linear::VectorN< 3,double > >::difference_type j)"""
         return _math_poly.Vector3Coefficients___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::difference_type i)
         __delitem__(Vector3Coefficients self, PySliceObject * slice)
@@ -390,7 +390,7 @@ class Vector3Coefficients(_object):
         return _math_poly.Vector3Coefficients___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< math::linear::VectorN< 3,double > >::value_type const &":
         """
         __getitem__(Vector3Coefficients self, PySliceObject * slice) -> Vector3Coefficients
         __getitem__(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::difference_type i) -> Vector3
@@ -398,7 +398,7 @@ class Vector3Coefficients(_object):
         return _math_poly.Vector3Coefficients___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(Vector3Coefficients self, PySliceObject * slice, Vector3Coefficients v)
         __setitem__(Vector3Coefficients self, PySliceObject * slice)
@@ -407,67 +407,67 @@ class Vector3Coefficients(_object):
         return _math_poly.Vector3Coefficients___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< math::linear::VectorN< 3,double > >::value_type":
         """pop(Vector3Coefficients self) -> Vector3"""
         return _math_poly.Vector3Coefficients_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'Vector3') -> "void":
         """append(Vector3Coefficients self, Vector3 x)"""
         return _math_poly.Vector3Coefficients_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(Vector3Coefficients self) -> bool"""
         return _math_poly.Vector3Coefficients_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< math::linear::VectorN< 3,double > >::size_type":
         """size(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::size_type"""
         return _math_poly.Vector3Coefficients_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'Vector3Coefficients') -> "void":
         """swap(Vector3Coefficients self, Vector3Coefficients v)"""
         return _math_poly.Vector3Coefficients_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< math::linear::VectorN< 3,double > >::iterator":
         """begin(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::iterator"""
         return _math_poly.Vector3Coefficients_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< math::linear::VectorN< 3,double > >::iterator":
         """end(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::iterator"""
         return _math_poly.Vector3Coefficients_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< math::linear::VectorN< 3,double > >::reverse_iterator":
         """rbegin(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::reverse_iterator"""
         return _math_poly.Vector3Coefficients_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< math::linear::VectorN< 3,double > >::reverse_iterator":
         """rend(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::reverse_iterator"""
         return _math_poly.Vector3Coefficients_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(Vector3Coefficients self)"""
         return _math_poly.Vector3Coefficients_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< math::linear::VectorN< 3,double > >::allocator_type":
         """get_allocator(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::allocator_type"""
         return _math_poly.Vector3Coefficients_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(Vector3Coefficients self)"""
         return _math_poly.Vector3Coefficients_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< math::linear::VectorN< 3,double > >::iterator":
         """
         erase(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::iterator pos) -> std::vector< math::linear::VectorN< 3,double > >::iterator
         erase(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::iterator first, std::vector< math::linear::VectorN< 3,double > >::iterator last) -> std::vector< math::linear::VectorN< 3,double > >::iterator
@@ -488,27 +488,27 @@ class Vector3Coefficients(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'Vector3') -> "void":
         """push_back(Vector3Coefficients self, Vector3 x)"""
         return _math_poly.Vector3Coefficients_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< math::linear::VectorN< 3,double > >::value_type const &":
         """front(Vector3Coefficients self) -> Vector3"""
         return _math_poly.Vector3Coefficients_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< math::linear::VectorN< 3,double > >::value_type const &":
         """back(Vector3Coefficients self) -> Vector3"""
         return _math_poly.Vector3Coefficients_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< math::linear::VectorN< 3,double > >::size_type', x: 'Vector3') -> "void":
         """assign(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::size_type n, Vector3 x)"""
         return _math_poly.Vector3Coefficients_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::size_type new_size)
         resize(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::size_type new_size, Vector3 x)
@@ -516,7 +516,7 @@ class Vector3Coefficients(_object):
         return _math_poly.Vector3Coefficients_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::iterator pos, Vector3 x) -> std::vector< math::linear::VectorN< 3,double > >::iterator
         insert(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::iterator pos, std::vector< math::linear::VectorN< 3,double > >::size_type n, Vector3 x)
@@ -524,12 +524,12 @@ class Vector3Coefficients(_object):
         return _math_poly.Vector3Coefficients_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< math::linear::VectorN< 3,double > >::size_type') -> "void":
         """reserve(Vector3Coefficients self, std::vector< math::linear::VectorN< 3,double > >::size_type n)"""
         return _math_poly.Vector3Coefficients_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< math::linear::VectorN< 3,double > >::size_type":
         """capacity(Vector3Coefficients self) -> std::vector< math::linear::VectorN< 3,double > >::size_type"""
         return _math_poly.Vector3Coefficients_capacity(self)
 
@@ -558,7 +558,7 @@ class Poly2D(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, Poly2D, name)
     __repr__ = _swig_repr
 
-    def coeffs(self):
+    def coeffs(self) -> "std::vector< math::poly::OneD< double >,std::allocator< math::poly::OneD< double > > > &":
         """coeffs(Poly2D self) -> Poly1DVector"""
         return _math_poly.Poly2D_coeffs(self)
 
@@ -575,52 +575,52 @@ class Poly2D(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(Poly2D self) -> bool"""
         return _math_poly.Poly2D_empty(self)
 
 
-    def orderX(self):
+    def orderX(self) -> "size_t":
         """orderX(Poly2D self) -> size_t"""
         return _math_poly.Poly2D_orderX(self)
 
 
-    def orderY(self):
+    def orderY(self) -> "size_t":
         """orderY(Poly2D self) -> size_t"""
         return _math_poly.Poly2D_orderY(self)
 
 
-    def integrate(self, xStart, xEnd, yStart, yEnd):
+    def integrate(self, xStart: 'double', xEnd: 'double', yStart: 'double', yEnd: 'double') -> "double":
         """integrate(Poly2D self, double xStart, double xEnd, double yStart, double yEnd) -> double"""
         return _math_poly.Poly2D_integrate(self, xStart, xEnd, yStart, yEnd)
 
 
-    def set(self, i, p):
+    def set(self, i: 'size_t', p: 'Poly1D') -> "void":
         """set(Poly2D self, size_t i, Poly1D p)"""
         return _math_poly.Poly2D_set(self, i, p)
 
 
-    def flipXY(self):
+    def flipXY(self) -> "math::poly::TwoD< double >":
         """flipXY(Poly2D self) -> Poly2D"""
         return _math_poly.Poly2D_flipXY(self)
 
 
-    def derivativeY(self):
+    def derivativeY(self) -> "math::poly::TwoD< double >":
         """derivativeY(Poly2D self) -> Poly2D"""
         return _math_poly.Poly2D_derivativeY(self)
 
 
-    def derivativeX(self):
+    def derivativeX(self) -> "math::poly::TwoD< double >":
         """derivativeX(Poly2D self) -> Poly2D"""
         return _math_poly.Poly2D_derivativeX(self)
 
 
-    def derivativeXY(self):
+    def derivativeXY(self) -> "math::poly::TwoD< double >":
         """derivativeXY(Poly2D self) -> Poly2D"""
         return _math_poly.Poly2D_derivativeXY(self)
 
 
-    def scaleVariable(self, *args):
+    def scaleVariable(self, *args) -> "math::poly::TwoD< double >":
         """
         scaleVariable(Poly2D self, double scaleX, double scaleY) -> Poly2D
         scaleVariable(Poly2D self, double scale) -> Poly2D
@@ -628,12 +628,12 @@ class Poly2D(_object):
         return _math_poly.Poly2D_scaleVariable(self, *args)
 
 
-    def truncateTo(self, orderX, orderY):
+    def truncateTo(self, orderX: 'size_t', orderY: 'size_t') -> "math::poly::TwoD< double >":
         """truncateTo(Poly2D self, size_t orderX, size_t orderY) -> Poly2D"""
         return _math_poly.Poly2D_truncateTo(self, orderX, orderY)
 
 
-    def truncateToNonZeros(self, zeroEpsilon=0.0):
+    def truncateToNonZeros(self, zeroEpsilon: 'double'=0.0) -> "math::poly::TwoD< double >":
         """
         truncateToNonZeros(Poly2D self, double zeroEpsilon=0.0) -> Poly2D
         truncateToNonZeros(Poly2D self) -> Poly2D
@@ -641,7 +641,7 @@ class Poly2D(_object):
         return _math_poly.Poly2D_truncateToNonZeros(self, zeroEpsilon)
 
 
-    def transformInput(self, *args):
+    def transformInput(self, *args) -> "math::poly::TwoD< double >":
         """
         transformInput(Poly2D self, Poly2D gx, Poly2D gy, double zeroEpsilon=0.0) -> Poly2D
         transformInput(Poly2D self, Poly2D gx, Poly2D gy) -> Poly2D
@@ -651,12 +651,12 @@ class Poly2D(_object):
         return _math_poly.Poly2D_transformInput(self, *args)
 
 
-    def atY(self, y):
+    def atY(self, y: 'double') -> "math::poly::OneD< double >":
         """atY(Poly2D self, double y) -> Poly1D"""
         return _math_poly.Poly2D_atY(self, y)
 
 
-    def __imul__(self, *args):
+    def __imul__(self, *args) -> "math::poly::TwoD< double > &":
         """
         __imul__(Poly2D self, double cv) -> Poly2D
         __imul__(Poly2D self, Poly2D p) -> Poly2D
@@ -664,7 +664,7 @@ class Poly2D(_object):
         return _math_poly.Poly2D___imul__(self, *args)
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::poly::TwoD< double >":
         """
         __mul__(Poly2D self, double cv) -> Poly2D
         __mul__(Poly2D self, Poly2D p) -> Poly2D
@@ -672,22 +672,22 @@ class Poly2D(_object):
         return _math_poly.Poly2D___mul__(self, *args)
 
 
-    def __iadd__(self, p):
+    def __iadd__(self, p: 'Poly2D') -> "math::poly::TwoD< double > &":
         """__iadd__(Poly2D self, Poly2D p) -> Poly2D"""
         return _math_poly.Poly2D___iadd__(self, p)
 
 
-    def __add__(self, p):
+    def __add__(self, p: 'Poly2D') -> "math::poly::TwoD< double >":
         """__add__(Poly2D self, Poly2D p) -> Poly2D"""
         return _math_poly.Poly2D___add__(self, p)
 
 
-    def __isub__(self, p):
+    def __isub__(self, p: 'Poly2D') -> "math::poly::TwoD< double > &":
         """__isub__(Poly2D self, Poly2D p) -> Poly2D"""
         return _math_poly.Poly2D___isub__(self, p)
 
 
-    def __sub__(self, p):
+    def __sub__(self, p: 'Poly2D') -> "math::poly::TwoD< double >":
         """__sub__(Poly2D self, Poly2D p) -> Poly2D"""
         return _math_poly.Poly2D___sub__(self, p)
 
@@ -704,22 +704,22 @@ class Poly2D(_object):
 
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'Poly2D') -> "bool":
         """__eq__(Poly2D self, Poly2D p) -> bool"""
         return _math_poly.Poly2D___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'Poly2D') -> "bool":
         """__ne__(Poly2D self, Poly2D p) -> bool"""
         return _math_poly.Poly2D___ne__(self, p)
 
 
-    def power(self, toThe):
+    def power(self, toThe: 'size_t') -> "math::poly::TwoD< double >":
         """power(Poly2D self, size_t toThe) -> Poly2D"""
         return _math_poly.Poly2D_power(self, toThe)
 
 
-    def isScalar(self):
+    def isScalar(self) -> "bool":
         """isScalar(Poly2D self) -> bool"""
         return _math_poly.Poly2D_isScalar(self)
 
@@ -738,27 +738,27 @@ class Poly2D(_object):
         return state
 
 
-    def __getitem__(self, inObj):
+    def __getitem__(self, inObj: 'PyObject *') -> "double":
         """__getitem__(Poly2D self, PyObject * inObj) -> double"""
         return _math_poly.Poly2D___getitem__(self, inObj)
 
 
-    def __setitem__(self, inObj, val):
+    def __setitem__(self, inObj: 'PyObject *', val: 'double') -> "void":
         """__setitem__(Poly2D self, PyObject * inObj, double val)"""
         return _math_poly.Poly2D___setitem__(self, inObj, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(Poly2D self) -> std::string"""
         return _math_poly.Poly2D___str__(self)
 
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: 'PyObject *') -> "math::poly::TwoD< double >":
         """__deepcopy__(Poly2D self, PyObject * memo) -> Poly2D"""
         return _math_poly.Poly2D___deepcopy__(self, memo)
 
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "PyObject *":
         """
         __call__(Poly2D self, double atX, double atY) -> double
         __call__(Poly2D self, PyObject * x_input, PyObject * y_input) -> PyObject *
@@ -766,7 +766,7 @@ class Poly2D(_object):
         return _math_poly.Poly2D___call__(self, *args)
 
 
-    def asArray(self):
+    def asArray(self) -> "PyObject *":
         """asArray(Poly2D self) -> PyObject *"""
         return _math_poly.Poly2D_asArray(self)
 
@@ -795,34 +795,34 @@ class Poly1DVector(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, Poly1DVector, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(Poly1DVector self) -> SwigPyIterator"""
         return _math_poly.Poly1DVector_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(Poly1DVector self) -> bool"""
         return _math_poly.Poly1DVector___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(Poly1DVector self) -> bool"""
         return _math_poly.Poly1DVector___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< math::poly::OneD< double > >::size_type":
         """__len__(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::size_type"""
         return _math_poly.Poly1DVector___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< math::poly::OneD< double > >::difference_type', j: 'std::vector< math::poly::OneD< double > >::difference_type') -> "std::vector< math::poly::OneD< double >,std::allocator< math::poly::OneD< double > > > *":
         """__getslice__(Poly1DVector self, std::vector< math::poly::OneD< double > >::difference_type i, std::vector< math::poly::OneD< double > >::difference_type j) -> Poly1DVector"""
         return _math_poly.Poly1DVector___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(Poly1DVector self, std::vector< math::poly::OneD< double > >::difference_type i, std::vector< math::poly::OneD< double > >::difference_type j)
         __setslice__(Poly1DVector self, std::vector< math::poly::OneD< double > >::difference_type i, std::vector< math::poly::OneD< double > >::difference_type j, Poly1DVector v)
@@ -830,12 +830,12 @@ class Poly1DVector(_object):
         return _math_poly.Poly1DVector___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< math::poly::OneD< double > >::difference_type', j: 'std::vector< math::poly::OneD< double > >::difference_type') -> "void":
         """__delslice__(Poly1DVector self, std::vector< math::poly::OneD< double > >::difference_type i, std::vector< math::poly::OneD< double > >::difference_type j)"""
         return _math_poly.Poly1DVector___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(Poly1DVector self, std::vector< math::poly::OneD< double > >::difference_type i)
         __delitem__(Poly1DVector self, PySliceObject * slice)
@@ -843,7 +843,7 @@ class Poly1DVector(_object):
         return _math_poly.Poly1DVector___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< math::poly::OneD< double > >::value_type const &":
         """
         __getitem__(Poly1DVector self, PySliceObject * slice) -> Poly1DVector
         __getitem__(Poly1DVector self, std::vector< math::poly::OneD< double > >::difference_type i) -> Poly1D
@@ -851,7 +851,7 @@ class Poly1DVector(_object):
         return _math_poly.Poly1DVector___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(Poly1DVector self, PySliceObject * slice, Poly1DVector v)
         __setitem__(Poly1DVector self, PySliceObject * slice)
@@ -860,67 +860,67 @@ class Poly1DVector(_object):
         return _math_poly.Poly1DVector___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< math::poly::OneD< double > >::value_type":
         """pop(Poly1DVector self) -> Poly1D"""
         return _math_poly.Poly1DVector_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'Poly1D') -> "void":
         """append(Poly1DVector self, Poly1D x)"""
         return _math_poly.Poly1DVector_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(Poly1DVector self) -> bool"""
         return _math_poly.Poly1DVector_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< math::poly::OneD< double > >::size_type":
         """size(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::size_type"""
         return _math_poly.Poly1DVector_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'Poly1DVector') -> "void":
         """swap(Poly1DVector self, Poly1DVector v)"""
         return _math_poly.Poly1DVector_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< math::poly::OneD< double > >::iterator":
         """begin(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::iterator"""
         return _math_poly.Poly1DVector_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< math::poly::OneD< double > >::iterator":
         """end(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::iterator"""
         return _math_poly.Poly1DVector_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< math::poly::OneD< double > >::reverse_iterator":
         """rbegin(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::reverse_iterator"""
         return _math_poly.Poly1DVector_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< math::poly::OneD< double > >::reverse_iterator":
         """rend(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::reverse_iterator"""
         return _math_poly.Poly1DVector_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(Poly1DVector self)"""
         return _math_poly.Poly1DVector_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< math::poly::OneD< double > >::allocator_type":
         """get_allocator(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::allocator_type"""
         return _math_poly.Poly1DVector_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(Poly1DVector self)"""
         return _math_poly.Poly1DVector_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< math::poly::OneD< double > >::iterator":
         """
         erase(Poly1DVector self, std::vector< math::poly::OneD< double > >::iterator pos) -> std::vector< math::poly::OneD< double > >::iterator
         erase(Poly1DVector self, std::vector< math::poly::OneD< double > >::iterator first, std::vector< math::poly::OneD< double > >::iterator last) -> std::vector< math::poly::OneD< double > >::iterator
@@ -941,27 +941,27 @@ class Poly1DVector(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'Poly1D') -> "void":
         """push_back(Poly1DVector self, Poly1D x)"""
         return _math_poly.Poly1DVector_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< math::poly::OneD< double > >::value_type const &":
         """front(Poly1DVector self) -> Poly1D"""
         return _math_poly.Poly1DVector_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< math::poly::OneD< double > >::value_type const &":
         """back(Poly1DVector self) -> Poly1D"""
         return _math_poly.Poly1DVector_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< math::poly::OneD< double > >::size_type', x: 'Poly1D') -> "void":
         """assign(Poly1DVector self, std::vector< math::poly::OneD< double > >::size_type n, Poly1D x)"""
         return _math_poly.Poly1DVector_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(Poly1DVector self, std::vector< math::poly::OneD< double > >::size_type new_size)
         resize(Poly1DVector self, std::vector< math::poly::OneD< double > >::size_type new_size, Poly1D x)
@@ -969,7 +969,7 @@ class Poly1DVector(_object):
         return _math_poly.Poly1DVector_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(Poly1DVector self, std::vector< math::poly::OneD< double > >::iterator pos, Poly1D x) -> std::vector< math::poly::OneD< double > >::iterator
         insert(Poly1DVector self, std::vector< math::poly::OneD< double > >::iterator pos, std::vector< math::poly::OneD< double > >::size_type n, Poly1D x)
@@ -977,12 +977,12 @@ class Poly1DVector(_object):
         return _math_poly.Poly1DVector_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< math::poly::OneD< double > >::size_type') -> "void":
         """reserve(Poly1DVector self, std::vector< math::poly::OneD< double > >::size_type n)"""
         return _math_poly.Poly1DVector_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< math::poly::OneD< double > >::size_type":
         """capacity(Poly1DVector self) -> std::vector< math::poly::OneD< double > >::size_type"""
         return _math_poly.Poly1DVector_capacity(self)
 
@@ -1003,7 +1003,7 @@ Poly1DVector_swigregister = _math_poly.Poly1DVector_swigregister
 Poly1DVector_swigregister(Poly1DVector)
 
 
-def fit(*args):
+def fit(*args) -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
     """
     fit(size_t numObs, double const * x, double const * y, size_t order) -> Poly1D
     fit(MatrixDouble x, MatrixDouble y, MatrixDouble z, size_t nx, size_t ny) -> Poly2D
@@ -1014,7 +1014,7 @@ def fit(*args):
     """
     return _math_poly.fit(*args)
 
-def FitVectorDouble(x, y, order):
+def FitVectorDouble(x: 'VectorDouble', y: 'VectorDouble', order: 'size_t') -> "math::poly::OneD< double >":
     """FitVectorDouble(VectorDouble x, VectorDouble y, size_t order) -> Poly1D"""
     return _math_poly.FitVectorDouble(x, y, order)
 class PolyVector3(_object):
@@ -1039,57 +1039,57 @@ class PolyVector3(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def order(self):
+    def order(self) -> "size_t":
         """order(PolyVector3 self) -> size_t"""
         return _math_poly.PolyVector3_order(self)
 
 
-    def size(self):
+    def size(self) -> "size_t":
         """size(PolyVector3 self) -> size_t"""
         return _math_poly.PolyVector3_size(self)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(PolyVector3 self) -> bool"""
         return _math_poly.PolyVector3_empty(self)
 
 
-    def coeffs(self):
+    def coeffs(self) -> "std::vector< math::linear::VectorN< 3,double >,std::allocator< math::linear::VectorN< 3,double > > > const &":
         """coeffs(PolyVector3 self) -> Vector3Coefficients"""
         return _math_poly.PolyVector3_coeffs(self)
 
 
-    def scaleVariable(self, scale):
+    def scaleVariable(self, scale: 'double') -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
         """scaleVariable(PolyVector3 self, double scale) -> PolyVector3"""
         return _math_poly.PolyVector3_scaleVariable(self, scale)
 
 
-    def truncateTo(self, order):
+    def truncateTo(self, order: 'size_t') -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
         """truncateTo(PolyVector3 self, size_t order) -> PolyVector3"""
         return _math_poly.PolyVector3_truncateTo(self, order)
 
 
-    def copyFrom(self, p):
+    def copyFrom(self, p: 'PolyVector3') -> "void":
         """copyFrom(PolyVector3 self, PolyVector3 p)"""
         return _math_poly.PolyVector3_copyFrom(self, p)
 
 
-    def derivative(self):
+    def derivative(self) -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
         """derivative(PolyVector3 self) -> PolyVector3"""
         return _math_poly.PolyVector3_derivative(self)
 
 
-    def velocity(self, x):
+    def velocity(self, x: 'double') -> "math::linear::VectorN< 3,double >":
         """velocity(PolyVector3 self, double x) -> Vector3"""
         return _math_poly.PolyVector3_velocity(self, x)
 
 
-    def acceleration(self, x):
+    def acceleration(self, x: 'double') -> "math::linear::VectorN< 3,double >":
         """acceleration(PolyVector3 self, double x) -> Vector3"""
         return _math_poly.PolyVector3_acceleration(self, x)
 
 
-    def __imul__(self, *args):
+    def __imul__(self, *args) -> "math::poly::OneD< math::linear::VectorN< 3,double > > &":
         """
         __imul__(PolyVector3 self, double cv) -> PolyVector3
         __imul__(PolyVector3 self, PolyVector3 p) -> PolyVector3
@@ -1097,7 +1097,7 @@ class PolyVector3(_object):
         return _math_poly.PolyVector3___imul__(self, *args)
 
 
-    def __mul__(self, *args):
+    def __mul__(self, *args) -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
         """
         __mul__(PolyVector3 self, double cv) -> PolyVector3
         __mul__(PolyVector3 self, PolyVector3 p) -> PolyVector3
@@ -1105,22 +1105,22 @@ class PolyVector3(_object):
         return _math_poly.PolyVector3___mul__(self, *args)
 
 
-    def __iadd__(self, p):
+    def __iadd__(self, p: 'PolyVector3') -> "math::poly::OneD< math::linear::VectorN< 3,double > > &":
         """__iadd__(PolyVector3 self, PolyVector3 p) -> PolyVector3"""
         return _math_poly.PolyVector3___iadd__(self, p)
 
 
-    def __add__(self, p):
+    def __add__(self, p: 'PolyVector3') -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
         """__add__(PolyVector3 self, PolyVector3 p) -> PolyVector3"""
         return _math_poly.PolyVector3___add__(self, p)
 
 
-    def __isub__(self, p):
+    def __isub__(self, p: 'PolyVector3') -> "math::poly::OneD< math::linear::VectorN< 3,double > > &":
         """__isub__(PolyVector3 self, PolyVector3 p) -> PolyVector3"""
         return _math_poly.PolyVector3___isub__(self, p)
 
 
-    def __sub__(self, p):
+    def __sub__(self, p: 'PolyVector3') -> "math::poly::OneD< math::linear::VectorN< 3,double > >":
         """__sub__(PolyVector3 self, PolyVector3 p) -> PolyVector3"""
         return _math_poly.PolyVector3___sub__(self, p)
 
@@ -1137,12 +1137,12 @@ class PolyVector3(_object):
 
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'PolyVector3') -> "bool":
         """__eq__(PolyVector3 self, PolyVector3 p) -> bool"""
         return _math_poly.PolyVector3___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'PolyVector3') -> "bool":
         """__ne__(PolyVector3 self, PolyVector3 p) -> bool"""
         return _math_poly.PolyVector3___ne__(self, p)
 
@@ -1162,27 +1162,27 @@ class PolyVector3(_object):
 
 
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: 'long') -> "Vector3":
         """__getitem__(PolyVector3 self, long i) -> Vector3"""
         return _math_poly.PolyVector3___getitem__(self, i)
 
 
-    def __setitem__(self, i, val):
+    def __setitem__(self, i: 'long', val: 'Vector3') -> "void":
         """__setitem__(PolyVector3 self, long i, Vector3 val)"""
         return _math_poly.PolyVector3___setitem__(self, i, val)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(PolyVector3 self) -> std::string"""
         return _math_poly.PolyVector3___str__(self)
 
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: 'PyObject *') -> "math::poly::OneD< Vector3 >":
         """__deepcopy__(PolyVector3 self, PyObject * memo) -> PolyVector3"""
         return _math_poly.PolyVector3___deepcopy__(self, memo)
 
 
-    def __call__(self, *args):
+    def __call__(self, *args) -> "PyObject *":
         """
         __call__(PolyVector3 self, double at) -> Vector3
         __call__(PolyVector3 self, PyObject * input) -> PyObject *
@@ -1190,7 +1190,7 @@ class PolyVector3(_object):
         return _math_poly.PolyVector3___call__(self, *args)
 
 
-    def asArray(self):
+    def asArray(self) -> "PyObject *":
         """asArray(PolyVector3 self) -> PyObject *"""
         return _math_poly.PolyVector3_asArray(self)
 
@@ -1213,34 +1213,34 @@ class StdVectorDouble(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, StdVectorDouble, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(StdVectorDouble self) -> SwigPyIterator"""
         return _math_poly.StdVectorDouble_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(StdVectorDouble self) -> bool"""
         return _math_poly.StdVectorDouble___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(StdVectorDouble self) -> bool"""
         return _math_poly.StdVectorDouble___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< double >::size_type":
         """__len__(StdVectorDouble self) -> std::vector< double >::size_type"""
         return _math_poly.StdVectorDouble___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< double >::difference_type', j: 'std::vector< double >::difference_type') -> "std::vector< double,std::allocator< double > > *":
         """__getslice__(StdVectorDouble self, std::vector< double >::difference_type i, std::vector< double >::difference_type j) -> std_vector_double"""
         return _math_poly.StdVectorDouble___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(StdVectorDouble self, std::vector< double >::difference_type i, std::vector< double >::difference_type j)
         __setslice__(StdVectorDouble self, std::vector< double >::difference_type i, std::vector< double >::difference_type j, std_vector_double v)
@@ -1248,12 +1248,12 @@ class StdVectorDouble(_object):
         return _math_poly.StdVectorDouble___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< double >::difference_type', j: 'std::vector< double >::difference_type') -> "void":
         """__delslice__(StdVectorDouble self, std::vector< double >::difference_type i, std::vector< double >::difference_type j)"""
         return _math_poly.StdVectorDouble___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(StdVectorDouble self, std::vector< double >::difference_type i)
         __delitem__(StdVectorDouble self, PySliceObject * slice)
@@ -1261,67 +1261,67 @@ class StdVectorDouble(_object):
         return _math_poly.StdVectorDouble___delitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< double >::value_type":
         """pop(StdVectorDouble self) -> std::vector< double >::value_type"""
         return _math_poly.StdVectorDouble_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'std::vector< double >::value_type const &') -> "void":
         """append(StdVectorDouble self, std::vector< double >::value_type const & x)"""
         return _math_poly.StdVectorDouble_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(StdVectorDouble self) -> bool"""
         return _math_poly.StdVectorDouble_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< double >::size_type":
         """size(StdVectorDouble self) -> std::vector< double >::size_type"""
         return _math_poly.StdVectorDouble_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'std_vector_double') -> "void":
         """swap(StdVectorDouble self, std_vector_double v)"""
         return _math_poly.StdVectorDouble_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< double >::iterator":
         """begin(StdVectorDouble self) -> std::vector< double >::iterator"""
         return _math_poly.StdVectorDouble_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< double >::iterator":
         """end(StdVectorDouble self) -> std::vector< double >::iterator"""
         return _math_poly.StdVectorDouble_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< double >::reverse_iterator":
         """rbegin(StdVectorDouble self) -> std::vector< double >::reverse_iterator"""
         return _math_poly.StdVectorDouble_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< double >::reverse_iterator":
         """rend(StdVectorDouble self) -> std::vector< double >::reverse_iterator"""
         return _math_poly.StdVectorDouble_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(StdVectorDouble self)"""
         return _math_poly.StdVectorDouble_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< double >::allocator_type":
         """get_allocator(StdVectorDouble self) -> std::vector< double >::allocator_type"""
         return _math_poly.StdVectorDouble_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(StdVectorDouble self)"""
         return _math_poly.StdVectorDouble_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< double >::iterator":
         """
         erase(StdVectorDouble self, std::vector< double >::iterator pos) -> std::vector< double >::iterator
         erase(StdVectorDouble self, std::vector< double >::iterator first, std::vector< double >::iterator last) -> std::vector< double >::iterator
@@ -1342,27 +1342,27 @@ class StdVectorDouble(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'std::vector< double >::value_type const &') -> "void":
         """push_back(StdVectorDouble self, std::vector< double >::value_type const & x)"""
         return _math_poly.StdVectorDouble_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< double >::value_type const &":
         """front(StdVectorDouble self) -> std::vector< double >::value_type const &"""
         return _math_poly.StdVectorDouble_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< double >::value_type const &":
         """back(StdVectorDouble self) -> std::vector< double >::value_type const &"""
         return _math_poly.StdVectorDouble_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< double >::size_type', x: 'std::vector< double >::value_type const &') -> "void":
         """assign(StdVectorDouble self, std::vector< double >::size_type n, std::vector< double >::value_type const & x)"""
         return _math_poly.StdVectorDouble_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(StdVectorDouble self, std::vector< double >::size_type new_size)
         resize(StdVectorDouble self, std::vector< double >::size_type new_size, std::vector< double >::value_type const & x)
@@ -1370,7 +1370,7 @@ class StdVectorDouble(_object):
         return _math_poly.StdVectorDouble_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(StdVectorDouble self, std::vector< double >::iterator pos, std::vector< double >::value_type const & x) -> std::vector< double >::iterator
         insert(StdVectorDouble self, std::vector< double >::iterator pos, std::vector< double >::size_type n, std::vector< double >::value_type const & x)
@@ -1378,12 +1378,12 @@ class StdVectorDouble(_object):
         return _math_poly.StdVectorDouble_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< double >::size_type') -> "void":
         """reserve(StdVectorDouble self, std::vector< double >::size_type n)"""
         return _math_poly.StdVectorDouble_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< double >::size_type":
         """capacity(StdVectorDouble self) -> std::vector< double >::size_type"""
         return _math_poly.StdVectorDouble_capacity(self)
 
@@ -1399,7 +1399,7 @@ class StdVectorDouble(_object):
             self.push_back(pickle.loads(elem))
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "double":
         """
         __getitem__(StdVectorDouble self, PySliceObject * slice) -> std_vector_double
         __getitem__(StdVectorDouble self, std::vector< double >::difference_type i) -> std::vector< double >::value_type const
@@ -1408,7 +1408,7 @@ class StdVectorDouble(_object):
         return _math_poly.StdVectorDouble___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(StdVectorDouble self, PySliceObject * slice, std_vector_double v)
         __setitem__(StdVectorDouble self, PySliceObject * slice)
@@ -1418,7 +1418,7 @@ class StdVectorDouble(_object):
         return _math_poly.StdVectorDouble___setitem__(self, *args)
 
 
-    def __str__(self):
+    def __str__(self) -> "std::string":
         """__str__(StdVectorDouble self) -> std::string"""
         return _math_poly.StdVectorDouble___str__(self)
 

--- a/modules/python/mt/source/generated/mt.py
+++ b/modules/python/mt/source/generated/mt.py
@@ -111,7 +111,7 @@ class Runnable(_object):
     __swig_destroy__ = _mt.delete_Runnable
     __del__ = lambda self: None
 
-    def run(self):
+    def run(self) -> "void":
         """run(Runnable self)"""
         return _mt.Runnable_run(self)
 
@@ -127,7 +127,7 @@ class ThreadPlanner(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, ThreadPlanner, name)
     __repr__ = _swig_repr
 
-    def __init__(self, numElements, numThreads):
+    def __init__(self, numElements: 'size_t', numThreads: 'size_t'):
         """__init__(mt::ThreadPlanner self, size_t numElements, size_t numThreads) -> ThreadPlanner"""
         this = _mt.new_ThreadPlanner(numElements, numThreads)
         try:
@@ -135,17 +135,17 @@ class ThreadPlanner(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def getNumElementsPerThread(self):
+    def getNumElementsPerThread(self) -> "size_t":
         """getNumElementsPerThread(ThreadPlanner self) -> size_t"""
         return _mt.ThreadPlanner_getNumElementsPerThread(self)
 
 
-    def getNumThreadsThatWillBeUsed(self):
+    def getNumThreadsThatWillBeUsed(self) -> "size_t":
         """getNumThreadsThatWillBeUsed(ThreadPlanner self) -> size_t"""
         return _mt.ThreadPlanner_getNumThreadsThatWillBeUsed(self)
 
 
-    def getThreadInfo(self, threadNum):
+    def getThreadInfo(self, threadNum: 'size_t') -> "PyObject *":
         """getThreadInfo(ThreadPlanner self, size_t threadNum) -> PyObject *"""
         return _mt.ThreadPlanner_getThreadInfo(self, threadNum)
 
@@ -173,12 +173,12 @@ class ThreadGroup(_object):
     __swig_destroy__ = _mt.delete_ThreadGroup
     __del__ = lambda self: None
 
-    def joinAll(self):
+    def joinAll(self) -> "void":
         """joinAll(ThreadGroup self)"""
         return _mt.ThreadGroup_joinAll(self)
 
 
-    def createThread(self, runnable):
+    def createThread(self, runnable: 'PyObject *') -> "void":
         """createThread(ThreadGroup self, PyObject * runnable)"""
         return _mt.ThreadGroup_createThread(self, runnable)
 

--- a/modules/python/sio.lite/source/generated/sio_lite.py
+++ b/modules/python/sio.lite/source/generated/sio_lite.py
@@ -130,107 +130,107 @@ class FileHeader(_object):
     __swig_destroy__ = _sio_lite.delete_FileHeader
     __del__ = lambda self: None
 
-    def getLength(self):
+    def getLength(self) -> "long":
         """getLength(FileHeader self) -> long"""
         return _sio_lite.FileHeader_getLength(self)
 
 
-    def getNumLines(self):
+    def getNumLines(self) -> "int":
         """getNumLines(FileHeader self) -> int"""
         return _sio_lite.FileHeader_getNumLines(self)
 
 
-    def setNumLines(self, numLines):
+    def setNumLines(self, numLines: 'int') -> "void":
         """setNumLines(FileHeader self, int numLines)"""
         return _sio_lite.FileHeader_setNumLines(self, numLines)
 
 
-    def getNumElements(self):
+    def getNumElements(self) -> "int":
         """getNumElements(FileHeader self) -> int"""
         return _sio_lite.FileHeader_getNumElements(self)
 
 
-    def setNumElements(self, numElements):
+    def setNumElements(self, numElements: 'int') -> "void":
         """setNumElements(FileHeader self, int numElements)"""
         return _sio_lite.FileHeader_setNumElements(self, numElements)
 
 
-    def getElementSize(self):
+    def getElementSize(self) -> "int":
         """getElementSize(FileHeader self) -> int"""
         return _sio_lite.FileHeader_getElementSize(self)
 
 
-    def setElementSize(self, size):
+    def setElementSize(self, size: 'int') -> "void":
         """setElementSize(FileHeader self, int size)"""
         return _sio_lite.FileHeader_setElementSize(self, size)
 
 
-    def getElementType(self):
+    def getElementType(self) -> "int":
         """getElementType(FileHeader self) -> int"""
         return _sio_lite.FileHeader_getElementType(self)
 
 
-    def setElementType(self, type):
+    def setElementType(self, type: 'int') -> "void":
         """setElementType(FileHeader self, int type)"""
         return _sio_lite.FileHeader_setElementType(self, type)
 
 
-    def getElementTypeAsString(self):
+    def getElementTypeAsString(self) -> "std::string":
         """getElementTypeAsString(FileHeader self) -> std::string"""
         return _sio_lite.FileHeader_getElementTypeAsString(self)
 
 
-    def getVersion(self):
+    def getVersion(self) -> "int":
         """getVersion(FileHeader self) -> int"""
         return _sio_lite.FileHeader_getVersion(self)
 
 
-    def setVersion(self, newVersion):
+    def setVersion(self, newVersion: 'int') -> "void":
         """setVersion(FileHeader self, int newVersion)"""
         return _sio_lite.FileHeader_setVersion(self, newVersion)
 
 
-    def idsAreNullTerminated(self):
+    def idsAreNullTerminated(self) -> "bool":
         """idsAreNullTerminated(FileHeader self) -> bool"""
         return _sio_lite.FileHeader_idsAreNullTerminated(self)
 
 
-    def setNullTerminationFlag(self, flag):
+    def setNullTerminationFlag(self, flag: 'bool') -> "void":
         """setNullTerminationFlag(FileHeader self, bool flag)"""
         return _sio_lite.FileHeader_setNullTerminationFlag(self, flag)
 
 
-    def isDifferentByteOrdering(self):
+    def isDifferentByteOrdering(self) -> "bool":
         """isDifferentByteOrdering(FileHeader self) -> bool"""
         return _sio_lite.FileHeader_isDifferentByteOrdering(self)
 
 
-    def setIsDifferentByteOrdering(self, isDifferent):
+    def setIsDifferentByteOrdering(self, isDifferent: 'bool') -> "void":
         """setIsDifferentByteOrdering(FileHeader self, bool isDifferent)"""
         return _sio_lite.FileHeader_setIsDifferentByteOrdering(self, isDifferent)
 
 
-    def userDataFieldExists(self, key):
+    def userDataFieldExists(self, key: 'std::string const &') -> "bool":
         """userDataFieldExists(FileHeader self, std::string const & key) -> bool"""
         return _sio_lite.FileHeader_userDataFieldExists(self, key)
 
 
-    def getAllUserDataFields(self, keys):
+    def getAllUserDataFields(self, keys: 'std::vector< std::string > &') -> "void":
         """getAllUserDataFields(FileHeader self, std::vector< std::string > & keys)"""
         return _sio_lite.FileHeader_getAllUserDataFields(self, keys)
 
 
-    def getNumUserDataFields(self):
+    def getNumUserDataFields(self) -> "size_t":
         """getNumUserDataFields(FileHeader self) -> size_t"""
         return _sio_lite.FileHeader_getNumUserDataFields(self)
 
 
-    def getUserData(self, key):
+    def getUserData(self, key: 'std::string const &') -> "std::vector< sys::byte > &":
         """getUserData(FileHeader self, std::string const & key) -> std::vector< sys::byte > &"""
         return _sio_lite.FileHeader_getUserData(self, key)
 
 
-    def getUserDataSection(self, *args):
+    def getUserDataSection(self, *args) -> "sio::lite::UserDataDictionary &":
         """
         getUserDataSection(FileHeader self) -> sio::lite::UserDataDictionary const
         getUserDataSection(FileHeader self) -> sio::lite::UserDataDictionary &
@@ -238,7 +238,7 @@ class FileHeader(_object):
         return _sio_lite.FileHeader_getUserDataSection(self, *args)
 
 
-    def addUserData(self, *args):
+    def addUserData(self, *args) -> "void":
         """
         addUserData(FileHeader self, std::string const & field, std::string const & data)
         addUserData(FileHeader self, std::string const & field, std::vector< sys::byte > const & data)
@@ -247,7 +247,7 @@ class FileHeader(_object):
         return _sio_lite.FileHeader_addUserData(self, *args)
 
 
-    def to(self, numBands, os):
+    def to(self, numBands: 'size_t', os: 'OutputStream') -> "void":
         """to(FileHeader self, size_t numBands, OutputStream os)"""
         return _sio_lite.FileHeader_to(self, numBands, os)
 
@@ -278,7 +278,7 @@ class FileWriter(_object):
     __swig_destroy__ = _sio_lite.delete_FileWriter
     __del__ = lambda self: None
 
-    def write(self, *args):
+    def write(self, *args) -> "void":
         """
         write(FileWriter self, FileHeader header, std::vector< io::InputStream * > bandStreams)
         write(FileWriter self, int numLines, int numElements, int elementSize, int elementType, std::vector< io::InputStream * > bandStreams)
@@ -321,7 +321,7 @@ class StreamReader(coda.coda_io.InputStream):
         except __builtin__.Exception:
             self.this = this
 
-    def setInputStream(self, arg2, adopt=False):
+    def setInputStream(self, arg2: 'InputStream', adopt: 'bool'=False) -> "void":
         """
         setInputStream(StreamReader self, InputStream arg2, bool adopt=False)
         setInputStream(StreamReader self, InputStream arg2)
@@ -329,12 +329,12 @@ class StreamReader(coda.coda_io.InputStream):
         return _sio_lite.StreamReader_setInputStream(self, arg2, adopt)
 
 
-    def getInputStream(self):
+    def getInputStream(self) -> "io::InputStream *":
         """getInputStream(StreamReader self) -> InputStream"""
         return _sio_lite.StreamReader_getInputStream(self)
 
 
-    def getHeader(self, *args):
+    def getHeader(self, *args) -> "sio::lite::FileHeader const *":
         """
         getHeader(StreamReader self) -> FileHeader
         getHeader(StreamReader self) -> FileHeader
@@ -342,17 +342,17 @@ class StreamReader(coda.coda_io.InputStream):
         return _sio_lite.StreamReader_getHeader(self, *args)
 
 
-    def readHeader(self):
+    def readHeader(self) -> "sio::lite::FileHeader *":
         """readHeader(StreamReader self) -> FileHeader"""
         return _sio_lite.StreamReader_readHeader(self)
 
 
-    def available(self):
+    def available(self) -> "sys::Off_T":
         """available(StreamReader self) -> sys::Off_T"""
         return _sio_lite.StreamReader_available(self)
 
 
-    def read(self, data, size):
+    def read(self, data: 'long long', size: 'long long') -> "sys::SSize_T":
         """read(StreamReader self, long long data, long long size) -> sys::SSize_T"""
         return _sio_lite.StreamReader_read(self, data, size)
 
@@ -387,17 +387,17 @@ class FileReader(StreamReader, coda.coda_io.Seekable):
         except __builtin__.Exception:
             self.this = this
 
-    def seek(self, offset, whence):
+    def seek(self, offset: 'sys::Off_T', whence: 'io::Seekable::Whence') -> "sys::Off_T":
         """seek(FileReader self, sys::Off_T offset, io::Seekable::Whence whence) -> sys::Off_T"""
         return _sio_lite.FileReader_seek(self, offset, whence)
 
 
-    def tell(self):
+    def tell(self) -> "sys::Off_T":
         """tell(FileReader self) -> sys::Off_T"""
         return _sio_lite.FileReader_tell(self)
 
 
-    def killStream(self):
+    def killStream(self) -> "void":
         """killStream(FileReader self)"""
         return _sio_lite.FileReader_killStream(self)
 

--- a/modules/python/sys/source/generated/coda_sys.py
+++ b/modules/python/sys/source/generated/coda_sys.py
@@ -98,25 +98,25 @@ except __builtin__.Exception:
 NativeLayer_func__ = _coda_sys.NativeLayer_func__
 SYS_FUNC = _coda_sys.SYS_FUNC
 
-def isBigEndianSystem():
+def isBigEndianSystem() -> "bool":
     """isBigEndianSystem() -> bool"""
     return _coda_sys.isBigEndianSystem()
 
-def byteSwap(*args):
+def byteSwap(*args) -> "void":
     """
     byteSwap(void * buffer, unsigned short elemSize, size_t numElems)
     byteSwap(void const * buffer, unsigned short elemSize, size_t numElems, void * outputBuffer)
     """
     return _coda_sys.byteSwap(*args)
 
-def alignedAlloc(*args):
+def alignedAlloc(*args) -> "void *":
     """
     alignedAlloc(size_t size, size_t alignment)
     alignedAlloc(size_t size) -> void *
     """
     return _coda_sys.alignedAlloc(*args)
 
-def alignedFree(p):
+def alignedFree(p: 'void *') -> "void":
     """alignedFree(void * p)"""
     return _coda_sys.alignedFree(p)
 class UTCDateTime(_object):
@@ -144,7 +144,7 @@ class UTCDateTime(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def format(self, *args):
+    def format(self, *args) -> "std::string":
         """
         format(UTCDateTime self)
         format(UTCDateTime self) -> std::string
@@ -160,11 +160,11 @@ SSE_INSTRUCTION_ALIGNMENT = cvar.SSE_INSTRUCTION_ALIGNMENT
 UTCDateTime.DEFAULT_DATETIME_FORMAT = _coda_sys.cvar.UTCDateTime_DEFAULT_DATETIME_FORMAT
 
 
-def __lshift__(os, dateTime):
+def __lshift__(os: 'std::ostream &', dateTime: 'UTCDateTime') -> "std::ostream &":
     """__lshift__(std::ostream & os, UTCDateTime dateTime) -> std::ostream &"""
     return _coda_sys.__lshift__(os, dateTime)
 
-def __rshift__(arg1, dateTime):
+def __rshift__(arg1: 'std::istream &', dateTime: 'UTCDateTime') -> "std::istream &":
     """__rshift__(std::istream & arg1, UTCDateTime dateTime) -> std::istream &"""
     return _coda_sys.__rshift__(arg1, dateTime)
 # This file is compatible with both classic and new-style classes.

--- a/modules/python/types/source/generated/coda_types.py
+++ b/modules/python/types/source/generated/coda_types.py
@@ -109,12 +109,12 @@ class SwigPyIterator(_object):
     __swig_destroy__ = _coda_types.delete_SwigPyIterator
     __del__ = lambda self: None
 
-    def value(self):
+    def value(self) -> "PyObject *":
         """value(SwigPyIterator self) -> PyObject *"""
         return _coda_types.SwigPyIterator_value(self)
 
 
-    def incr(self, n=1):
+    def incr(self, n: 'size_t'=1) -> "swig::SwigPyIterator *":
         """
         incr(SwigPyIterator self, size_t n=1) -> SwigPyIterator
         incr(SwigPyIterator self) -> SwigPyIterator
@@ -122,7 +122,7 @@ class SwigPyIterator(_object):
         return _coda_types.SwigPyIterator_incr(self, n)
 
 
-    def decr(self, n=1):
+    def decr(self, n: 'size_t'=1) -> "swig::SwigPyIterator *":
         """
         decr(SwigPyIterator self, size_t n=1) -> SwigPyIterator
         decr(SwigPyIterator self) -> SwigPyIterator
@@ -130,67 +130,67 @@ class SwigPyIterator(_object):
         return _coda_types.SwigPyIterator_decr(self, n)
 
 
-    def distance(self, x):
+    def distance(self, x: 'SwigPyIterator') -> "ptrdiff_t":
         """distance(SwigPyIterator self, SwigPyIterator x) -> ptrdiff_t"""
         return _coda_types.SwigPyIterator_distance(self, x)
 
 
-    def equal(self, x):
+    def equal(self, x: 'SwigPyIterator') -> "bool":
         """equal(SwigPyIterator self, SwigPyIterator x) -> bool"""
         return _coda_types.SwigPyIterator_equal(self, x)
 
 
-    def copy(self):
+    def copy(self) -> "swig::SwigPyIterator *":
         """copy(SwigPyIterator self) -> SwigPyIterator"""
         return _coda_types.SwigPyIterator_copy(self)
 
 
-    def next(self):
+    def next(self) -> "PyObject *":
         """next(SwigPyIterator self) -> PyObject *"""
         return _coda_types.SwigPyIterator_next(self)
 
 
-    def __next__(self):
+    def __next__(self) -> "PyObject *":
         """__next__(SwigPyIterator self) -> PyObject *"""
         return _coda_types.SwigPyIterator___next__(self)
 
 
-    def previous(self):
+    def previous(self) -> "PyObject *":
         """previous(SwigPyIterator self) -> PyObject *"""
         return _coda_types.SwigPyIterator_previous(self)
 
 
-    def advance(self, n):
+    def advance(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator *":
         """advance(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _coda_types.SwigPyIterator_advance(self, n)
 
 
-    def __eq__(self, x):
+    def __eq__(self, x: 'SwigPyIterator') -> "bool":
         """__eq__(SwigPyIterator self, SwigPyIterator x) -> bool"""
         return _coda_types.SwigPyIterator___eq__(self, x)
 
 
-    def __ne__(self, x):
+    def __ne__(self, x: 'SwigPyIterator') -> "bool":
         """__ne__(SwigPyIterator self, SwigPyIterator x) -> bool"""
         return _coda_types.SwigPyIterator___ne__(self, x)
 
 
-    def __iadd__(self, n):
+    def __iadd__(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator &":
         """__iadd__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _coda_types.SwigPyIterator___iadd__(self, n)
 
 
-    def __isub__(self, n):
+    def __isub__(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator &":
         """__isub__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _coda_types.SwigPyIterator___isub__(self, n)
 
 
-    def __add__(self, n):
+    def __add__(self, n: 'ptrdiff_t') -> "swig::SwigPyIterator *":
         """__add__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator"""
         return _coda_types.SwigPyIterator___add__(self, n)
 
 
-    def __sub__(self, *args):
+    def __sub__(self, *args) -> "ptrdiff_t":
         """
         __sub__(SwigPyIterator self, ptrdiff_t n) -> SwigPyIterator
         __sub__(SwigPyIterator self, SwigPyIterator x) -> ptrdiff_t
@@ -235,32 +235,32 @@ class RowColDouble(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def __iadd__(self, scalar):
+    def __iadd__(self, scalar: 'double') -> "types::RowCol< double > &":
         """__iadd__(RowColDouble self, double scalar) -> RowColDouble"""
         return _coda_types.RowColDouble___iadd__(self, scalar)
 
 
-    def __add__(self, scalar):
+    def __add__(self, scalar: 'double') -> "types::RowCol< double >":
         """__add__(RowColDouble self, double scalar) -> RowColDouble"""
         return _coda_types.RowColDouble___add__(self, scalar)
 
 
-    def __isub__(self, scalar):
+    def __isub__(self, scalar: 'double') -> "types::RowCol< double > &":
         """__isub__(RowColDouble self, double scalar) -> RowColDouble"""
         return _coda_types.RowColDouble___isub__(self, scalar)
 
 
-    def __sub__(self, scalar):
+    def __sub__(self, scalar: 'double') -> "types::RowCol< double >":
         """__sub__(RowColDouble self, double scalar) -> RowColDouble"""
         return _coda_types.RowColDouble___sub__(self, scalar)
 
 
-    def __imul__(self, scalar):
+    def __imul__(self, scalar: 'double') -> "types::RowCol< double > &":
         """__imul__(RowColDouble self, double scalar) -> RowColDouble"""
         return _coda_types.RowColDouble___imul__(self, scalar)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "types::RowCol< double >":
         """__mul__(RowColDouble self, double scalar) -> RowColDouble"""
         return _coda_types.RowColDouble___mul__(self, scalar)
 
@@ -277,22 +277,22 @@ class RowColDouble(_object):
 
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'RowColDouble') -> "bool":
         """__eq__(RowColDouble self, RowColDouble p) -> bool"""
         return _coda_types.RowColDouble___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'RowColDouble') -> "bool":
         """__ne__(RowColDouble self, RowColDouble p) -> bool"""
         return _coda_types.RowColDouble___ne__(self, p)
 
 
-    def area(self):
+    def area(self) -> "double":
         """area(RowColDouble self) -> double"""
         return _coda_types.RowColDouble_area(self)
 
 
-    def normL2(self):
+    def normL2(self) -> "double":
         """normL2(RowColDouble self) -> double"""
         return _coda_types.RowColDouble_normL2(self)
 
@@ -337,32 +337,32 @@ class RowColInt(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def __iadd__(self, scalar):
+    def __iadd__(self, scalar: 'ssize_t') -> "types::RowCol< sys::SSize_T > &":
         """__iadd__(RowColInt self, ssize_t scalar) -> RowColInt"""
         return _coda_types.RowColInt___iadd__(self, scalar)
 
 
-    def __add__(self, scalar):
+    def __add__(self, scalar: 'ssize_t') -> "types::RowCol< sys::SSize_T >":
         """__add__(RowColInt self, ssize_t scalar) -> RowColInt"""
         return _coda_types.RowColInt___add__(self, scalar)
 
 
-    def __isub__(self, scalar):
+    def __isub__(self, scalar: 'ssize_t') -> "types::RowCol< sys::SSize_T > &":
         """__isub__(RowColInt self, ssize_t scalar) -> RowColInt"""
         return _coda_types.RowColInt___isub__(self, scalar)
 
 
-    def __sub__(self, scalar):
+    def __sub__(self, scalar: 'ssize_t') -> "types::RowCol< sys::SSize_T >":
         """__sub__(RowColInt self, ssize_t scalar) -> RowColInt"""
         return _coda_types.RowColInt___sub__(self, scalar)
 
 
-    def __imul__(self, scalar):
+    def __imul__(self, scalar: 'ssize_t') -> "types::RowCol< sys::SSize_T > &":
         """__imul__(RowColInt self, ssize_t scalar) -> RowColInt"""
         return _coda_types.RowColInt___imul__(self, scalar)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'ssize_t') -> "types::RowCol< sys::SSize_T >":
         """__mul__(RowColInt self, ssize_t scalar) -> RowColInt"""
         return _coda_types.RowColInt___mul__(self, scalar)
 
@@ -379,22 +379,22 @@ class RowColInt(_object):
 
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'RowColInt') -> "bool":
         """__eq__(RowColInt self, RowColInt p) -> bool"""
         return _coda_types.RowColInt___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'RowColInt') -> "bool":
         """__ne__(RowColInt self, RowColInt p) -> bool"""
         return _coda_types.RowColInt___ne__(self, p)
 
 
-    def area(self):
+    def area(self) -> "ssize_t":
         """area(RowColInt self) -> ssize_t"""
         return _coda_types.RowColInt_area(self)
 
 
-    def normL2(self):
+    def normL2(self) -> "ssize_t":
         """normL2(RowColInt self) -> ssize_t"""
         return _coda_types.RowColInt_normL2(self)
 
@@ -439,32 +439,32 @@ class RowColSizeT(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def __iadd__(self, scalar):
+    def __iadd__(self, scalar: 'size_t') -> "types::RowCol< size_t > &":
         """__iadd__(RowColSizeT self, size_t scalar) -> RowColSizeT"""
         return _coda_types.RowColSizeT___iadd__(self, scalar)
 
 
-    def __add__(self, scalar):
+    def __add__(self, scalar: 'size_t') -> "types::RowCol< size_t >":
         """__add__(RowColSizeT self, size_t scalar) -> RowColSizeT"""
         return _coda_types.RowColSizeT___add__(self, scalar)
 
 
-    def __isub__(self, scalar):
+    def __isub__(self, scalar: 'size_t') -> "types::RowCol< size_t > &":
         """__isub__(RowColSizeT self, size_t scalar) -> RowColSizeT"""
         return _coda_types.RowColSizeT___isub__(self, scalar)
 
 
-    def __sub__(self, scalar):
+    def __sub__(self, scalar: 'size_t') -> "types::RowCol< size_t >":
         """__sub__(RowColSizeT self, size_t scalar) -> RowColSizeT"""
         return _coda_types.RowColSizeT___sub__(self, scalar)
 
 
-    def __imul__(self, scalar):
+    def __imul__(self, scalar: 'size_t') -> "types::RowCol< size_t > &":
         """__imul__(RowColSizeT self, size_t scalar) -> RowColSizeT"""
         return _coda_types.RowColSizeT___imul__(self, scalar)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'size_t') -> "types::RowCol< size_t >":
         """__mul__(RowColSizeT self, size_t scalar) -> RowColSizeT"""
         return _coda_types.RowColSizeT___mul__(self, scalar)
 
@@ -481,22 +481,22 @@ class RowColSizeT(_object):
 
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'RowColSizeT') -> "bool":
         """__eq__(RowColSizeT self, RowColSizeT p) -> bool"""
         return _coda_types.RowColSizeT___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'RowColSizeT') -> "bool":
         """__ne__(RowColSizeT self, RowColSizeT p) -> bool"""
         return _coda_types.RowColSizeT___ne__(self, p)
 
 
-    def area(self):
+    def area(self) -> "size_t":
         """area(RowColSizeT self) -> size_t"""
         return _coda_types.RowColSizeT_area(self)
 
 
-    def normL2(self):
+    def normL2(self) -> "size_t":
         """normL2(RowColSizeT self) -> size_t"""
         return _coda_types.RowColSizeT_normL2(self)
 
@@ -541,32 +541,32 @@ class RgAzDouble(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def __iadd__(self, scalar):
+    def __iadd__(self, scalar: 'double') -> "types::RgAz< double > &":
         """__iadd__(RgAzDouble self, double scalar) -> RgAzDouble"""
         return _coda_types.RgAzDouble___iadd__(self, scalar)
 
 
-    def __add__(self, scalar):
+    def __add__(self, scalar: 'double') -> "types::RgAz< double >":
         """__add__(RgAzDouble self, double scalar) -> RgAzDouble"""
         return _coda_types.RgAzDouble___add__(self, scalar)
 
 
-    def __isub__(self, scalar):
+    def __isub__(self, scalar: 'double') -> "types::RgAz< double > &":
         """__isub__(RgAzDouble self, double scalar) -> RgAzDouble"""
         return _coda_types.RgAzDouble___isub__(self, scalar)
 
 
-    def __sub__(self, scalar):
+    def __sub__(self, scalar: 'double') -> "types::RgAz< double >":
         """__sub__(RgAzDouble self, double scalar) -> RgAzDouble"""
         return _coda_types.RgAzDouble___sub__(self, scalar)
 
 
-    def __imul__(self, scalar):
+    def __imul__(self, scalar: 'double') -> "types::RgAz< double > &":
         """__imul__(RgAzDouble self, double scalar) -> RgAzDouble"""
         return _coda_types.RgAzDouble___imul__(self, scalar)
 
 
-    def __mul__(self, scalar):
+    def __mul__(self, scalar: 'double') -> "types::RgAz< double >":
         """__mul__(RgAzDouble self, double scalar) -> RgAzDouble"""
         return _coda_types.RgAzDouble___mul__(self, scalar)
 
@@ -583,12 +583,12 @@ class RgAzDouble(_object):
 
 
 
-    def __eq__(self, p):
+    def __eq__(self, p: 'RgAzDouble') -> "bool":
         """__eq__(RgAzDouble self, RgAzDouble p) -> bool"""
         return _coda_types.RgAzDouble___eq__(self, p)
 
 
-    def __ne__(self, p):
+    def __ne__(self, p: 'RgAzDouble') -> "bool":
         """__ne__(RgAzDouble self, RgAzDouble p) -> bool"""
         return _coda_types.RgAzDouble___ne__(self, p)
 
@@ -613,34 +613,34 @@ class VectorRowColInt(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, VectorRowColInt, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(VectorRowColInt self) -> SwigPyIterator"""
         return _coda_types.VectorRowColInt_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(VectorRowColInt self) -> bool"""
         return _coda_types.VectorRowColInt___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(VectorRowColInt self) -> bool"""
         return _coda_types.VectorRowColInt___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< types::RowCol< ssize_t > >::size_type":
         """__len__(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::size_type"""
         return _coda_types.VectorRowColInt___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< types::RowCol< ssize_t > >::difference_type', j: 'std::vector< types::RowCol< ssize_t > >::difference_type') -> "std::vector< types::RowCol< sys::SSize_T >,std::allocator< types::RowCol< sys::SSize_T > > > *":
         """__getslice__(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::difference_type i, std::vector< types::RowCol< ssize_t > >::difference_type j) -> VectorRowColInt"""
         return _coda_types.VectorRowColInt___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::difference_type i, std::vector< types::RowCol< ssize_t > >::difference_type j)
         __setslice__(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::difference_type i, std::vector< types::RowCol< ssize_t > >::difference_type j, VectorRowColInt v)
@@ -648,12 +648,12 @@ class VectorRowColInt(_object):
         return _coda_types.VectorRowColInt___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< types::RowCol< ssize_t > >::difference_type', j: 'std::vector< types::RowCol< ssize_t > >::difference_type') -> "void":
         """__delslice__(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::difference_type i, std::vector< types::RowCol< ssize_t > >::difference_type j)"""
         return _coda_types.VectorRowColInt___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::difference_type i)
         __delitem__(VectorRowColInt self, PySliceObject * slice)
@@ -661,7 +661,7 @@ class VectorRowColInt(_object):
         return _coda_types.VectorRowColInt___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< types::RowCol< ssize_t > >::value_type const &":
         """
         __getitem__(VectorRowColInt self, PySliceObject * slice) -> VectorRowColInt
         __getitem__(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::difference_type i) -> RowColInt
@@ -669,7 +669,7 @@ class VectorRowColInt(_object):
         return _coda_types.VectorRowColInt___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(VectorRowColInt self, PySliceObject * slice, VectorRowColInt v)
         __setitem__(VectorRowColInt self, PySliceObject * slice)
@@ -678,67 +678,67 @@ class VectorRowColInt(_object):
         return _coda_types.VectorRowColInt___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< types::RowCol< ssize_t > >::value_type":
         """pop(VectorRowColInt self) -> RowColInt"""
         return _coda_types.VectorRowColInt_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'RowColInt') -> "void":
         """append(VectorRowColInt self, RowColInt x)"""
         return _coda_types.VectorRowColInt_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(VectorRowColInt self) -> bool"""
         return _coda_types.VectorRowColInt_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< types::RowCol< ssize_t > >::size_type":
         """size(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::size_type"""
         return _coda_types.VectorRowColInt_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'VectorRowColInt') -> "void":
         """swap(VectorRowColInt self, VectorRowColInt v)"""
         return _coda_types.VectorRowColInt_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< types::RowCol< ssize_t > >::iterator":
         """begin(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::iterator"""
         return _coda_types.VectorRowColInt_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< types::RowCol< ssize_t > >::iterator":
         """end(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::iterator"""
         return _coda_types.VectorRowColInt_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< types::RowCol< ssize_t > >::reverse_iterator":
         """rbegin(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::reverse_iterator"""
         return _coda_types.VectorRowColInt_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< types::RowCol< ssize_t > >::reverse_iterator":
         """rend(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::reverse_iterator"""
         return _coda_types.VectorRowColInt_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(VectorRowColInt self)"""
         return _coda_types.VectorRowColInt_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< types::RowCol< ssize_t > >::allocator_type":
         """get_allocator(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::allocator_type"""
         return _coda_types.VectorRowColInt_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(VectorRowColInt self)"""
         return _coda_types.VectorRowColInt_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< types::RowCol< ssize_t > >::iterator":
         """
         erase(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::iterator pos) -> std::vector< types::RowCol< ssize_t > >::iterator
         erase(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::iterator first, std::vector< types::RowCol< ssize_t > >::iterator last) -> std::vector< types::RowCol< ssize_t > >::iterator
@@ -759,27 +759,27 @@ class VectorRowColInt(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'RowColInt') -> "void":
         """push_back(VectorRowColInt self, RowColInt x)"""
         return _coda_types.VectorRowColInt_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< types::RowCol< ssize_t > >::value_type const &":
         """front(VectorRowColInt self) -> RowColInt"""
         return _coda_types.VectorRowColInt_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< types::RowCol< ssize_t > >::value_type const &":
         """back(VectorRowColInt self) -> RowColInt"""
         return _coda_types.VectorRowColInt_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< types::RowCol< ssize_t > >::size_type', x: 'RowColInt') -> "void":
         """assign(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::size_type n, RowColInt x)"""
         return _coda_types.VectorRowColInt_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::size_type new_size)
         resize(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::size_type new_size, RowColInt x)
@@ -787,7 +787,7 @@ class VectorRowColInt(_object):
         return _coda_types.VectorRowColInt_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::iterator pos, RowColInt x) -> std::vector< types::RowCol< ssize_t > >::iterator
         insert(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::iterator pos, std::vector< types::RowCol< ssize_t > >::size_type n, RowColInt x)
@@ -795,12 +795,12 @@ class VectorRowColInt(_object):
         return _coda_types.VectorRowColInt_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< types::RowCol< ssize_t > >::size_type') -> "void":
         """reserve(VectorRowColInt self, std::vector< types::RowCol< ssize_t > >::size_type n)"""
         return _coda_types.VectorRowColInt_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< types::RowCol< ssize_t > >::size_type":
         """capacity(VectorRowColInt self) -> std::vector< types::RowCol< ssize_t > >::size_type"""
         return _coda_types.VectorRowColInt_capacity(self)
 
@@ -829,34 +829,34 @@ class VectorRowColDouble(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, VectorRowColDouble, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(VectorRowColDouble self) -> SwigPyIterator"""
         return _coda_types.VectorRowColDouble_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(VectorRowColDouble self) -> bool"""
         return _coda_types.VectorRowColDouble___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(VectorRowColDouble self) -> bool"""
         return _coda_types.VectorRowColDouble___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< types::RowCol< double > >::size_type":
         """__len__(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::size_type"""
         return _coda_types.VectorRowColDouble___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< types::RowCol< double > >::difference_type', j: 'std::vector< types::RowCol< double > >::difference_type') -> "std::vector< types::RowCol< double >,std::allocator< types::RowCol< double > > > *":
         """__getslice__(VectorRowColDouble self, std::vector< types::RowCol< double > >::difference_type i, std::vector< types::RowCol< double > >::difference_type j) -> VectorRowColDouble"""
         return _coda_types.VectorRowColDouble___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(VectorRowColDouble self, std::vector< types::RowCol< double > >::difference_type i, std::vector< types::RowCol< double > >::difference_type j)
         __setslice__(VectorRowColDouble self, std::vector< types::RowCol< double > >::difference_type i, std::vector< types::RowCol< double > >::difference_type j, VectorRowColDouble v)
@@ -864,12 +864,12 @@ class VectorRowColDouble(_object):
         return _coda_types.VectorRowColDouble___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< types::RowCol< double > >::difference_type', j: 'std::vector< types::RowCol< double > >::difference_type') -> "void":
         """__delslice__(VectorRowColDouble self, std::vector< types::RowCol< double > >::difference_type i, std::vector< types::RowCol< double > >::difference_type j)"""
         return _coda_types.VectorRowColDouble___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(VectorRowColDouble self, std::vector< types::RowCol< double > >::difference_type i)
         __delitem__(VectorRowColDouble self, PySliceObject * slice)
@@ -877,7 +877,7 @@ class VectorRowColDouble(_object):
         return _coda_types.VectorRowColDouble___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< types::RowCol< double > >::value_type const &":
         """
         __getitem__(VectorRowColDouble self, PySliceObject * slice) -> VectorRowColDouble
         __getitem__(VectorRowColDouble self, std::vector< types::RowCol< double > >::difference_type i) -> RowColDouble
@@ -885,7 +885,7 @@ class VectorRowColDouble(_object):
         return _coda_types.VectorRowColDouble___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(VectorRowColDouble self, PySliceObject * slice, VectorRowColDouble v)
         __setitem__(VectorRowColDouble self, PySliceObject * slice)
@@ -894,67 +894,67 @@ class VectorRowColDouble(_object):
         return _coda_types.VectorRowColDouble___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< types::RowCol< double > >::value_type":
         """pop(VectorRowColDouble self) -> RowColDouble"""
         return _coda_types.VectorRowColDouble_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'RowColDouble') -> "void":
         """append(VectorRowColDouble self, RowColDouble x)"""
         return _coda_types.VectorRowColDouble_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(VectorRowColDouble self) -> bool"""
         return _coda_types.VectorRowColDouble_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< types::RowCol< double > >::size_type":
         """size(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::size_type"""
         return _coda_types.VectorRowColDouble_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'VectorRowColDouble') -> "void":
         """swap(VectorRowColDouble self, VectorRowColDouble v)"""
         return _coda_types.VectorRowColDouble_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< types::RowCol< double > >::iterator":
         """begin(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::iterator"""
         return _coda_types.VectorRowColDouble_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< types::RowCol< double > >::iterator":
         """end(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::iterator"""
         return _coda_types.VectorRowColDouble_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< types::RowCol< double > >::reverse_iterator":
         """rbegin(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::reverse_iterator"""
         return _coda_types.VectorRowColDouble_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< types::RowCol< double > >::reverse_iterator":
         """rend(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::reverse_iterator"""
         return _coda_types.VectorRowColDouble_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(VectorRowColDouble self)"""
         return _coda_types.VectorRowColDouble_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< types::RowCol< double > >::allocator_type":
         """get_allocator(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::allocator_type"""
         return _coda_types.VectorRowColDouble_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(VectorRowColDouble self)"""
         return _coda_types.VectorRowColDouble_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< types::RowCol< double > >::iterator":
         """
         erase(VectorRowColDouble self, std::vector< types::RowCol< double > >::iterator pos) -> std::vector< types::RowCol< double > >::iterator
         erase(VectorRowColDouble self, std::vector< types::RowCol< double > >::iterator first, std::vector< types::RowCol< double > >::iterator last) -> std::vector< types::RowCol< double > >::iterator
@@ -975,27 +975,27 @@ class VectorRowColDouble(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'RowColDouble') -> "void":
         """push_back(VectorRowColDouble self, RowColDouble x)"""
         return _coda_types.VectorRowColDouble_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< types::RowCol< double > >::value_type const &":
         """front(VectorRowColDouble self) -> RowColDouble"""
         return _coda_types.VectorRowColDouble_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< types::RowCol< double > >::value_type const &":
         """back(VectorRowColDouble self) -> RowColDouble"""
         return _coda_types.VectorRowColDouble_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< types::RowCol< double > >::size_type', x: 'RowColDouble') -> "void":
         """assign(VectorRowColDouble self, std::vector< types::RowCol< double > >::size_type n, RowColDouble x)"""
         return _coda_types.VectorRowColDouble_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(VectorRowColDouble self, std::vector< types::RowCol< double > >::size_type new_size)
         resize(VectorRowColDouble self, std::vector< types::RowCol< double > >::size_type new_size, RowColDouble x)
@@ -1003,7 +1003,7 @@ class VectorRowColDouble(_object):
         return _coda_types.VectorRowColDouble_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(VectorRowColDouble self, std::vector< types::RowCol< double > >::iterator pos, RowColDouble x) -> std::vector< types::RowCol< double > >::iterator
         insert(VectorRowColDouble self, std::vector< types::RowCol< double > >::iterator pos, std::vector< types::RowCol< double > >::size_type n, RowColDouble x)
@@ -1011,12 +1011,12 @@ class VectorRowColDouble(_object):
         return _coda_types.VectorRowColDouble_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< types::RowCol< double > >::size_type') -> "void":
         """reserve(VectorRowColDouble self, std::vector< types::RowCol< double > >::size_type n)"""
         return _coda_types.VectorRowColDouble_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< types::RowCol< double > >::size_type":
         """capacity(VectorRowColDouble self) -> std::vector< types::RowCol< double > >::size_type"""
         return _coda_types.VectorRowColDouble_capacity(self)
 
@@ -1045,34 +1045,34 @@ class VectorSizeT(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, VectorSizeT, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(VectorSizeT self) -> SwigPyIterator"""
         return _coda_types.VectorSizeT_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(VectorSizeT self) -> bool"""
         return _coda_types.VectorSizeT___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(VectorSizeT self) -> bool"""
         return _coda_types.VectorSizeT___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< size_t >::size_type":
         """__len__(VectorSizeT self) -> std::vector< size_t >::size_type"""
         return _coda_types.VectorSizeT___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< size_t >::difference_type', j: 'std::vector< size_t >::difference_type') -> "std::vector< size_t,std::allocator< size_t > > *":
         """__getslice__(VectorSizeT self, std::vector< size_t >::difference_type i, std::vector< size_t >::difference_type j) -> VectorSizeT"""
         return _coda_types.VectorSizeT___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(VectorSizeT self, std::vector< size_t >::difference_type i, std::vector< size_t >::difference_type j)
         __setslice__(VectorSizeT self, std::vector< size_t >::difference_type i, std::vector< size_t >::difference_type j, VectorSizeT v)
@@ -1080,12 +1080,12 @@ class VectorSizeT(_object):
         return _coda_types.VectorSizeT___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< size_t >::difference_type', j: 'std::vector< size_t >::difference_type') -> "void":
         """__delslice__(VectorSizeT self, std::vector< size_t >::difference_type i, std::vector< size_t >::difference_type j)"""
         return _coda_types.VectorSizeT___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(VectorSizeT self, std::vector< size_t >::difference_type i)
         __delitem__(VectorSizeT self, PySliceObject * slice)
@@ -1093,7 +1093,7 @@ class VectorSizeT(_object):
         return _coda_types.VectorSizeT___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< size_t >::value_type const &":
         """
         __getitem__(VectorSizeT self, PySliceObject * slice) -> VectorSizeT
         __getitem__(VectorSizeT self, std::vector< size_t >::difference_type i) -> std::vector< size_t >::value_type const &
@@ -1101,7 +1101,7 @@ class VectorSizeT(_object):
         return _coda_types.VectorSizeT___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(VectorSizeT self, PySliceObject * slice, VectorSizeT v)
         __setitem__(VectorSizeT self, PySliceObject * slice)
@@ -1110,67 +1110,67 @@ class VectorSizeT(_object):
         return _coda_types.VectorSizeT___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< size_t >::value_type":
         """pop(VectorSizeT self) -> std::vector< size_t >::value_type"""
         return _coda_types.VectorSizeT_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'std::vector< size_t >::value_type const &') -> "void":
         """append(VectorSizeT self, std::vector< size_t >::value_type const & x)"""
         return _coda_types.VectorSizeT_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(VectorSizeT self) -> bool"""
         return _coda_types.VectorSizeT_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< size_t >::size_type":
         """size(VectorSizeT self) -> std::vector< size_t >::size_type"""
         return _coda_types.VectorSizeT_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'VectorSizeT') -> "void":
         """swap(VectorSizeT self, VectorSizeT v)"""
         return _coda_types.VectorSizeT_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< size_t >::iterator":
         """begin(VectorSizeT self) -> std::vector< size_t >::iterator"""
         return _coda_types.VectorSizeT_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< size_t >::iterator":
         """end(VectorSizeT self) -> std::vector< size_t >::iterator"""
         return _coda_types.VectorSizeT_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< size_t >::reverse_iterator":
         """rbegin(VectorSizeT self) -> std::vector< size_t >::reverse_iterator"""
         return _coda_types.VectorSizeT_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< size_t >::reverse_iterator":
         """rend(VectorSizeT self) -> std::vector< size_t >::reverse_iterator"""
         return _coda_types.VectorSizeT_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(VectorSizeT self)"""
         return _coda_types.VectorSizeT_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< size_t >::allocator_type":
         """get_allocator(VectorSizeT self) -> std::vector< size_t >::allocator_type"""
         return _coda_types.VectorSizeT_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(VectorSizeT self)"""
         return _coda_types.VectorSizeT_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< size_t >::iterator":
         """
         erase(VectorSizeT self, std::vector< size_t >::iterator pos) -> std::vector< size_t >::iterator
         erase(VectorSizeT self, std::vector< size_t >::iterator first, std::vector< size_t >::iterator last) -> std::vector< size_t >::iterator
@@ -1191,27 +1191,27 @@ class VectorSizeT(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'std::vector< size_t >::value_type const &') -> "void":
         """push_back(VectorSizeT self, std::vector< size_t >::value_type const & x)"""
         return _coda_types.VectorSizeT_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< size_t >::value_type const &":
         """front(VectorSizeT self) -> std::vector< size_t >::value_type const &"""
         return _coda_types.VectorSizeT_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< size_t >::value_type const &":
         """back(VectorSizeT self) -> std::vector< size_t >::value_type const &"""
         return _coda_types.VectorSizeT_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< size_t >::size_type', x: 'std::vector< size_t >::value_type const &') -> "void":
         """assign(VectorSizeT self, std::vector< size_t >::size_type n, std::vector< size_t >::value_type const & x)"""
         return _coda_types.VectorSizeT_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(VectorSizeT self, std::vector< size_t >::size_type new_size)
         resize(VectorSizeT self, std::vector< size_t >::size_type new_size, std::vector< size_t >::value_type const & x)
@@ -1219,7 +1219,7 @@ class VectorSizeT(_object):
         return _coda_types.VectorSizeT_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(VectorSizeT self, std::vector< size_t >::iterator pos, std::vector< size_t >::value_type const & x) -> std::vector< size_t >::iterator
         insert(VectorSizeT self, std::vector< size_t >::iterator pos, std::vector< size_t >::size_type n, std::vector< size_t >::value_type const & x)
@@ -1227,12 +1227,12 @@ class VectorSizeT(_object):
         return _coda_types.VectorSizeT_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< size_t >::size_type') -> "void":
         """reserve(VectorSizeT self, std::vector< size_t >::size_type n)"""
         return _coda_types.VectorSizeT_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< size_t >::size_type":
         """capacity(VectorSizeT self) -> std::vector< size_t >::size_type"""
         return _coda_types.VectorSizeT_capacity(self)
 
@@ -1261,34 +1261,34 @@ class VectorString(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, VectorString, name)
     __repr__ = _swig_repr
 
-    def iterator(self):
+    def iterator(self) -> "swig::SwigPyIterator *":
         """iterator(VectorString self) -> SwigPyIterator"""
         return _coda_types.VectorString_iterator(self)
 
     def __iter__(self):
         return self.iterator()
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> "bool":
         """__nonzero__(VectorString self) -> bool"""
         return _coda_types.VectorString___nonzero__(self)
 
 
-    def __bool__(self):
+    def __bool__(self) -> "bool":
         """__bool__(VectorString self) -> bool"""
         return _coda_types.VectorString___bool__(self)
 
 
-    def __len__(self):
+    def __len__(self) -> "std::vector< std::string >::size_type":
         """__len__(VectorString self) -> std::vector< std::string >::size_type"""
         return _coda_types.VectorString___len__(self)
 
 
-    def __getslice__(self, i, j):
+    def __getslice__(self, i: 'std::vector< std::string >::difference_type', j: 'std::vector< std::string >::difference_type') -> "std::vector< std::string,std::allocator< std::string > > *":
         """__getslice__(VectorString self, std::vector< std::string >::difference_type i, std::vector< std::string >::difference_type j) -> VectorString"""
         return _coda_types.VectorString___getslice__(self, i, j)
 
 
-    def __setslice__(self, *args):
+    def __setslice__(self, *args) -> "void":
         """
         __setslice__(VectorString self, std::vector< std::string >::difference_type i, std::vector< std::string >::difference_type j)
         __setslice__(VectorString self, std::vector< std::string >::difference_type i, std::vector< std::string >::difference_type j, VectorString v)
@@ -1296,12 +1296,12 @@ class VectorString(_object):
         return _coda_types.VectorString___setslice__(self, *args)
 
 
-    def __delslice__(self, i, j):
+    def __delslice__(self, i: 'std::vector< std::string >::difference_type', j: 'std::vector< std::string >::difference_type') -> "void":
         """__delslice__(VectorString self, std::vector< std::string >::difference_type i, std::vector< std::string >::difference_type j)"""
         return _coda_types.VectorString___delslice__(self, i, j)
 
 
-    def __delitem__(self, *args):
+    def __delitem__(self, *args) -> "void":
         """
         __delitem__(VectorString self, std::vector< std::string >::difference_type i)
         __delitem__(VectorString self, PySliceObject * slice)
@@ -1309,7 +1309,7 @@ class VectorString(_object):
         return _coda_types.VectorString___delitem__(self, *args)
 
 
-    def __getitem__(self, *args):
+    def __getitem__(self, *args) -> "std::vector< std::string >::value_type const &":
         """
         __getitem__(VectorString self, PySliceObject * slice) -> VectorString
         __getitem__(VectorString self, std::vector< std::string >::difference_type i) -> std::vector< std::string >::value_type const &
@@ -1317,7 +1317,7 @@ class VectorString(_object):
         return _coda_types.VectorString___getitem__(self, *args)
 
 
-    def __setitem__(self, *args):
+    def __setitem__(self, *args) -> "void":
         """
         __setitem__(VectorString self, PySliceObject * slice, VectorString v)
         __setitem__(VectorString self, PySliceObject * slice)
@@ -1326,67 +1326,67 @@ class VectorString(_object):
         return _coda_types.VectorString___setitem__(self, *args)
 
 
-    def pop(self):
+    def pop(self) -> "std::vector< std::string >::value_type":
         """pop(VectorString self) -> std::vector< std::string >::value_type"""
         return _coda_types.VectorString_pop(self)
 
 
-    def append(self, x):
+    def append(self, x: 'std::vector< std::string >::value_type const &') -> "void":
         """append(VectorString self, std::vector< std::string >::value_type const & x)"""
         return _coda_types.VectorString_append(self, x)
 
 
-    def empty(self):
+    def empty(self) -> "bool":
         """empty(VectorString self) -> bool"""
         return _coda_types.VectorString_empty(self)
 
 
-    def size(self):
+    def size(self) -> "std::vector< std::string >::size_type":
         """size(VectorString self) -> std::vector< std::string >::size_type"""
         return _coda_types.VectorString_size(self)
 
 
-    def swap(self, v):
+    def swap(self, v: 'VectorString') -> "void":
         """swap(VectorString self, VectorString v)"""
         return _coda_types.VectorString_swap(self, v)
 
 
-    def begin(self):
+    def begin(self) -> "std::vector< std::string >::iterator":
         """begin(VectorString self) -> std::vector< std::string >::iterator"""
         return _coda_types.VectorString_begin(self)
 
 
-    def end(self):
+    def end(self) -> "std::vector< std::string >::iterator":
         """end(VectorString self) -> std::vector< std::string >::iterator"""
         return _coda_types.VectorString_end(self)
 
 
-    def rbegin(self):
+    def rbegin(self) -> "std::vector< std::string >::reverse_iterator":
         """rbegin(VectorString self) -> std::vector< std::string >::reverse_iterator"""
         return _coda_types.VectorString_rbegin(self)
 
 
-    def rend(self):
+    def rend(self) -> "std::vector< std::string >::reverse_iterator":
         """rend(VectorString self) -> std::vector< std::string >::reverse_iterator"""
         return _coda_types.VectorString_rend(self)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(VectorString self)"""
         return _coda_types.VectorString_clear(self)
 
 
-    def get_allocator(self):
+    def get_allocator(self) -> "std::vector< std::string >::allocator_type":
         """get_allocator(VectorString self) -> std::vector< std::string >::allocator_type"""
         return _coda_types.VectorString_get_allocator(self)
 
 
-    def pop_back(self):
+    def pop_back(self) -> "void":
         """pop_back(VectorString self)"""
         return _coda_types.VectorString_pop_back(self)
 
 
-    def erase(self, *args):
+    def erase(self, *args) -> "std::vector< std::string >::iterator":
         """
         erase(VectorString self, std::vector< std::string >::iterator pos) -> std::vector< std::string >::iterator
         erase(VectorString self, std::vector< std::string >::iterator first, std::vector< std::string >::iterator last) -> std::vector< std::string >::iterator
@@ -1407,27 +1407,27 @@ class VectorString(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def push_back(self, x):
+    def push_back(self, x: 'std::vector< std::string >::value_type const &') -> "void":
         """push_back(VectorString self, std::vector< std::string >::value_type const & x)"""
         return _coda_types.VectorString_push_back(self, x)
 
 
-    def front(self):
+    def front(self) -> "std::vector< std::string >::value_type const &":
         """front(VectorString self) -> std::vector< std::string >::value_type const &"""
         return _coda_types.VectorString_front(self)
 
 
-    def back(self):
+    def back(self) -> "std::vector< std::string >::value_type const &":
         """back(VectorString self) -> std::vector< std::string >::value_type const &"""
         return _coda_types.VectorString_back(self)
 
 
-    def assign(self, n, x):
+    def assign(self, n: 'std::vector< std::string >::size_type', x: 'std::vector< std::string >::value_type const &') -> "void":
         """assign(VectorString self, std::vector< std::string >::size_type n, std::vector< std::string >::value_type const & x)"""
         return _coda_types.VectorString_assign(self, n, x)
 
 
-    def resize(self, *args):
+    def resize(self, *args) -> "void":
         """
         resize(VectorString self, std::vector< std::string >::size_type new_size)
         resize(VectorString self, std::vector< std::string >::size_type new_size, std::vector< std::string >::value_type const & x)
@@ -1435,7 +1435,7 @@ class VectorString(_object):
         return _coda_types.VectorString_resize(self, *args)
 
 
-    def insert(self, *args):
+    def insert(self, *args) -> "void":
         """
         insert(VectorString self, std::vector< std::string >::iterator pos, std::vector< std::string >::value_type const & x) -> std::vector< std::string >::iterator
         insert(VectorString self, std::vector< std::string >::iterator pos, std::vector< std::string >::size_type n, std::vector< std::string >::value_type const & x)
@@ -1443,12 +1443,12 @@ class VectorString(_object):
         return _coda_types.VectorString_insert(self, *args)
 
 
-    def reserve(self, n):
+    def reserve(self, n: 'std::vector< std::string >::size_type') -> "void":
         """reserve(VectorString self, std::vector< std::string >::size_type n)"""
         return _coda_types.VectorString_reserve(self, n)
 
 
-    def capacity(self):
+    def capacity(self) -> "std::vector< std::string >::size_type":
         """capacity(VectorString self) -> std::vector< std::string >::size_type"""
         return _coda_types.VectorString_capacity(self)
 

--- a/modules/python/xml.lite/source/generated/xml_lite.py
+++ b/modules/python/xml.lite/source/generated/xml_lite.py
@@ -106,7 +106,7 @@ class Element(_object):
     __swig_destroy__ = _xml_lite.delete_Element
     __del__ = lambda self: None
 
-    def destroyChildren(self):
+    def destroyChildren(self) -> "void":
         """destroyChildren(Element self)"""
         return _xml_lite.Element_destroyChildren(self)
 
@@ -125,17 +125,17 @@ class Element(_object):
         except __builtin__.Exception:
             self.this = this
 
-    def clone(self, element):
+    def clone(self, element: 'Element') -> "void":
         """clone(Element self, Element element)"""
         return _xml_lite.Element_clone(self, element)
 
 
-    def attribute(self, s):
+    def attribute(self, s: 'std::string const &') -> "std::string &":
         """attribute(Element self, std::string const & s) -> std::string &"""
         return _xml_lite.Element_attribute(self, s)
 
 
-    def getElementsByTagNameNS(self, *args):
+    def getElementsByTagNameNS(self, *args) -> "std::vector< xml::lite::Element * >":
         """
         getElementsByTagNameNS(Element self, std::string const & qname, std::vector< xml::lite::Element * > & elements, bool recurse=False)
         getElementsByTagNameNS(Element self, std::string const & qname, std::vector< xml::lite::Element * > & elements)
@@ -145,7 +145,7 @@ class Element(_object):
         return _xml_lite.Element_getElementsByTagNameNS(self, *args)
 
 
-    def getElementsByTagName(self, *args):
+    def getElementsByTagName(self, *args) -> "void":
         """
         getElementsByTagName(Element self, std::string const & localName, std::vector< xml::lite::Element * > & elements, bool recurse=False)
         getElementsByTagName(Element self, std::string const & localName, std::vector< xml::lite::Element * > & elements)
@@ -157,22 +157,22 @@ class Element(_object):
         return _xml_lite.Element_getElementsByTagName(self, *args)
 
 
-    def setNamespacePrefix(self, prefix, uri):
+    def setNamespacePrefix(self, prefix: 'std::string', uri: 'std::string') -> "void":
         """setNamespacePrefix(Element self, std::string prefix, std::string uri)"""
         return _xml_lite.Element_setNamespacePrefix(self, prefix, uri)
 
 
-    def setNamespaceURI(self, prefix, uri):
+    def setNamespaceURI(self, prefix: 'std::string', uri: 'std::string') -> "void":
         """setNamespaceURI(Element self, std::string prefix, std::string uri)"""
         return _xml_lite.Element_setNamespaceURI(self, prefix, uri)
 
 
-    def _print(self, stream):
+    def _print(self, stream: 'io::OutputStream &') -> "void":
         """_print(Element self, io::OutputStream & stream)"""
         return _xml_lite.Element__print(self, stream)
 
 
-    def prettyPrint(self, *args):
+    def prettyPrint(self, *args) -> "void":
         """
         prettyPrint(Element self, io::OutputStream & stream, std::string const & formatter)
         prettyPrint(Element self, io::OutputStream & stream)
@@ -180,7 +180,7 @@ class Element(_object):
         return _xml_lite.Element_prettyPrint(self, *args)
 
 
-    def hasElement(self, *args):
+    def hasElement(self, *args) -> "bool":
         """
         hasElement(Element self, std::string const & localName) -> bool
         hasElement(Element self, std::string const & uri, std::string const & localName) -> bool
@@ -188,47 +188,47 @@ class Element(_object):
         return _xml_lite.Element_hasElement(self, *args)
 
 
-    def getCharacterData(self):
+    def getCharacterData(self) -> "std::string":
         """getCharacterData(Element self) -> std::string"""
         return _xml_lite.Element_getCharacterData(self)
 
 
-    def setCharacterData(self, characters):
+    def setCharacterData(self, characters: 'std::string const &') -> "void":
         """setCharacterData(Element self, std::string const & characters)"""
         return _xml_lite.Element_setCharacterData(self, characters)
 
 
-    def setLocalName(self, localName):
+    def setLocalName(self, localName: 'std::string const &') -> "void":
         """setLocalName(Element self, std::string const & localName)"""
         return _xml_lite.Element_setLocalName(self, localName)
 
 
-    def getLocalName(self):
+    def getLocalName(self) -> "std::string":
         """getLocalName(Element self) -> std::string"""
         return _xml_lite.Element_getLocalName(self)
 
 
-    def setQName(self, qname):
+    def setQName(self, qname: 'std::string const &') -> "void":
         """setQName(Element self, std::string const & qname)"""
         return _xml_lite.Element_setQName(self, qname)
 
 
-    def getQName(self):
+    def getQName(self) -> "std::string":
         """getQName(Element self) -> std::string"""
         return _xml_lite.Element_getQName(self)
 
 
-    def setUri(self, uri):
+    def setUri(self, uri: 'std::string const &') -> "void":
         """setUri(Element self, std::string const & uri)"""
         return _xml_lite.Element_setUri(self, uri)
 
 
-    def getUri(self):
+    def getUri(self) -> "std::string":
         """getUri(Element self) -> std::string"""
         return _xml_lite.Element_getUri(self)
 
 
-    def getChildren(self, *args):
+    def getChildren(self, *args) -> "std::vector< xml::lite::Element * > const &":
         """
         getChildren(Element self) -> std::vector< xml::lite::Element * >
         getChildren(Element self) -> std::vector< xml::lite::Element * > const &
@@ -236,12 +236,12 @@ class Element(_object):
         return _xml_lite.Element_getChildren(self, *args)
 
 
-    def getParent(self):
+    def getParent(self) -> "xml::lite::Element *":
         """getParent(Element self) -> Element"""
         return _xml_lite.Element_getParent(self)
 
 
-    def setParent(self, parent):
+    def setParent(self, parent: 'Element') -> "void":
         """setParent(Element self, Element parent)"""
         return _xml_lite.Element_setParent(self, parent)
 
@@ -257,7 +257,7 @@ class Document(_object):
     __getattr__ = lambda self, name: _swig_getattr(self, Document, name)
     __repr__ = _swig_repr
 
-    def __init__(self, rootNode=None, own=True):
+    def __init__(self, rootNode: 'Element'=None, own: 'bool'=True):
         """
         __init__(xml::lite::Document self, Element rootNode=None, bool own=True) -> Document
         __init__(xml::lite::Document self, Element rootNode=None) -> Document
@@ -271,12 +271,12 @@ class Document(_object):
     __swig_destroy__ = _xml_lite.delete_Document
     __del__ = lambda self: None
 
-    def clone(self):
+    def clone(self) -> "xml::lite::Document *":
         """clone(Document self) -> Document"""
         return _xml_lite.Document_clone(self)
 
 
-    def createElement(self, *args):
+    def createElement(self, *args) -> "xml::lite::Element *":
         """
         createElement(Document self, std::string const & qname, std::string const & uri, std::string characterData) -> Element
         createElement(Document self, std::string const & qname, std::string const & uri) -> Element
@@ -284,17 +284,17 @@ class Document(_object):
         return _xml_lite.Document_createElement(self, *args)
 
 
-    def destroy(self):
+    def destroy(self) -> "void":
         """destroy(Document self)"""
         return _xml_lite.Document_destroy(self)
 
 
-    def insert(self, element, underThis):
+    def insert(self, element: 'Element', underThis: 'Element') -> "void":
         """insert(Document self, Element element, Element underThis)"""
         return _xml_lite.Document_insert(self, element, underThis)
 
 
-    def remove(self, *args):
+    def remove(self, *args) -> "void":
         """
         remove(Document self, Element toDelete)
         remove(Document self, Element toDelete, Element fromHere)
@@ -302,7 +302,7 @@ class Document(_object):
         return _xml_lite.Document_remove(self, *args)
 
 
-    def setRootElement(self, element, own=True):
+    def setRootElement(self, element: 'Element', own: 'bool'=True) -> "void":
         """
         setRootElement(Document self, Element element, bool own=True)
         setRootElement(Document self, Element element)
@@ -310,7 +310,7 @@ class Document(_object):
         return _xml_lite.Document_setRootElement(self, element, own)
 
 
-    def getRootElement(self, *args):
+    def getRootElement(self, *args) -> "xml::lite::Element *":
         """
         getRootElement(Document self, bool steal=False) -> Element
         getRootElement(Document self) -> Element
@@ -340,7 +340,7 @@ class MinidomParser(_object):
     __swig_destroy__ = _xml_lite.delete_MinidomParser
     __del__ = lambda self: None
 
-    def parse(self, *args):
+    def parse(self, *args) -> "void":
         """
         parse(MinidomParser self, io::InputStream & arg2, int size)
         parse(MinidomParser self, io::InputStream & arg2)
@@ -348,12 +348,12 @@ class MinidomParser(_object):
         return _xml_lite.MinidomParser_parse(self, *args)
 
 
-    def clear(self):
+    def clear(self) -> "void":
         """clear(MinidomParser self)"""
         return _xml_lite.MinidomParser_clear(self)
 
 
-    def getDocument(self, *args):
+    def getDocument(self, *args) -> "xml::lite::Document *":
         """
         getDocument(MinidomParser self) -> Document
         getDocument(MinidomParser self, bool steal=False) -> Document
@@ -362,7 +362,7 @@ class MinidomParser(_object):
         return _xml_lite.MinidomParser_getDocument(self, *args)
 
 
-    def getReader(self, *args):
+    def getReader(self, *args) -> "XMLReader &":
         """
         getReader(MinidomParser self) -> XMLReader const
         getReader(MinidomParser self) -> XMLReader &
@@ -370,7 +370,7 @@ class MinidomParser(_object):
         return _xml_lite.MinidomParser_getReader(self, *args)
 
 
-    def setDocument(self, newDocument, own=True):
+    def setDocument(self, newDocument: 'Document', own: 'bool'=True) -> "void":
         """
         setDocument(MinidomParser self, Document newDocument, bool own=True)
         setDocument(MinidomParser self, Document newDocument)
@@ -378,7 +378,7 @@ class MinidomParser(_object):
         return _xml_lite.MinidomParser_setDocument(self, newDocument, own)
 
 
-    def preserveCharacterData(self, preserve):
+    def preserveCharacterData(self, preserve: 'bool') -> "void":
         """preserveCharacterData(MinidomParser self, bool preserve)"""
         return _xml_lite.MinidomParser_preserveCharacterData(self, preserve)
 


### PR DESCRIPTION
There's a lot of noise here. The only actual change is adding `#define SWIG_PYTHON_STRICT_BYTE_CHAR` in `io.i`