### PR TITLE
Fix writing to StringStream from Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Build artifacts
 
+install/
 target/
 
 # Waf

--- a/modules/python/io/source/generated/coda_io.py
+++ b/modules/python/io/source/generated/coda_io.py
@@ -368,6 +368,11 @@ class StringStream(SeekableBidirectionalStream):
         """str(StringStream self) -> std::string"""
         return _coda_io.StringStream_str(self)
 
+
+    def writeBytes(self, bytes):
+        """writeBytes(StringStream self, PyObject * bytes)"""
+        return _coda_io.StringStream_writeBytes(self, bytes)
+
     __swig_destroy__ = _coda_io.delete_StringStream
     __del__ = lambda self: None
 StringStream_swigregister = _coda_io.StringStream_swigregister

--- a/modules/python/io/source/generated/coda_io_wrap.cxx
+++ b/modules/python/io/source/generated/coda_io_wrap.cxx
@@ -3138,7 +3138,6 @@ namespace swig {
   #include "import/sys.h"
   #include "import/io.h"
   using namespace io;
-  #define SWIG_PYTHON_STRICT_BYTE_CHAR
 
 
 SWIGINTERNINLINE PyObject*
@@ -3623,6 +3622,9 @@ SWIG_From_std_string  (const std::string& s)
   return SWIG_FromCharPtrAndSize(s.data(), s.size());
 }
 
+SWIGINTERN void io_StringStream_writeBytes(io::StringStream *self,PyObject *bytes){
+        self->write(PyBytes_AsString(bytes), PyBytes_Size(bytes));
+    }
 
 SWIGINTERNINLINE PyObject*
   SWIG_From_bool  (bool value)
@@ -5270,6 +5272,30 @@ SWIGINTERN PyObject *_wrap_StringStream_str(PyObject *SWIGUNUSEDPARM(self), PyOb
   arg1 = reinterpret_cast< io::StringStream * >(argp1);
   result = io_StringStream_str(arg1);
   resultobj = SWIG_From_std_string(static_cast< std::string >(result));
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_StringStream_writeBytes(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  io::StringStream *arg1 = (io::StringStream *) 0 ;
+  PyObject *arg2 = (PyObject *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:StringStream_writeBytes",&obj0,&obj1)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_io__StringStream, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "StringStream_writeBytes" "', argument " "1"" of type '" "io::StringStream *""'"); 
+  }
+  arg1 = reinterpret_cast< io::StringStream * >(argp1);
+  arg2 = obj1;
+  io_StringStream_writeBytes(arg1,arg2);
+  resultobj = SWIG_Py_Void();
   return resultobj;
 fail:
   return NULL;
@@ -6997,6 +7023,7 @@ static PyMethodDef SwigMethods[] = {
 		""},
 	 { (char *)"StringStream_reset", _wrap_StringStream_reset, METH_VARARGS, (char *)"StringStream_reset(StringStream self)"},
 	 { (char *)"StringStream_str", _wrap_StringStream_str, METH_VARARGS, (char *)"StringStream_str(StringStream self) -> std::string"},
+	 { (char *)"StringStream_writeBytes", _wrap_StringStream_writeBytes, METH_VARARGS, (char *)"StringStream_writeBytes(StringStream self, PyObject * bytes)"},
 	 { (char *)"delete_StringStream", _wrap_delete_StringStream, METH_VARARGS, (char *)"delete_StringStream(StringStream self)"},
 	 { (char *)"StringStream_swigregister", StringStream_swigregister, METH_VARARGS, NULL},
 	 { (char *)"new_NullInputStream", _wrap_new_NullInputStream, METH_VARARGS, (char *)"new_NullInputStream(sys::SSize_T size) -> NullInputStream"},

--- a/modules/python/io/source/io.i
+++ b/modules/python/io/source/io.i
@@ -30,7 +30,6 @@
   #include "import/sys.h"
   #include "import/io.h"
   using namespace io;
-  #define SWIG_PYTHON_STRICT_BYTE_CHAR
 %}
 
 %include "io/InputStream.h"
@@ -57,3 +56,11 @@
 %include "io/FileInputStreamOS.h"
 %include "io/FileOutputStreamOS.h"
 
+
+%extend io::StringStream
+{
+    void writeBytes(PyObject* bytes)
+    {
+        $self->write(PyBytes_AsString(bytes), PyBytes_Size(bytes));
+    }
+}

--- a/modules/python/io/unittests/test_string_conversions.py
+++ b/modules/python/io/unittests/test_string_conversions.py
@@ -2,12 +2,12 @@
 
 """
  * =========================================================================
- * This file is part of io-c++
+ * This file is part of io-python
  * =========================================================================
  *
  * (C) Copyright 2019, MDA Information Systems LLC
  *
- * io-c++ is free software; you can redistribute it and/or modify
+ * io-python is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.

--- a/modules/python/io/unittests/test_string_conversions.py
+++ b/modules/python/io/unittests/test_string_conversions.py
@@ -2,12 +2,12 @@
 
 """
  * =========================================================================
- * This file is part of logging-c++
+ * This file is part of io-c++
  * =========================================================================
  *
  * (C) Copyright 2019, MDA Information Systems LLC
  *
- * logging-c++ is free software; you can redistribute it and/or modify
+ * io-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation; either version 3 of the License, or
  * (at your option) any later version.

--- a/modules/python/io/unittests/test_string_conversions.py
+++ b/modules/python/io/unittests/test_string_conversions.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+"""
+ * =========================================================================
+ * This file is part of logging-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2019, MDA Information Systems LLC
+ *
+ * logging-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ *
+"""
+
+import unittest
+import sys
+from coda.coda_io import StringStream
+
+
+class TestStringStream(unittest.TestCase):
+    def test_write_string(self):
+        stream = StringStream()
+        stream.write('text')
+        self.assertEqual(stream.str(), 'text')
+
+    def test_write_bytes(self):
+        stream = StringStream()
+        if sys.version_info[0] == 3:
+            bytesInput = bytes('text', 'utf-8')
+        else:
+            # There's no reason to ever want to do this, but just to prove
+            # that nothing breaks...
+            bytesInput = bytes('text')
+        stream.writeBytes(bytesInput)
+        self.assertEqual(stream.str(), 'text')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
About 9 months ago, I added #define SWIG_PYTHON_STRICT_BYTE_CHAR, to io.i, because there was a need to use StringStream with a Python bytes object. Unfortunately, this broke other things with Python3 that I didn't notice until recently.

This PR reverts that change, and adds a writeBytes method to the Python layer.