### PR TITLE
Added stdc++ explicit operator bool syntax for ScopedCopyablePtr for …

### DIFF
--- a/modules/c++/mem/include/mem/ScopedCopyablePtr.h
+++ b/modules/c++/mem/include/mem/ScopedCopyablePtr.h
@@ -106,6 +106,11 @@ public:
     {
         return !(*this == rhs);
     }
+    
+    explicit operator bool() const 
+    { 
+        return get() == NULL ? false : true; 
+    }
 
     T* get() const
     {


### PR DESCRIPTION
…testing the PTR object to true fals in a boolean expression.