### PR TITLE
Affinity-based CPU reporting

### DIFF
--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -216,14 +216,30 @@ public:
     virtual std::string getDSOSuffix() const = 0;
 
     /*!
-     * \return the number of logical CPUs available (includes hyperthreading)
+     * \return the number of logical CPUs present on the machine
+     *         (includes hyperthreading)
      */
     virtual size_t getNumCPUs() const = 0;
 
     /*!
-     * \return the number of physical CPUs available (excludes hyperthreading)
+     * \return the number of logical CPUs available. This will be
+     *         affected by pinning (e.g. start/affinity/numactl/taskset),
+     *         and will always be <= getNumCPUs.
+     */
+    virtual size_t getNumCPUsAvailable() const = 0;
+
+    /*!
+     * \return the number of physical CPUs present on the machine
+     *         (excludes hyperthreading)
      */
     virtual size_t getNumPhysicalCPUs() const = 0;
+
+    /*!
+     * \return the number of physical CPUs available. This will be
+     *         affected by pinning (e.g. start/affinity/numactl/taskset),
+     *         and will always be <= getNumPhysicalCPUs.
+     */
+    virtual size_t getNumPhysicalCPUsAvailable() const = 0;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative

--- a/modules/c++/sys/include/sys/OSUnix.h
+++ b/modules/c++/sys/include/sys/OSUnix.h
@@ -162,14 +162,30 @@ public:
     virtual std::string getDSOSuffix() const;
 
     /*!
-     * \return the number of logical CPUs available (includes hyperthreading)
+     * \return the number of logical CPUs present on the machine
+     *         (includes hyperthreading)
      */
     virtual size_t getNumCPUs() const;
 
     /*!
-     * \return the number of physical CPUs available (excludes hyperthreading)
+     * \return the number of logical CPUs available. This will be
+     *         affected by pinning (e.g. numactl/taskset), and will
+     *         always be <= getNumCPUs.
+     */
+    virtual size_t getNumCPUsAvailable() const;
+
+    /*!
+     * \return the number of physical CPUs present on the machine
+     *         (excludes hyperthreading)
      */
     virtual size_t getNumPhysicalCPUs() const;
+
+    /*!
+     * \return the number of physical CPUs available. This will be
+     *         affected by pinning (e.g. numactl/taskset), and will
+     *         always be <= getNumPhysicalCPUs.
+     */
+    virtual size_t getNumPhysicalCPUsAvailable() const;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative

--- a/modules/c++/sys/include/sys/OSWin32.h
+++ b/modules/c++/sys/include/sys/OSWin32.h
@@ -182,15 +182,33 @@ public:
     virtual void unsetEnv(const std::string& var);
 
     /*!
-     * \return the number of logical CPUs available (includes hyperthreading)
+     * \return the number of logical CPUs present on the machine
+     *         (includes hyperthreading)
      */
     virtual size_t getNumCPUs() const;
 
     /*!
      * \todo Not yet implemented
-     * \return the number of physical CPUs available (excludes hyperthreading)
+     * \return the number of logical CPUs available. This will be
+     *         affected by pinning (e.g. start/affinity), and will
+     *         always be <= getNumCPUs.
+     */
+    virtual size_t getNumCPUsAvailable() const;
+
+    /*!
+     * \todo Not yet implemented
+     * \return the number of physical CPUs present on the machine
+     *         (excludes hyperthreading)
      */
     virtual size_t getNumPhysicalCPUs() const;
+
+    /*!
+     * \todo Not yet implemented
+     * \return the number of physical CPUs available. This will be
+     *         affected by pinning (e.g. start/affinity), and will
+     *         always be <= getNumPhysicalCPUs.
+     */
+    virtual size_t getNumPhysicalCPUsAvailable() const;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -131,6 +131,14 @@ std::set<std::string> get_unique_thread_siblings()
 
     return unique_ts;
 }
+
+void get_cpu_affinity(cpu_set_t* mask)
+{
+    if (-1 == sched_getaffinity(0, sizeof(cpu_set_t), mask))
+    {
+        throw except::Exception(Ctxt("Failed to get CPU affinity"));
+    }
+}
 }
 
 std::string sys::OSUnix::getPlatformName() const
@@ -363,11 +371,7 @@ size_t sys::OSUnix::getNumCPUs() const
 size_t sys::OSUnix::getNumCPUsAvailable() const
 {
     cpu_set_t mask;
-    if (-1 == sched_getaffinity(0, sizeof(cpu_set_t), &mask))
-    {
-        throw except::Exception(Ctxt("Failed to get CPU affinity"));
-    }
-
+    get_cpu_affinity(&mask);
     return CPU_COUNT(&mask);
 }
 
@@ -380,10 +384,7 @@ size_t sys::OSUnix::getNumPhysicalCPUsAvailable() const
 {
     // Obtain scheduling affinity for all CPUs (including hyperthreading)
     cpu_set_t mask;
-    if (-1 == sched_getaffinity(0, sizeof(cpu_set_t), &mask))
-    {
-        throw except::Exception(Ctxt("Failed to get CPU affinity"));
-    }
+    get_cpu_affinity(&mask);
 
     // Cross-reference the thread siblings with active CPUs
     // and count unique instances in this filtered subset

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -281,6 +281,12 @@ size_t sys::OSWin32::getNumCPUs() const
     return info.dwNumberOfProcessors;
 }
 
+size_t sys::OSWin32::getNumCPUsAvailable() const
+{
+    throw except::NotImplementedException(
+        Ctxt("Windows getNumCPUsAvailable not yet implemented."));
+}
+
 size_t sys::OSWin32::getNumPhysicalCPUs() const
 {
     // TODO Need to use GetLogicalProcessorInformationEx.
@@ -288,6 +294,12 @@ size_t sys::OSWin32::getNumPhysicalCPUs() const
     //      https://devblogs.microsoft.com/oldnewthing/?p=2823
     throw except::NotImplementedException(
         Ctxt("Windows getNumPhysicalCPUs not yet implemented."));
+}
+
+size_t sys::OSWin32::getNumPhysicalCPUsAvailable() const
+{
+    throw except::NotImplementedException(
+        Ctxt("Windows getNumPhysicalCPUsAvailable not yet implemented."));
 }
 
 void sys::OSWin32::createSymlink(const std::string& origPathname,

--- a/modules/c++/sys/tests/CPUTest.cpp
+++ b/modules/c++/sys/tests/CPUTest.cpp
@@ -1,0 +1,51 @@
+/* =========================================================================
+ * This file is part of sys-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <import/sys.h>
+
+using namespace sys;
+
+int main(int argc, char **argv)
+{
+    try
+    {
+        sys::OS os;
+
+        std::cout << "Present number of CPUs: "
+                  << os.getNumCPUs() << std::endl;
+        std::cout << "Present number of physical CPUs: "
+                  << os.getNumPhysicalCPUs() << std::endl;
+        std::cout << "Available number of CPUs: "
+                  << os.getNumCPUsAvailable() << std::endl;
+        std::cout << "Available number of physical CPUs: "
+                  << os.getNumPhysicalCPUsAvailable() << std::endl;
+    }
+    catch (except::Throwable& t)
+    {
+        std::cerr << "Caught throwable: " << t.toString() << std::endl;
+        exit( EXIT_FAILURE);
+    }
+    catch (...)
+    {
+        std::cerr << "Caught unnamed exception" << std::endl;
+    }
+    return 0;
+}

--- a/modules/c++/sys/tests/CPUTest.cpp
+++ b/modules/c++/sys/tests/CPUTest.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv)
     catch (except::Throwable& t)
     {
         std::cerr << "Caught throwable: " << t.toString() << std::endl;
-        exit( EXIT_FAILURE);
+        exit(EXIT_FAILURE);
     }
     catch (...)
     {

--- a/modules/c++/sys/tests/CPUTest.cpp
+++ b/modules/c++/sys/tests/CPUTest.cpp
@@ -21,9 +21,7 @@
  */
 #include <import/sys.h>
 
-using namespace sys;
-
-int main(int argc, char **argv)
+int main(int /*argc*/, char** /*argv*/)
 {
     try
     {
@@ -38,14 +36,15 @@ int main(int argc, char **argv)
         std::cout << "Available number of physical CPUs: "
                   << os.getNumPhysicalCPUsAvailable() << std::endl;
     }
-    catch (except::Throwable& t)
+    catch (const except::Throwable& t)
     {
         std::cerr << "Caught throwable: " << t.toString() << std::endl;
-        exit(EXIT_FAILURE);
+        return 1;
     }
     catch (...)
     {
         std::cerr << "Caught unnamed exception" << std::endl;
+        return 1;
     }
     return 0;
 }


### PR DESCRIPTION
Added affinity-based CPU count reporting to `OS`, available through `getNumCPUsAvailable` and `getNumPhysicalCPUsAvailable`. On Linux, these functions use `sched_getaffinity` and associated helpers to report total and physical CPU counts that may have been restricted by `numactl`/`taskset`. 

On Windows, these functions throw `NotImplementedException`. 