### PR TITLE
Add StreamSplitter for efficient line-by-line stream reading

### DIFF
--- a/modules/c++/io/include/import/io.h
+++ b/modules/c++/io/include/import/io.h
@@ -72,6 +72,7 @@
 #include <io/SerializableArray.h>
 #include <io/CountingStreams.h>
 #include <io/RotatingFileOutputStream.h>
+#include <io/StreamSplitter.h>
 
 //#include "io/MMapInputStream.h"
 //using namespace io;

--- a/modules/c++/io/include/io/StreamSplitter.h
+++ b/modules/c++/io/include/io/StreamSplitter.h
@@ -1,0 +1,122 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __IO_STREAM_SPLITTER_H__
+#define __IO_STREAM_SPLITTER_H__
+
+#include <string>
+#include <vector>
+
+#include <sys/Conf.h>
+#include <io/InputStream.h>
+
+namespace io
+{
+/*!
+ * StreamSplitter splits the bytes from a stream into substrings separated by a
+ * specified delimiter string. It uses buffered stream reads internally for
+ * better efficiency than InputStream::readln for reading large amounts of data.
+ */
+class StreamSplitter {
+public:
+    /*!
+     * \brief Create a stream splitter.
+     *
+     * \param inputStream The stream to read.
+     * \param delimiter String containing the delimiter. Defaults to Unix line
+     *        break "\n".
+     * \param bufferSize Size of internal buffer.
+     *        Defaults to 64KiB (2^16 bytes).
+     */
+    explicit StreamSplitter(io::InputStream& inputStream,
+                            const std::string& delimiter = std::string("\n"),
+                            size_t bufferSize = 65536);
+
+    /*!
+     * \brief Get the next substring from the stream.
+     *
+     * \param[out] substring A string which will be written and possibly resized
+     *             if this call succeeds. Otherwise it will NOT be modified
+     *             (return value should be checked).
+     * \return true if this call succeeded, false if this call failed.
+     */
+    bool getNext(std::string& substring);
+
+    /*!
+     * \brief Check if the stream has no more substrings to return.
+     *
+     * \return true if no substrings remain, false otherwise
+     */
+    bool isEnd() const;
+
+    /*!
+     * \brief Get the number of substrings this splitter has returned.
+     */
+    size_t getNumSubstringsReturned() const;
+
+    /*!
+     * \brief Get the number of bytes this splitter has returned (does not
+     *        include delimiters).
+     */
+    size_t getNumBytesReturned() const;
+
+    /*!
+     * \brief Get the number of bytes this splitter has processed (includes
+     *        delimiters).
+     *
+     * This includes the content of all returned substrings and all delimiters
+     * seen so far.
+     *
+     * For seekable streams, this may be used to set the stream position to the
+     * point immediately following the last call to getNext, since the stream
+     * may have been read past that point.
+     */
+    size_t getNumBytesProcessed() const;
+
+private:
+    /*!
+     * \brief Append the buffer section from mBufferBegin to bufferSegmentEnd
+     *        to the substring and remove it from the buffer.
+     */
+    void transferBufferSegmentToSubstring(std::string& substring,
+                                          size_t& tokenSize,
+                                          sys::SSize_T bufferSegmentEnd);
+
+    /*!
+     * \brief Read from the stream if it has more data and the buffer has space.
+     */
+    void handleStreamRead();
+
+    const std::string mDelimiter;
+    const sys::SSize_T mBufferCapacity;
+    sys::SSize_T mBufferBegin;
+    sys::SSize_T mBufferEnd;
+    size_t mNumSubstringsReturned;
+    size_t mNumBytesReturned;
+    size_t mNumDelimitersProcessed;
+    std::vector<sys::byte> mBuffer;
+    io::InputStream& mInputStream;
+    bool mStreamEmpty;
+};
+}
+
+#endif

--- a/modules/c++/io/source/StreamSplitter.cpp
+++ b/modules/c++/io/source/StreamSplitter.cpp
@@ -1,0 +1,185 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sstream>
+
+#include <io/StreamSplitter.h>
+#include <except/Exception.h>
+#include <io/InputStream.h>
+
+namespace io
+{
+StreamSplitter::StreamSplitter(io::InputStream& inputStream,
+                               const std::string& delimiter,
+                               size_t bufferSize) :
+    mDelimiter(delimiter),
+    mBufferCapacity(bufferSize),
+    mBufferBegin(0),
+    mBufferEnd(0),
+    mNumSubstringsReturned(0),
+    mNumBytesReturned(0),
+    mNumDelimitersProcessed(0),
+    mBuffer(mBufferCapacity),
+    mInputStream(inputStream),
+    mStreamEmpty(false)
+{
+    if (delimiter.empty())
+    {
+        throw except::InvalidArgumentException(
+                Ctxt("delimiter must be a string with size > 0"));
+    }
+
+    if (bufferSize < delimiter.size() * 2 + 1)
+    {
+        std::ostringstream os;
+        os << "bufferSize must be >= twice the delimiter size + 1 byte. "
+           << "Normally it should be much larger for good performance.";
+        throw except::InvalidArgumentException(Ctxt(os.str()));
+    }
+}
+
+bool StreamSplitter::getNext(std::string& substring)
+{
+    if (isEnd())
+    {
+        return false;
+    }
+
+    if (mNumDelimitersProcessed > 0)
+    {
+        // discard the delimiter before the start of the next substring
+        mBufferBegin += mDelimiter.size();
+    }
+
+    size_t substringSize = 0;
+    while (true)
+    {
+        handleStreamRead();
+
+        // search for delimiter in buffer
+        for (sys::SSize_T ii = mBufferBegin;
+             ii < mBufferEnd - static_cast<sys::SSize_T>(mDelimiter.size() - 1);
+             ++ii)
+        {
+            if (0 == mDelimiter.compare(0,
+                                        mDelimiter.size(),
+                                        &mBuffer[ii],
+                                        mDelimiter.size()))
+            {
+                // delimiter found starting at buffer position ii
+                // append the buffer contents preceding that point to output
+                transferBufferSegmentToSubstring(substring, substringSize, ii);
+                mNumDelimitersProcessed++;
+                mNumSubstringsReturned++;
+                mNumBytesReturned += substringSize;
+                return true;
+            }
+        }
+
+        // no delimiter found in buffer
+        // append the current buffer contents to output
+        const sys::SSize_T segmentEnd = mStreamEmpty ?
+                mBufferEnd
+                :
+                mBufferEnd - static_cast<sys::SSize_T>(mDelimiter.size() - 1);
+        transferBufferSegmentToSubstring(substring, substringSize, segmentEnd);
+
+        // if no bytes remain in stream or buffer, we are done
+        if (isEnd())
+        {
+            mNumSubstringsReturned++;
+            mNumBytesReturned += substringSize;
+            return true;
+        }
+
+        // still have some bytes in stream and/or buffer
+    }
+}
+
+bool StreamSplitter::isEnd() const
+{
+    return mStreamEmpty && mBufferBegin >= mBufferEnd;
+}
+
+size_t StreamSplitter::getNumSubstringsReturned() const
+{
+    return mNumSubstringsReturned;
+}
+
+size_t StreamSplitter::getNumBytesReturned() const
+{
+    return mNumBytesReturned;
+}
+
+size_t StreamSplitter::getNumBytesProcessed() const
+{
+    return getNumBytesReturned() + mNumDelimitersProcessed * mDelimiter.size();
+}
+
+void StreamSplitter::transferBufferSegmentToSubstring(
+        std::string& substring,
+        size_t& substringSize,
+        sys::SSize_T bufferSegmentEnd)
+{
+    const sys::SSize_T segmentSize = bufferSegmentEnd - mBufferBegin;
+    if (segmentSize >= 0)
+    {
+        substring.resize(substringSize + segmentSize);
+        substring.replace(substringSize,
+                          segmentSize,
+                          &mBuffer[mBufferBegin],
+                          segmentSize);
+        substringSize += segmentSize;
+        mBufferBegin += segmentSize;
+    }
+}
+
+void StreamSplitter::handleStreamRead()
+{
+    if (mBufferBegin > mBufferCapacity / 2)
+    {
+        // first half of buffer is no longer needed, shift the rest
+        // down to make space for reading in more
+        std::copy(&mBuffer[mBufferBegin],
+                  &mBuffer[mBufferEnd],
+                  &mBuffer[0]);
+        mBufferEnd = mBufferEnd - mBufferBegin;
+        mBufferBegin = 0;
+    }
+
+    // read more from stream if buffer has space
+    if (!mStreamEmpty && (mBufferEnd < mBufferCapacity))
+    {
+        const sys::SSize_T numRead =
+                mInputStream.read(&mBuffer[mBufferEnd],
+                                  mBufferCapacity - mBufferEnd);
+        if (numRead > 0)
+        {
+            mBufferEnd += numRead;
+        }
+        else
+        {
+            mStreamEmpty = true;
+        }
+    }
+}
+}

--- a/modules/c++/io/unittests/test_stream_splitter.cpp
+++ b/modules/c++/io/unittests/test_stream_splitter.cpp
@@ -1,0 +1,240 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <algorithm>
+#include <string>
+#include <vector>
+#include <io/StreamSplitter.h>
+#include <io/StringStream.h>
+#include <TestCase.h>
+
+// return true if the string sequences are the same, false otherwise
+bool compareStringSequence(const std::vector<std::string>& a,
+                           const std::vector<std::string>& b)
+{
+    if (a.size() != b.size())
+    {
+        return false;
+    }
+    return std::equal(a.begin(), a.end(), b.begin());
+}
+
+std::string getTestLine(size_t length)
+{
+    std::string lineTemplate = "012345678901234567890";
+    return lineTemplate.substr(0, length);
+}
+
+// join lines into StringStream and verify StreamSplitter produces the same
+// sequence of lines
+// return true for success, false for failure
+bool streamSplitterTestRunner(size_t numLines,
+                              size_t lineLength,
+                              const std::string& delimiter,
+                              size_t bufferSize)
+{
+    std::vector<std::string> inputLines;
+    io::StringStream stream;
+
+    std::string lineString;
+    if (lineLength <= 20)
+    {
+        lineString = getTestLine(lineLength);
+    }
+    inputLines.push_back(lineString);
+    stream.write(lineString.data(), lineString.length());
+    size_t numBytesTotal = lineString.length();
+    std::vector<size_t> numBytesCumulative;
+    if (numLines > 1)
+    {
+        numBytesTotal += delimiter.length();
+    }
+    numBytesCumulative.push_back(numBytesTotal);
+    for (size_t ii = 1; ii < numLines; ++ii)
+    {
+        lineString = getTestLine((lineLength <= 20) ? lineLength : ii % 20);
+        inputLines.push_back(lineString);
+        stream.write(delimiter.data(), delimiter.length());
+        stream.write(lineString.data(), lineString.length());
+        numBytesTotal += lineString.length();
+        if (ii < numLines - 1)
+        {
+            numBytesTotal += delimiter.length();
+        }
+        numBytesCumulative.push_back(numBytesTotal);
+    }
+
+    io::StreamSplitter splitter(stream, delimiter, bufferSize);
+    std::vector<std::string> outputLines;
+    std::string substring;
+    size_t numBytesReturned = 0;
+
+    if (splitter.getNumSubstringsReturned() != 0 ||
+        splitter.getNumBytesReturned() != 0 ||
+        splitter.getNumBytesProcessed() != 0)
+    {
+        return false;
+    }
+
+    while (splitter.getNext(substring))
+    {
+        outputLines.push_back(substring);
+
+        if (splitter.getNumSubstringsReturned() != outputLines.size())
+        {
+            return false;
+        }
+
+        numBytesReturned += substring.size();
+        if (numBytesReturned != splitter.getNumBytesReturned() ||
+            (numBytesCumulative[outputLines.size() - 1] !=
+             splitter.getNumBytesProcessed()))
+        {
+            return false;
+        }
+    }
+
+    if (splitter.getNumBytesProcessed() != numBytesTotal)
+    {
+        return false;
+    }
+
+    if (splitter.getNext(substring))
+    {
+        // stream should be empty
+        return false;
+    }
+    return compareStringSequence(inputLines, outputLines);
+}
+
+TEST_CASE(testStreamSplitter)
+{
+    std::vector<size_t> lineCounts;
+    lineCounts.push_back(1);
+    lineCounts.push_back(2);
+    lineCounts.push_back(3);
+    lineCounts.push_back(11);
+    lineCounts.push_back(19);
+    lineCounts.push_back(20);
+    lineCounts.push_back(21);
+    lineCounts.push_back(37);
+
+    std::vector<size_t> lineLengths;
+    lineLengths.push_back(0);
+    lineLengths.push_back(1);
+    lineLengths.push_back(9);
+    lineLengths.push_back(10);
+    lineLengths.push_back(11);
+    lineLengths.push_back(50);  // variable line lengths
+
+    std::vector<std::string> delimiters;
+    delimiters.push_back(",");
+    delimiters.push_back(" ");
+    delimiters.push_back("  ");
+    delimiters.push_back("aaa");
+    delimiters.push_back("abc");
+    delimiters.push_back("\n");
+    delimiters.push_back("\r\n");
+
+    std::vector<size_t> bufferSizes;
+    bufferSizes.push_back(65536); // default size
+
+    bufferSizes.push_back(30); // too small to read full stream at once
+    bufferSizes.push_back(31);
+    bufferSizes.push_back(32);
+    bufferSizes.push_back(33);
+    bufferSizes.push_back(34);
+    bufferSizes.push_back(35);
+    bufferSizes.push_back(36);
+    bufferSizes.push_back(37);
+    bufferSizes.push_back(38);
+
+    bufferSizes.push_back(7); // too small to fit a single line
+    bufferSizes.push_back(8);
+    bufferSizes.push_back(9);
+    bufferSizes.push_back(10);
+    bufferSizes.push_back(11);
+    bufferSizes.push_back(12);
+
+    // check every combination of lineCount, lineLength, delimiter, and bufferSize
+    for (size_t i_lineCount = 0; i_lineCount < lineCounts.size(); ++i_lineCount)
+    {
+        const size_t lineCount = lineCounts[i_lineCount];
+        for (size_t i_lineLength = 0; i_lineLength < lineLengths.size(); ++i_lineLength)
+        {
+            const size_t lineLength = lineLengths[i_lineLength];
+            for (size_t i_delimiter = 0; i_delimiter < delimiters.size(); ++i_delimiter)
+            {
+                const std::string delimiter = delimiters[i_delimiter];
+                for (size_t i_bufferSize = 0; i_bufferSize < bufferSizes.size(); ++i_bufferSize)
+                {
+                    const size_t bufferSize = bufferSizes[i_bufferSize];
+                    TEST_ASSERT(streamSplitterTestRunner(lineCount, lineLength, delimiter, bufferSize));
+                }
+            }
+        }
+    }
+
+}
+
+TEST_CASE(testStreamSplitterEmpty)
+{
+    // empty stream should return 1 empty token
+    std::string substring;
+    io::StringStream stream;
+    io::StreamSplitter splitter(stream);
+    TEST_ASSERT(splitter.getNumSubstringsReturned() == 0);
+    TEST_ASSERT(splitter.getNumBytesReturned() == 0);
+    TEST_ASSERT(splitter.getNumBytesProcessed() == 0);
+    bool success = splitter.getNext(substring);
+    TEST_ASSERT(success);
+    TEST_ASSERT(substring == "");
+    success = splitter.getNext(substring);
+    TEST_ASSERT(!success);
+
+    TEST_ASSERT(splitter.getNumSubstringsReturned() == 1);
+    TEST_ASSERT(splitter.getNumBytesReturned() == 0);
+    TEST_ASSERT(splitter.getNumBytesProcessed() == 0);
+}
+
+TEST_CASE(testStreamSplitterInputValidation)
+{
+    // delimiter must be nonempty string
+    TEST_EXCEPTION(streamSplitterTestRunner(10, 10, "", 2));
+
+    // buffer too small to support delimiter
+    TEST_EXCEPTION(streamSplitterTestRunner(10, 10, " ", 2));
+    TEST_ASSERT(streamSplitterTestRunner(10, 10, " ", 3));
+
+    TEST_EXCEPTION(streamSplitterTestRunner(10, 10, "  ", 4));
+    TEST_ASSERT(streamSplitterTestRunner(10, 10, "  ", 5));
+
+    TEST_EXCEPTION(streamSplitterTestRunner(10, 10, "abc", 6));
+    TEST_ASSERT(streamSplitterTestRunner(10, 10, "abc", 7));
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(testStreamSplitterEmpty);
+    TEST_CHECK(testStreamSplitter);
+    TEST_CHECK(testStreamSplitterInputValidation);
+}


### PR DESCRIPTION
This class is a more efficient alternative to the `InputStream::readln` method, which reads 1 byte at a time from the stream.