### PR TITLE
Physical core count

### DIFF
--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -215,7 +215,15 @@ public:
 
     virtual std::string getDSOSuffix() const = 0;
 
+    /*!
+     * Get the number of logical CPUs available (includes hyperthreading)
+     */
     virtual size_t getNumCPUs() const = 0;
+
+    /*!
+     * Get the number of physical CPUs available (excludes hyperthreading)
+     */
+    virtual size_t getNumPhysicalCPUs() const = 0;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -216,12 +216,12 @@ public:
     virtual std::string getDSOSuffix() const = 0;
 
     /*!
-     * Get the number of logical CPUs available (includes hyperthreading)
+     * \return the number of logical CPUs available (includes hyperthreading)
      */
     virtual size_t getNumCPUs() const = 0;
 
     /*!
-     * Get the number of physical CPUs available (excludes hyperthreading)
+     * \return the number of physical CPUs available (excludes hyperthreading)
      */
     virtual size_t getNumPhysicalCPUs() const = 0;
 

--- a/modules/c++/sys/include/sys/OSUnix.h
+++ b/modules/c++/sys/include/sys/OSUnix.h
@@ -161,7 +161,15 @@ public:
 
     virtual std::string getDSOSuffix() const;
 
+    /*!
+     * Get the number of logical CPUs available (includes hyperthreading)
+     */
     virtual size_t getNumCPUs() const;
+
+    /*!
+     * Get the number of physical CPUs available (excludes hyperthreading)
+     */
+    virtual size_t getNumPhysicalCPUs() const;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative

--- a/modules/c++/sys/include/sys/OSUnix.h
+++ b/modules/c++/sys/include/sys/OSUnix.h
@@ -162,12 +162,12 @@ public:
     virtual std::string getDSOSuffix() const;
 
     /*!
-     * Get the number of logical CPUs available (includes hyperthreading)
+     * \return the number of logical CPUs available (includes hyperthreading)
      */
     virtual size_t getNumCPUs() const;
 
     /*!
-     * Get the number of physical CPUs available (excludes hyperthreading)
+     * \return the number of physical CPUs available (excludes hyperthreading)
      */
     virtual size_t getNumPhysicalCPUs() const;
 

--- a/modules/c++/sys/include/sys/OSWin32.h
+++ b/modules/c++/sys/include/sys/OSWin32.h
@@ -182,13 +182,13 @@ public:
     virtual void unsetEnv(const std::string& var);
 
     /*!
-     * Get the number of logical CPUs available (includes hyperthreading)
+     * \return the number of logical CPUs available (includes hyperthreading)
      */
     virtual size_t getNumCPUs() const;
 
     /*!
-     * Get the number of physical CPUs available (excludes hyperthreading)
-     * TODO: Not yet implemented
+     * \todo Not yet implemented
+     * \return the number of physical CPUs available (excludes hyperthreading)
      */
     virtual size_t getNumPhysicalCPUs() const;
 

--- a/modules/c++/sys/include/sys/OSWin32.h
+++ b/modules/c++/sys/include/sys/OSWin32.h
@@ -181,12 +181,21 @@ public:
      */
     virtual void unsetEnv(const std::string& var);
 
+    /*!
+     * Get the number of logical CPUs available (includes hyperthreading)
+     */
     virtual size_t getNumCPUs() const;
+
+    /*!
+     * Get the number of physical CPUs available (excludes hyperthreading)
+     * TODO: Not yet implemented
+     */
+    virtual size_t getNumPhysicalCPUs() const;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative
      */
-    virtual void createSymlink(const std::string& origPathname, 
+    virtual void createSymlink(const std::string& origPathname,
                                const std::string& symlinkPathname) const;
 
     /*!

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -29,6 +29,9 @@
 #include <unistd.h>
 #include <sstream>
 #include <limits.h>
+#include <vector>
+#include <set>
+#include <fstream>
 
 #if defined(__APPLE__)
 
@@ -307,6 +310,52 @@ size_t sys::OSUnix::getNumCPUs() const
 #else
     throw except::NotImplementedException(Ctxt("Unable to get the number of CPUs"));
 #endif
+}
+
+size_t sys::OSUnix::getNumPhysicalCPUs() const
+{
+    // Our goal is to count the number of unique entries that occur
+    // in the files /sys/devices/system/cpu/cpu*/topology/thread_siblings_list
+    const sys::Path sysCPUPath("/sys/devices/system/cpu");
+    if (!sysCPUPath.isDirectory())
+    {
+        throw except::Exception(
+                Ctxt("Expected dir /sys/devices/system/cpu does not exist"));
+    }
+
+    const std::vector<std::string> searchPaths(1, sysCPUPath.getPath());
+    const std::vector<std::string> subDirs =
+        sys::FileFinder::search(
+            sys::DirectoryOnlyPredicate(),
+            searchPaths,
+            false);
+
+    std::set<std::string> unique_thread_siblings;
+    for (std::vector<std::string>::const_iterator ii = subDirs.begin();
+         ii != subDirs.end();
+         ++ii)
+    {
+        const sys::Path tsPath(*ii, "topology/thread_siblings_list");
+        if (tsPath.exists())
+        {
+            std::ifstream tsIFS(tsPath.getPath().c_str());
+            if (!tsIFS.is_open())
+            {
+                std::ostringstream msg;
+                msg << "Unable to open thread siblings file "
+                    << tsPath.getPath();
+                throw except::Exception(Ctxt(msg.str()));
+            }
+
+            std::string tsContents;
+            tsIFS >> tsContents;
+            tsIFS.close();
+
+            unique_thread_siblings.insert(tsContents);
+        }
+    }
+
+    return unique_thread_siblings.size();
 }
 
 void sys::OSUnix::createSymlink(const std::string& origPathname,

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -283,6 +283,9 @@ size_t sys::OSWin32::getNumCPUs() const
 
 size_t sys::OSWin32::getNumPhysicalCPUs() const
 {
+    // TODO Need to use GetLogicalProcessorInformationEx.
+    //      See reference implementation at
+    //      https://devblogs.microsoft.com/oldnewthing/?p=2823
     throw except::NotImplementedException(
         Ctxt("Windows getNumPhysicalCPUs not yet implemented."));
 }

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -281,6 +281,12 @@ size_t sys::OSWin32::getNumCPUs() const
     return info.dwNumberOfProcessors;
 }
 
+size_t sys::OSWin32::getNumPhysicalCPUs() const
+{
+    throw except::NotImplementedException(
+        Ctxt("Windows getNumPhysicalCPUs not yet implemented."));
+}
+
 void sys::OSWin32::createSymlink(const std::string& origPathname,
                                  const std::string& symlinkPathname) const
 {

--- a/modules/c++/sys/tests/OSTest.cpp
+++ b/modules/c++/sys/tests/OSTest.cpp
@@ -44,7 +44,6 @@ int main(int argc, char **argv)
         std::cout << "User path: " << os["PATH"] << std::endl;
         std::cout << "Platform: " << os.getPlatformName() << std::endl;
         std::cout << "Num CPUs: " << os.getNumCPUs() << std::endl;
-        std::cout << "Num Physical CPUs: " << os.getNumPhysicalCPUs() << std::endl;
         std::cout << "The delimiter on this platform: " << os.getDelimiter()
                 << std::endl;
         std::cout << "The process id: " << os.getProcessId() << std::endl;

--- a/modules/c++/sys/tests/OSTest.cpp
+++ b/modules/c++/sys/tests/OSTest.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv)
         std::cout << "User path: " << os["PATH"] << std::endl;
         std::cout << "Platform: " << os.getPlatformName() << std::endl;
         std::cout << "Num CPUs: " << os.getNumCPUs() << std::endl;
+        std::cout << "Num Physical CPUs: " << os.getNumPhysicalCPUs() << std::endl;
         std::cout << "The delimiter on this platform: " << os.getDelimiter()
                 << std::endl;
         std::cout << "The process id: " << os.getProcessId() << std::endl;


### PR DESCRIPTION
Added `OS::getNumPhysicalCPUs()` to return the physical core count (as opposed to `OS::getNumCPUs()` which returns the logical core count).

__Unix implementation__: Scan for `thread_siblings_list` files under `/sys/devices/system/cpu/cpu*/topology/` and count the number of unique entries across files. 

__Windows implementation__: Throw `NotYetImplemented`. Not as simple as `getNumCPUs()`, and not needed at this time. A reference implementation for how to use `GetLogicalProcessorInformationEx` is at https://devblogs.microsoft.com/oldnewthing/?p=2823. 