### PR TITLE
Remove exception specifications.

### DIFF
--- a/modules/c++/cli/include/cli/Results.h
+++ b/modules/c++/cli/include/cli/Results.h
@@ -59,13 +59,11 @@ public:
     }
 
     cli::Value* operator[](const std::string& key) const
-            throw (except::NoSuchKeyException)
     {
         return getValue(key);
     }
 
     cli::Value* getValue(const std::string& key) const
-            throw (except::NoSuchKeyException)
     {
         ConstValueIter_T p = mValues.find(key);
         if (p == mValues.end())
@@ -78,20 +76,17 @@ public:
 
     template<typename T>
     T get(const std::string& key, unsigned int index = 0) const
-            throw (except::NoSuchKeyException)
     {
         return getValue(key)->get<T>(index);
     }
 
     template<typename T>
     T operator()(const std::string& key, unsigned int index = 0) const
-            throw (except::NoSuchKeyException)
     {
         return get<T>(key, index);
     }
 
     cli::Results* getSubResults(const std::string& key) const
-            throw (except::NoSuchKeyException)
     {
         ConstResultsIter_T p = mResults.find(key);
         if (p == mResults.end())

--- a/modules/c++/dbi/include/dbi/DatabaseClientFactory.h
+++ b/modules/c++/dbi/include/dbi/DatabaseClientFactory.h
@@ -82,7 +82,7 @@ public:
                                         const std::string& user = "",
                                         const std::string& pass = "",
                                         const std::string& host = "localhost",
-                                        unsigned int port = 0) throw (except::Exception);
+                                        unsigned int port = 0);
 
     /*!
      *  Destroy a previously created connection

--- a/modules/c++/dbi/source/DatabaseClientFactory.cpp
+++ b/modules/c++/dbi/source/DatabaseClientFactory.cpp
@@ -42,7 +42,7 @@ dbi::DatabaseConnection * dbi::DatabaseClientFactory::create(const std::string& 
         const std::string& user,
         const std::string& pass,
         const std::string& host,
-        unsigned int port) throw (except::Exception)
+        unsigned int port)
 {
     dbi::DatabaseConnection * connection = NULL;
 #   if defined(USE_PGSQL)

--- a/modules/c++/io/include/io/FileUtils.h
+++ b/modules/c++/io/include/io/FileUtils.h
@@ -85,11 +85,11 @@ public:
      * given one. If the given filename is empty, a temporary name is used.
      */
     static std::string createFile(std::string dirname, std::string filename =
-            std::string(""), bool overwrite = true) throw (except::IOException);
+            std::string(""), bool overwrite = true);
 
-    static void touchFile(std::string filename) throw (except::IOException);
+    static void touchFile(std::string filename);
 
-    static void forceMkdir(std::string dirname) throw (except::IOException);
+    static void forceMkdir(std::string dirname);
 
 private:
     //private constructor

--- a/modules/c++/io/source/FileUtils.cpp
+++ b/modules/c++/io/source/FileUtils.cpp
@@ -125,7 +125,7 @@ void io::copy(const std::string& path,
 }
 
 std::string io::FileUtils::createFile(std::string dirname,
-        std::string filename, bool overwrite) throw (except::IOException)
+        std::string filename, bool overwrite)
 {
     sys::OS os;
 
@@ -171,7 +171,7 @@ std::string io::FileUtils::createFile(std::string dirname,
     return outFilename;
 }
 
-void io::FileUtils::touchFile(std::string filename) throw (except::IOException)
+void io::FileUtils::touchFile(std::string filename)
 {
     sys::OS os;
     if (os.exists(filename))
@@ -188,7 +188,7 @@ void io::FileUtils::touchFile(std::string filename) throw (except::IOException)
     }
 }
 
-void io::FileUtils::forceMkdir(std::string dirname) throw (except::IOException)
+void io::FileUtils::forceMkdir(std::string dirname)
 {
     sys::OS os;
     if (os.exists(dirname))

--- a/modules/c++/net/include/net/URL.h
+++ b/modules/c++/net/include/net/URL.h
@@ -49,11 +49,11 @@ public:
     URLParams(const std::string paramString = "");
 
     bool contains(std::string key) const;
-    ParamValues& get(std::string key) throw (except::NoSuchKeyException);
-    const ParamValues& get(std::string key) const throw (except::NoSuchKeyException);
+    ParamValues& get(std::string key);
+    const ParamValues& get(std::string key) const;
     Params& get() { return mParams; }
     const Params& get() const { return mParams; }
-    std::string getFirst(std::string key) const throw (except::NoSuchKeyException);
+    std::string getFirst(std::string key) const;
     void add(std::string key, std::string value = "");
     void remove(std::string key);
 

--- a/modules/c++/net/source/URL.cpp
+++ b/modules/c++/net/source/URL.cpp
@@ -152,7 +152,6 @@ bool net::URLParams::contains(std::string key) const
 }
 
 net::URLParams::ParamValues& net::URLParams::get(std::string key)
-        throw (except::NoSuchKeyException)
 {
     net::URLParams::Params::iterator it = mParams.find(key);
     if (it == mParams.end() || it->second.size() == 0)
@@ -161,7 +160,6 @@ net::URLParams::ParamValues& net::URLParams::get(std::string key)
 }
 
 const net::URLParams::ParamValues& net::URLParams::get(std::string key) const
-        throw (except::NoSuchKeyException)
 {
     net::URLParams::Params::const_iterator it = mParams.find(key);
     if (it == mParams.end() || it->second.size() == 0)
@@ -169,7 +167,6 @@ const net::URLParams::ParamValues& net::URLParams::get(std::string key) const
     return it->second;
 }
 std::string net::URLParams::getFirst(std::string key) const
-        throw (except::NoSuchKeyException)
 {
     net::URLParams::Params::const_iterator it = mParams.find(key);
     if (it == mParams.end() || it->second.size() == 0)

--- a/modules/c++/sio.lite/include/sio/lite/FileHeader.h
+++ b/modules/c++/sio.lite/include/sio/lite/FileHeader.h
@@ -175,8 +175,7 @@ public:
      *  Get the raw byte user data for a given user data ID.
      *  @return An array of user data for a given key
      */
-    std::vector<sys::byte>& getUserData(const std::string& key)
-        throw (except::NoSuchKeyException);
+    std::vector<sys::byte>& getUserData(const std::string& key);
 
     /**
      *  Get back the whole hash table

--- a/modules/c++/sio.lite/include/sio/lite/UserDataDictionary.h
+++ b/modules/c++/sio.lite/include/sio/lite/UserDataDictionary.h
@@ -64,7 +64,6 @@ public:
     ConstIterator end() const { return mList.end(); }
 
     virtual Value_T& operator[] (const Key_T& key)
-        throw(except::NoSuchKeyException)
     {
         typename std::map < Key_T, Value_T >::iterator it = mMap.find(key);
         if (it == mMap.end())

--- a/modules/c++/sio.lite/source/FileHeader.cpp
+++ b/modules/c++/sio.lite/source/FileHeader.cpp
@@ -95,7 +95,6 @@ void sio::lite::FileHeader::getAllUserDataFields(
 }
 
 std::vector<sys::byte>& sio::lite::FileHeader::getUserData(const std::string& key)
-    throw (except::NoSuchKeyException)
 {
     if (!userData.exists(key))
         throw except::NoSuchKeyException(key);

--- a/modules/c++/str/include/str/Convert.h
+++ b/modules/c++/str/include/str/Convert.h
@@ -171,7 +171,7 @@ template<> int getPrecision(const long double& type);
  @throw BadCastException thrown if cast cannot be performed.
  */
 template<typename T>
-T generic_cast(const std::string& value) throw (except::BadCastException)
+T generic_cast(const std::string& value)
 {
     return str::toType<T>(value);
 }

--- a/modules/c++/unique/include/unique/UUID.hpp
+++ b/modules/c++/unique/include/unique/UUID.hpp
@@ -11,7 +11,7 @@ typedef except::InvalidFormatException UUIDException;
 /*!
  * Create a 36-character UUID and return as a std::string
  */ 
-std::string generateUUID() throw(unique::UUIDException);
+std::string generateUUID();
 
 }
 #endif

--- a/modules/c++/unique/source/UUID.cpp
+++ b/modules/c++/unique/source/UUID.cpp
@@ -28,7 +28,7 @@
 #include <uuid/uuid.h>
 #endif
 
-std::string unique::generateUUID() throw(unique::UUIDException)
+std::string unique::generateUUID()
 {
 #ifdef WIN32
     GUID uuid;


### PR DESCRIPTION
Exception specifications were discouraged in C++11, deprecated in C++14,
and removed in C++17.

Get rid of them so that newer compilers stop warning about them.