### PR TITLE
Fixed bug in nautical miles to feet conversion

### DIFF
--- a/modules/c++/math/include/math/Constants.h
+++ b/modules/c++/math/include/math/Constants.h
@@ -41,7 +41,7 @@ struct Constants
     static constexpr double METERS_TO_NAUTICAL_MILES =
                                     1.0 / NAUTICAL_MILES_TO_METERS;
     static constexpr double NAUTICAL_MILES_TO_FEET =
-                                    NAUTICAL_MILES_TO_METERS * FEET_TO_METERS;
+                                    NAUTICAL_MILES_TO_METERS * METERS_TO_FEET;
 
     static constexpr double SPEED_OF_LIGHT_METERS_PER_SEC = 299792458.0;
     static constexpr double SPEED_OF_LIGHT_FEET_PER_SEC =

--- a/modules/c++/math/source/Constants.cpp
+++ b/modules/c++/math/source/Constants.cpp
@@ -34,7 +34,7 @@ const double Constants::NAUTICAL_MILES_TO_METERS = 1852.0;
 const double Constants::METERS_TO_NAUTICAL_MILES =
         1.0 / Constants::NAUTICAL_MILES_TO_METERS;
 const double Constants::NAUTICAL_MILES_TO_FEET =
-        Constants::NAUTICAL_MILES_TO_METERS * Constants::FEET_TO_METERS;
+        Constants::NAUTICAL_MILES_TO_METERS * Constants::METERS_TO_FEET;
 const double Constants::SPEED_OF_LIGHT_METERS_PER_SEC = 299792458.0;
 const double Constants::SPEED_OF_LIGHT_FEET_PER_SEC =
         Constants::SPEED_OF_LIGHT_METERS_PER_SEC * Constants::METERS_TO_FEET;


### PR DESCRIPTION
We were multiplying by feet to meters rather than meters to feet