### PR TITLE
MT fixes

### DIFF
--- a/modules/c++/mt/include/mt/AbstractTiedThreadPool.h
+++ b/modules/c++/mt/include/mt/AbstractTiedThreadPool.h
@@ -1,8 +1,8 @@
 /* =========================================================================
- * This file is part of mt-c++ 
+ * This file is part of mt-c++
  * =========================================================================
- * 
- * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
  *
  * mt-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -14,8 +14,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -35,39 +35,45 @@ class AbstractTiedThreadPool : public AbstractThreadPool<Request_T>
 {
 
 public:
-	AbstractTiedThreadPool(unsigned short numThreads = 0) : AbstractThreadPool<Request_T>(numThreads) {}
+    AbstractTiedThreadPool(unsigned short numThreads = 0) :
+            AbstractThreadPool<Request_T>(numThreads)
+    {
+    }
 
-	virtual ~AbstractTiedThreadPool(){}
+    virtual ~AbstractTiedThreadPool(){}
 
-	virtual void initialize(CPUAffinityInitializer* affinityInit = NULL)
-	{
-	    mAffinityInit = affinityInit;
-	}
-	virtual CPUAffinityThreadInitializer* getCPUAffinityThreadInitializer()
-	{
-	    CPUAffinityThreadInitializer* threadInit = NULL;
-	    
-	    // If we were passed a schematic 
-	    // for initializing thread affinity...
-	    if (mAffinityInit)
-	    {
-		threadInit = mAffinityInit->newThreadInitializer();
-	    }
-	    return threadInit;
-	}
+    virtual void initialize(CPUAffinityInitializer* affinityInit = NULL)
+    {
+        mAffinityInit = affinityInit;
+    }
 
-	virtual mt::WorkerThread<Request_T>* newWorker()
-	{
-	    return newTiedWorker(&this->mRequestQueue, 
-				 getCPUAffinityThreadInitializer());
-	}
+    virtual std::auto_ptr<CPUAffinityThreadInitializer>
+    getCPUAffinityThreadInitializer()
+    {
+        std::auto_ptr<CPUAffinityThreadInitializer> threadInit(NULL);
+
+        // If we were passed a schematic
+        // for initializing thread affinity...
+        if (mAffinityInit)
+        {
+            threadInit = mAffinityInit->newThreadInitializer();
+        }
+        return threadInit;
+    }
+
+    virtual mt::WorkerThread<Request_T>* newWorker()
+    {
+        return newTiedWorker(&this->mRequestQueue,
+                 getCPUAffinityThreadInitializer());
+    }
 
  protected:
-	virtual mt::TiedWorkerThread<Request_T>* newTiedWorker(mt::RequestQueue<Request_T>* q, 
-							       CPUAffinityThreadInitializer* init) = 0;
+    virtual mt::TiedWorkerThread<Request_T>*
+    newTiedWorker(mt::RequestQueue<Request_T>* q,
+                  std::auto_ptr<CPUAffinityThreadInitializer> init) = 0;
 
 private:
-	CPUAffinityInitializer* mAffinityInit;
+    CPUAffinityInitializer* mAffinityInit;
 };
 
 }

--- a/modules/c++/mt/include/mt/TiedWorkerThread.h
+++ b/modules/c++/mt/include/mt/TiedWorkerThread.h
@@ -1,8 +1,8 @@
 /* =========================================================================
- * This file is part of mt-c++ 
+ * This file is part of mt-c++
  * =========================================================================
- * 
- * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
  *
  * mt-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -14,8 +14,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -37,33 +37,28 @@ template <typename Request_T>
 class TiedWorkerThread : public mt::WorkerThread<Request_T>
 {
 public:
-	TiedWorkerThread(mt::RequestQueue<Request_T>* requestQueue, 
-			 CPUAffinityThreadInitializer* cpuAffinityInit = NULL):
-	    mt::WorkerThread<Request_T>(requestQueue), 
-	    mCPUAffinityInit(cpuAffinityInit){}
+    TiedWorkerThread(
+            mt::RequestQueue<Request_T>* requestQueue,
+            std::auto_ptr<CPUAffinityThreadInitializer> cpuAffinityInit =
+                    std::auto_ptr<CPUAffinityThreadInitializer>(NULL)) :
+        mt::WorkerThread<Request_T>(requestQueue),
+        mCPUAffinityInit(cpuAffinityInit)
+    {
+    }
 
-	virtual ~TiedWorkerThread()
-	{
-	    if (mCPUAffinityInit)
-	    {
-		delete mCPUAffinityInit;
-		mCPUAffinityInit = NULL;
-	    }
-	}
-	
-	virtual void initialize()
-	{
-	    if (mCPUAffinityInit)
-	    {
-		mCPUAffinityInit->initialize();
-	    }
-	}
+    virtual void initialize()
+    {
+        if (mCPUAffinityInit.get())
+        {
+            mCPUAffinityInit->initialize();
+        }
+    }
 
-	virtual void performTask(Request_T& request) = 0;
+    virtual void performTask(Request_T& request) = 0;
 
 private:
-	TiedWorkerThread();
-	CPUAffinityThreadInitializer* mCPUAffinityInit;
+    TiedWorkerThread();
+    std::auto_ptr<CPUAffinityThreadInitializer> mCPUAffinityInit;
 };
 
 }


### PR DESCRIPTION
1. Updated `AbstractTiedThreadPool` and `TiedWorkerThread` to accept `std::auto_ptr<CPUAffinityThreadInitializer>` objects instead of raw pointers.

1. Restored functionality for setting an offset when constructing a `CPUAffinityInitializerLinux` object. Note that this ignores everything about external affinity masking (e.g. taskset) -- as did the original implementation in `LinuxCPUAffinityInitializer`. 