### PR TITLE
Read SIOs of type complex<double> (reuses the complex<float> case)

### DIFF
--- a/modules/c++/sio.lite/include/sio/lite/ElementType.h
+++ b/modules/c++/sio.lite/include/sio/lite/ElementType.h
@@ -70,6 +70,11 @@ struct ElementType<std::complex<float> >
 {
     static const size_t Type = sio::lite::FileHeader::COMPLEX_FLOAT;
 };
+template <>
+struct ElementType<std::complex<double> >
+{
+    static const size_t Type = sio::lite::FileHeader::COMPLEX_FLOAT;
+};
 }
 }
 


### PR DESCRIPTION
Allows reading SIOs of type complex<double>, here an alias for reading complex<float>.