### PR TITLE
Add PageRowCol type with a similar implementation to RowCol.

### DIFF
--- a/modules/c++/types/include/import/types.h
+++ b/modules/c++/types/include/import/types.h
@@ -25,6 +25,7 @@
 
 #include <types/RgAz.h>
 #include <types/RowCol.h>
+#include <types/PageRowCol.h>
 #include <types/Range.h>
 
 #endif

--- a/modules/c++/types/include/types/PageRowCol.h
+++ b/modules/c++/types/include/types/PageRowCol.h
@@ -32,7 +32,6 @@
 
 namespace types
 {
-
 /*!
  *  \class PageRowCol
  *  \brief Templated PageRowCol type

--- a/modules/c++/types/include/types/PageRowCol.h
+++ b/modules/c++/types/include/types/PageRowCol.h
@@ -1,0 +1,268 @@
+/* =========================================================================
+ * This file is part of types-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * types-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __TYPES_PAGE_ROW_COL_H__
+#define __TYPES_PAGE_ROW_COL_H__
+
+#include <cstddef>
+#include <cmath>
+#include <cstdlib>
+#include <limits>
+
+#include <types/RowCol.h>
+
+namespace types
+{
+
+/*!
+ *  \class PageRowCol
+ *  \brief Templated PageRowCol type
+ *
+ *  This class attempts to provide a simple interface for
+ *  accessing page-row-col triples that just does what you want.
+ *
+ */
+template<typename T>
+struct PageRowCol
+{
+    T page;
+    T row;
+    T col;
+
+    // Try to protect us from the unfortunate and probably unintended case
+    // where one or more fields is set and the remaining ones are not,
+    // especially when doing scalar operations that might otherwise
+    // create ambiguities
+    PageRowCol() :
+        page((T)0.0), row((T)0.0), col((T)0.0) {}
+
+
+    PageRowCol(T p, T r, T c) :
+        page(p), row(r), col(c) {}
+
+    template<typename Other_T>
+    explicit PageRowCol(const PageRowCol<Other_T>& p)
+    {
+        page = (T)p.page;
+        row = (T)p.row;
+        col = (T)p.col;
+    }
+
+    template<typename Other_T1, typename Other_T2>
+    PageRowCol(Other_T1 p, const RowCol<Other_T2>& rc)
+    {
+        page = (T)p;
+        row = (T)rc.row;
+        col = (T)rc.col;
+    }
+
+    template<typename Other_T>
+    PageRowCol& operator=(const PageRowCol<Other_T>& p)
+    {
+        if (this != (PageRowCol*)&p)
+        {
+            page = (T)p.page;
+            row = (T)p.row;
+            col = (T)p.col;
+        }
+        return *this;
+    }
+
+    template<typename Other_T>
+    PageRowCol& operator+=(const PageRowCol<Other_T>& p)
+    {
+        page += (T)p.page;
+        row += (T)p.row;
+        col += (T)p.col;
+        return *this;
+    }
+
+    template<typename Other_T>
+    PageRowCol operator+(const PageRowCol<Other_T>& p) const
+    {
+        PageRowCol copy(*this);
+        return copy += p;
+    }
+
+    template<typename Other_T>
+    PageRowCol& operator*=(const PageRowCol<Other_T>& p)
+    {
+        page *= (T)p.page;
+        row *= (T)p.row;
+        col *= (T)p.col;
+        return *this;
+    }
+
+    template<typename Other_T>
+    PageRowCol operator*(const PageRowCol<Other_T>& p) const
+    {
+        PageRowCol copy(*this);
+        return copy *= p;
+    }
+
+    template<typename Other_T>
+    PageRowCol& operator-=(const PageRowCol<Other_T>& p)
+    {
+        page -= (T)p.page;
+        row -= (T)p.row;
+        col -= (T)p.col;
+        return *this;
+    }
+
+    template<typename Other_T>
+    PageRowCol operator-(const PageRowCol<Other_T>& p) const
+    {
+        PageRowCol copy(*this);
+        return copy -= p;
+    }
+
+    template<typename Other_T>
+    PageRowCol& operator/=(const PageRowCol<Other_T>& p)
+    {
+        page /= (T)p.page;
+        row /= (T)p.row;
+        col /= (T)p.col;
+        return *this;
+    }
+
+    template<typename Other_T>
+    PageRowCol operator/(const PageRowCol<Other_T>& p) const
+    {
+        PageRowCol copy(*this);
+        return copy /= p;
+    }
+
+    PageRowCol& operator+=(T scalar)
+    {
+        page += scalar;
+        row += scalar;
+        col += scalar;
+        return *this;
+    }
+
+    PageRowCol operator+(T scalar) const
+    {
+        PageRowCol copy(*this);
+        return copy += scalar;
+    }
+
+    PageRowCol& operator-=(T scalar)
+    {
+        page -= scalar;
+        row -= scalar;
+        col -= scalar;
+        return *this;
+    }
+
+    PageRowCol operator-(T scalar) const
+    {
+        PageRowCol copy(*this);
+        return copy -= scalar;
+    }
+
+    PageRowCol& operator*=(T scalar)
+    {
+        page *= scalar;
+        row *= scalar;
+        col *= scalar;
+        return *this;
+    }
+
+    PageRowCol operator*(T scalar) const
+    {
+        PageRowCol copy(*this);
+        return copy *= scalar;
+    }
+
+    PageRowCol& operator/=(T scalar)
+    {
+        page /= scalar;
+        row /= scalar;
+        col /= scalar;
+        return *this;
+    }
+
+    PageRowCol operator/(T scalar) const
+    {
+        PageRowCol copy(*this);
+        return copy /= scalar;
+    }
+
+    /*!
+     *  Compare the types considering that some
+     *  specializations (e.g., double)
+     *  are not exact
+     */
+    bool operator==(const PageRowCol<T>& p) const
+    {
+        return page == p.page && row == p.row && col == p.col;
+    }
+
+
+    bool operator!=(const PageRowCol<T>& p) const
+    {
+        return ! (PageRowCol::operator==(p));
+    }
+
+    T volume() const
+    {
+        return std::abs(page) * std::abs(row) * std::abs(col);
+    }
+
+    T normL2() const
+    {
+        //! Should be able to just use sqrt() here but VC++ 2010 compiler
+        //  appears to (incorrectly) be calling std::sqrt() in this scenario
+        //  and then complaining it can't find an overloading for some types
+        //  (like size_t)
+        //  So, cast to double and at that point we might as well just call
+        //  std::sqrt()
+        return static_cast<T>(std::sqrt(
+                static_cast<double>(page * page + row * row + col * col)));
+    }
+};
+
+template <>
+inline size_t PageRowCol<size_t>::volume() const
+{
+    return page * row * col;
+}
+
+template <>
+inline bool PageRowCol<float>::operator==(const PageRowCol<float>& p) const
+{
+    float eps = std::numeric_limits<float>::epsilon();
+    return std::abs(page - p.page) < eps &&
+           std::abs(row - p.row) < eps &&
+           std::abs(col - p.col) < eps;
+}
+template <>
+inline bool PageRowCol<double>::operator==(const PageRowCol<double>& p) const
+{
+    double eps = std::numeric_limits<double>::epsilon();
+    return std::abs(page - p.page) < eps &&
+           std::abs(row - p.row) < eps &&
+           std::abs(col - p.col) < eps;
+}
+}
+
+#endif

--- a/modules/c++/types/unittests/test_page_row_col.cpp
+++ b/modules/c++/types/unittests/test_page_row_col.cpp
@@ -1,0 +1,125 @@
+/* =========================================================================
+ * This file is part of types-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * types-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "TestCase.h"
+#include <cmath>
+#include <limits>
+#include <types/RowCol.h>
+#include <types/PageRowCol.h>
+
+namespace
+{
+TEST_CASE(TestPageRowColSizeT)
+{
+    // default constructor should initialize all to 0
+    const types::PageRowCol<size_t> pageRowColDefault;
+    TEST_ASSERT_EQ(pageRowColDefault.page, 0);
+    TEST_ASSERT_EQ(pageRowColDefault.row, 0);
+    TEST_ASSERT_EQ(pageRowColDefault.col, 0);
+
+
+    const types::PageRowCol<size_t> pageRowColA(3,5,11);
+    const types::PageRowCol<size_t> pageRowColB(1,2,3);
+
+    // test equality operators
+    TEST_ASSERT(pageRowColA == pageRowColA);
+    TEST_ASSERT(!(pageRowColA != pageRowColA));
+
+    // test page + RowCol constructor
+    const types::RowCol<size_t> rowCol(5, 11);
+    const types::PageRowCol<size_t> pageRowColFromRowCol(3, rowCol);
+    TEST_ASSERT(pageRowColFromRowCol == pageRowColA);
+
+    // test copy construction
+    const types::PageRowCol<size_t> pageRowColCopy(pageRowColA);
+    TEST_ASSERT(pageRowColCopy == pageRowColA);
+
+    // test copy assignment
+    types::PageRowCol<size_t> pageRowColAssign;
+    pageRowColAssign = pageRowColA;
+    TEST_ASSERT(pageRowColAssign == pageRowColA);
+
+    TEST_ASSERT_EQ(pageRowColA.volume(), 3 * 5 * 11);
+
+    // test arithmetic operators
+    const types::PageRowCol<size_t> sum = pageRowColA + pageRowColB;
+    TEST_ASSERT(sum == types::PageRowCol<size_t>(4, 7, 14));
+
+    const types::PageRowCol<size_t> diff = pageRowColA - pageRowColB;
+    TEST_ASSERT(diff == types::PageRowCol<size_t>(2, 3, 8));
+
+    const types::PageRowCol<size_t> prod = pageRowColA * pageRowColB;
+    TEST_ASSERT(prod == types::PageRowCol<size_t>(3, 10, 33));
+
+    const types::PageRowCol<size_t> div = pageRowColA / pageRowColB;
+    TEST_ASSERT(div == types::PageRowCol<size_t>(3, 2, 3));
+}
+
+TEST_CASE(TestPageRowColDouble)
+{
+    const types::PageRowCol<double> pageRowColA(3.1, 5.2, 11.3);
+    const types::PageRowCol<double> pageRowColB(1.1, 2.2, 3.3);
+
+    // test equality operators
+    TEST_ASSERT(pageRowColA == pageRowColA);
+    TEST_ASSERT(!(pageRowColA != pageRowColA));
+
+    // test copy construction
+    const types::PageRowCol<double> pageRowColCopy(pageRowColA);
+    TEST_ASSERT(pageRowColCopy == pageRowColA);
+
+    // test copy assignment
+    types::PageRowCol<double> pageRowColAssign;
+    pageRowColAssign = pageRowColA;
+    TEST_ASSERT(pageRowColAssign == pageRowColA);
+
+    // test approximate equality
+    pageRowColAssign.page += std::numeric_limits<double>::epsilon() / 2.0;
+    TEST_ASSERT(pageRowColAssign == pageRowColA);
+
+    pageRowColAssign.page += std::numeric_limits<double>::epsilon() * 2.0;
+    TEST_ASSERT(pageRowColAssign != pageRowColA);
+
+    TEST_ASSERT_EQ(pageRowColA.volume(), 3.1 * 5.2 * 11.3);
+    TEST_ASSERT_EQ(pageRowColA.normL2(), std::sqrt(3.1 * 3.1 +  5.2 * 5.2 + 11.3 * 11.3));
+
+    // test arithmetic operators
+    const types::PageRowCol<double> sum = pageRowColA + pageRowColB;
+    TEST_ASSERT(sum == types::PageRowCol<double>(3.1 + 1.1, 5.2 + 2.2, 11.3 + 3.3));
+
+    const types::PageRowCol<double> diff = pageRowColA - pageRowColB;
+    TEST_ASSERT(diff == types::PageRowCol<double>(3.1 - 1.1, 5.2 - 2.2, 11.3 - 3.3));
+
+    const types::PageRowCol<double> prod = pageRowColA * pageRowColB;
+    TEST_ASSERT(prod == types::PageRowCol<double>(3.1 * 1.1, 5.2 * 2.2, 11.3 * 3.3));
+
+    const types::PageRowCol<double> div = pageRowColA / pageRowColB;
+    TEST_ASSERT(div == types::PageRowCol<double>(3.1 / 1.1, 5.2 / 2.2, 11.3 / 3.3));
+}
+}
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    TEST_CHECK(TestPageRowColSizeT);
+    TEST_CHECK(TestPageRowColDouble);
+    return 0;
+}


### PR DESCRIPTION
A new class `PageRowCol` was added to the types library. The interface mirrors `RowCol` with a few exceptions:
* `volume()` method instead of `area()`
* no `std::pair` constructor
* added a new constructor taking a scalar page and a `RowCol`