### PR TITLE
Add convenience methods to get buffer view of scratch segment.

### DIFF
--- a/modules/c++/mem/include/mem/ScratchMemory.h
+++ b/modules/c++/mem/include/mem/ScratchMemory.h
@@ -108,8 +108,7 @@ public:
      *         the key does not exist, or index of buffer is out of bounds
      */
     template <typename T>
-    mem::BufferView<T> getBufferView(const std::string& key,
-                                     size_t indexBuffer = 0);
+    BufferView<T> getBufferView(const std::string& key, size_t indexBuffer = 0);
 
     /*!
      * \brief Get const buffer view of buffer segment.
@@ -123,8 +122,8 @@ public:
      *         the key does not exist, or index of buffer is out of bounds
      */
     template <typename T>
-    mem::BufferView<const T> getBufferView(const std::string& key,
-                                           size_t indexBuffer = 0) const;
+    BufferView<const T> getBufferView(const std::string& key,
+                                      size_t indexBuffer = 0) const;
 
     /*!
      * \brief Ensure underlying memory is properly set up and position segment
@@ -138,8 +137,8 @@ public:
      *         to hold the requested scratch memory or has size > 0 with null
      *         data pointer
      */
-    void setup(const mem::BufferView<sys::ubyte>& scratchBuffer =
-            mem::BufferView<sys::ubyte>());
+    void setup(const BufferView<sys::ubyte>& scratchBuffer =
+            BufferView<sys::ubyte>());
 
     /*!
      * \brief Get number of bytes needed to store scratch memory, including the
@@ -169,7 +168,7 @@ private:
 
     std::map<std::string, Segment> mSegments;
     std::vector<sys::ubyte> mStorage;
-    mem::BufferView<sys::ubyte> mBuffer;
+    BufferView<sys::ubyte> mBuffer;
     size_t mNumBytesNeeded;
 };
 }

--- a/modules/c++/mem/include/mem/ScratchMemory.h
+++ b/modules/c++/mem/include/mem/ScratchMemory.h
@@ -97,6 +97,36 @@ public:
     const T* get(const std::string& key, size_t indexBuffer = 0) const;
 
     /*!
+     * \brief Get buffer view of buffer segment.
+     *
+     * \param key Identifier for scratch segment
+     * \param indexBuffer Index of distinct buffer. Defaults to 0.
+     *
+     * \return Buffer view of buffer segment
+     *
+     * \throws except::Exception if the scratch memory has not been set up,
+     *         the key does not exist, or index of buffer is out of bounds
+     */
+    template <typename T>
+    mem::BufferView<T> getBufferView(const std::string& key,
+                                     size_t indexBuffer = 0);
+
+    /*!
+     * \brief Get const buffer view of buffer segment.
+     *
+     * \param key Identifier for scratch segment
+     * \param indexBuffer Index of distinct buffer. Defaults to 0.
+     *
+     * \return Const buffer view of buffer segment
+     *
+     * \throws except::Exception if the scratch memory has not been set up,
+     *         the key does not exist, or index of buffer is out of bounds
+     */
+    template <typename T>
+    mem::BufferView<const T> getBufferView(const std::string& key,
+                                           size_t indexBuffer = 0) const;
+
+    /*!
      * \brief Ensure underlying memory is properly set up and position segment
      *        pointers.
      *

--- a/modules/c++/mem/include/mem/ScratchMemory.hpp
+++ b/modules/c++/mem/include/mem/ScratchMemory.hpp
@@ -70,20 +70,20 @@ const T* ScratchMemory::get(const std::string& key, size_t indexBuffer) const
 }
 
 template <typename T>
-mem::BufferView<T> ScratchMemory::getBufferView(const std::string& key, size_t indexBuffer)
+BufferView<T> ScratchMemory::getBufferView(const std::string& key,
+                                           size_t indexBuffer)
 {
     const Segment& segment = lookupSegment(key, indexBuffer);
-    return mem::BufferView<T>(
-            reinterpret_cast<T*>(segment.buffers[indexBuffer]),
-            segment.numBytes);
+    return BufferView<T>(reinterpret_cast<T*>(segment.buffers[indexBuffer]),
+                         segment.numBytes);
 }
 
 template <typename T>
-mem::BufferView<const T> ScratchMemory::getBufferView(const std::string& key,
-                                                      size_t indexBuffer) const
+BufferView<const T> ScratchMemory::getBufferView(const std::string& key,
+                                                 size_t indexBuffer) const
 {
     const Segment& segment = lookupSegment(key, indexBuffer);
-    return mem::BufferView<const T>(
+    return BufferView<const T>(
             reinterpret_cast<const T*>(segment.buffers[indexBuffer]),
             segment.numBytes);
 }

--- a/modules/c++/mem/include/mem/ScratchMemory.hpp
+++ b/modules/c++/mem/include/mem/ScratchMemory.hpp
@@ -68,4 +68,23 @@ const T* ScratchMemory::get(const std::string& key, size_t indexBuffer) const
     return reinterpret_cast<const T*>(
             lookupSegment(key, indexBuffer).buffers[indexBuffer]);
 }
+
+template <typename T>
+mem::BufferView<T> ScratchMemory::getBufferView(const std::string& key, size_t indexBuffer)
+{
+    const Segment& segment = lookupSegment(key, indexBuffer);
+    return mem::BufferView<T>(
+            reinterpret_cast<T*>(segment.buffers[indexBuffer]),
+            segment.numBytes);
+}
+
+template <typename T>
+mem::BufferView<const T> ScratchMemory::getBufferView(const std::string& key,
+                                                      size_t indexBuffer) const
+{
+    const Segment& segment = lookupSegment(key, indexBuffer);
+    return mem::BufferView<const T>(
+            reinterpret_cast<const T*>(segment.buffers[indexBuffer]),
+            segment.numBytes);
+}
 }

--- a/modules/c++/mem/source/ScratchMemory.cpp
+++ b/modules/c++/mem/source/ScratchMemory.cpp
@@ -54,7 +54,7 @@ ScratchMemory::Segment::Segment(size_t numBytes,
 {
 }
 
-void ScratchMemory::setup(const mem::BufferView<sys::ubyte>& scratchBuffer)
+void ScratchMemory::setup(const BufferView<sys::ubyte>& scratchBuffer)
 {
     if (scratchBuffer.size == 0)
     {

--- a/modules/c++/mem/unittests/test_scratch_memory.cpp
+++ b/modules/c++/mem/unittests/test_scratch_memory.cpp
@@ -75,10 +75,35 @@ TEST_CASE(testScratchMemory)
         sys::ubyte* pBuf2_2 = scratch.get<sys::ubyte>("buf2", 2);
         sys::ubyte* pBuf3 = scratch.get<sys::ubyte>("buf3");
 
+        // verify getBufferView matches get
+        mem::BufferView<sys::ubyte> bufView0 =
+                scratch.getBufferView<sys::ubyte>("buf0");
+        mem::BufferView<sys::ubyte> bufView1 =
+                scratch.getBufferView<sys::ubyte>("buf1");
+        mem::BufferView<sys::ubyte> bufView2_0 =
+                scratch.getBufferView<sys::ubyte>("buf2", 0);
+        mem::BufferView<sys::ubyte> bufView2_1 =
+                scratch.getBufferView<sys::ubyte>("buf2", 1);
+        TEST_ASSERT_EQ(pBuf0, bufView0.data);
+        TEST_ASSERT_EQ(pBuf1, bufView1.data);
+        TEST_ASSERT_EQ(pBuf2_0, bufView2_0.data);
+        TEST_ASSERT_EQ(pBuf2_1, bufView2_1.data);
+
+        // verify getBufferView size in bytes
+        TEST_ASSERT_EQ(bufView0.size, 11);
+        TEST_ASSERT_EQ(bufView1.size, 17 * sizeof(int));
+        TEST_ASSERT_EQ(bufView2_0.size, 29);
+        TEST_ASSERT_EQ(bufView2_1.size, 29);
+
         // verify get works with const reference to ScratchMemory
         const mem::ScratchMemory& constScratch = scratch;
         const sys::ubyte* pConstBuf0 = constScratch.get<sys::ubyte>("buf0");
-        TEST_ASSERT_EQ(pBuf0, pConstBuf0)
+        TEST_ASSERT_EQ(pBuf0, pConstBuf0);
+
+        // verify getBufferView works with const reference to ScratchMemory
+        mem::BufferView<const sys::ubyte> constBufView0 =
+                constScratch.getBufferView<sys::ubyte>("buf0");
+        TEST_ASSERT_EQ(bufView0.data, constBufView0.data);
 
         // trying to get buffer index out of range should throw
         TEST_EXCEPTION(scratch.get<sys::ubyte>("buf0", 1));


### PR DESCRIPTION
A new method getBufferView helps to simplify usage of ScratchMemory in constructor initializer lists.