### PR TITLE
Make ThreadGroup default CPU pinning setting configurable at runtime

### DIFF
--- a/modules/c++/mt/include/mt/ThreadGroup.h
+++ b/modules/c++/mt/include/mt/ThreadGroup.h
@@ -88,12 +88,22 @@ public:
     /*!
      * Checks whether CPU pinning is set (i.e. whether mAffinityInit is NULL)
      *
-     * \returns true if CPU pinning is set, false otherwise
+     * \return true if CPU pinning is set, false otherwise
      */
     bool isPinToCPUEnabled() const;
 
+    /*!
+     * Gets the current default value for CPU pinning
+     *
+     * \return true if CPU pinning is enabled by default, false otherwise
+     */
     static bool getDefaultPinToCPU();
 
+    /*!
+     * Sets the default value for CPU pinning
+     *
+     * \param newDefault the new default value for CPU pinning
+     */
     static void setDefaultPinToCPU(const bool newDefault);
 
 private:

--- a/modules/c++/mt/include/mt/ThreadGroup.h
+++ b/modules/c++/mt/include/mt/ThreadGroup.h
@@ -57,15 +57,11 @@ public:
      * Constructor.
      * \param pinToCPU Optional flag specifying whether CPU pinning
      *                 should occur, using a CPUAffinityInitializer.
-     *                 If MT_FORCE_PINNING is defined, defaults to true
+     *                 If MT_DEFAULT_PINNING is defined, defaults to true
      *                 (enable affinity-based thread pinning).
      *                 Otherwise, defaults to false (no pinning).
      */
-#if defined(MT_FORCE_PINNING)
-    ThreadGroup(bool pinToCPU = true);
-#else
-    ThreadGroup(bool pinToCPU = false);
-#endif
+    ThreadGroup(bool pinToCPU = getDefaultPinToCPU());
 
     /*!
     *  Destructor. Attempts to join all threads.
@@ -89,12 +85,23 @@ public:
      */
     void joinAll();
 
+    static bool getDefaultPinToCPU();
+
+    static void setDefaultPinToCPU(const bool newDefault);
+
 private:
     std::auto_ptr<CPUAffinityInitializer> mAffinityInit;
     size_t mLastJoined;
     std::vector<mem::SharedPtr<sys::Thread> > mThreads;
     std::vector<except::Exception> mExceptions;
     sys::Mutex mMutex;
+
+    /*!
+     * The default setting for pinToCPU, used in the ThreadGroup constructor
+     * Can't set non-const static values in the header, so set at the top of
+     * the implementation
+     */
+    static bool defaultPinToCPU;
 
     /*!
      * Adds an exception to the mExceptions vector

--- a/modules/c++/mt/include/mt/ThreadGroup.h
+++ b/modules/c++/mt/include/mt/ThreadGroup.h
@@ -108,7 +108,7 @@ private:
      * Can't set non-const static values in the header, so set at the top of
      * the implementation
      */
-    static bool defaultPinToCPU;
+    static bool DEFAULT_PIN_TO_CPU;
 
     /*!
      * Adds an exception to the mExceptions vector

--- a/modules/c++/mt/include/mt/ThreadGroup.h
+++ b/modules/c++/mt/include/mt/ThreadGroup.h
@@ -85,6 +85,13 @@ public:
      */
     void joinAll();
 
+    /*!
+     * Checks whether CPU pinning is set (i.e. whether mAffinityInit is NULL)
+     *
+     * \returns true if CPU pinning is set, false otherwise
+     */
+    bool isPinToCPUEnabled() const;
+
     static bool getDefaultPinToCPU();
 
     static void setDefaultPinToCPU(const bool newDefault);

--- a/modules/c++/mt/include/mt/ThreadGroup.h
+++ b/modules/c++/mt/include/mt/ThreadGroup.h
@@ -104,7 +104,7 @@ public:
      *
      * \param newDefault the new default value for CPU pinning
      */
-    static void setDefaultPinToCPU(const bool newDefault);
+    static void setDefaultPinToCPU(bool newDefault);
 
 private:
     std::auto_ptr<CPUAffinityInitializer> mAffinityInit;

--- a/modules/c++/mt/source/ThreadGroup.cpp
+++ b/modules/c++/mt/source/ThreadGroup.cpp
@@ -26,7 +26,6 @@
 
 namespace mt
 {
-
 #if defined(MT_DEFAULT_PINNING)
     bool ThreadGroup::DEFAULT_PIN_TO_CPU = true;
 #else

--- a/modules/c++/mt/source/ThreadGroup.cpp
+++ b/modules/c++/mt/source/ThreadGroup.cpp
@@ -26,6 +26,14 @@
 
 namespace mt
 {
+
+#if defined(MT_DEFAULT_PINNING)
+    bool ThreadGroup::defaultPinToCPU = true;
+#else
+    bool ThreadGroup::defaultPinToCPU = false;
+#endif
+
+
 ThreadGroup::ThreadGroup(bool pinToCPU) :
     mAffinityInit(pinToCPU ? new CPUAffinityInitializer() : NULL),
     mLastJoined(0)
@@ -152,5 +160,15 @@ void ThreadGroup::ThreadGroupRunnable::run()
         mParentThreadGroup.addException(
             except::Exception(Ctxt("Unknown ThreadGroup exception.")));
     }
+}
+
+bool ThreadGroup::getDefaultPinToCPU()
+{
+    return defaultPinToCPU;
+}
+
+void ThreadGroup::setDefaultPinToCPU(const bool newDefault)
+{
+    defaultPinToCPU = newDefault;
 }
 }

--- a/modules/c++/mt/source/ThreadGroup.cpp
+++ b/modules/c++/mt/source/ThreadGroup.cpp
@@ -162,6 +162,11 @@ void ThreadGroup::ThreadGroupRunnable::run()
     }
 }
 
+bool ThreadGroup::isPinToCPUEnabled() const
+{
+    return mAffinityInit.get() != NULL;
+}
+
 bool ThreadGroup::getDefaultPinToCPU()
 {
     return defaultPinToCPU;

--- a/modules/c++/mt/source/ThreadGroup.cpp
+++ b/modules/c++/mt/source/ThreadGroup.cpp
@@ -28,9 +28,9 @@ namespace mt
 {
 
 #if defined(MT_DEFAULT_PINNING)
-    bool ThreadGroup::defaultPinToCPU = true;
+    bool ThreadGroup::DEFAULT_PIN_TO_CPU = true;
 #else
-    bool ThreadGroup::defaultPinToCPU = false;
+    bool ThreadGroup::DEFAULT_PIN_TO_CPU = false;
 #endif
 
 
@@ -169,11 +169,11 @@ bool ThreadGroup::isPinToCPUEnabled() const
 
 bool ThreadGroup::getDefaultPinToCPU()
 {
-    return defaultPinToCPU;
+    return DEFAULT_PIN_TO_CPU;
 }
 
-void ThreadGroup::setDefaultPinToCPU(const bool newDefault)
+void ThreadGroup::setDefaultPinToCPU(bool newDefault)
 {
-    defaultPinToCPU = newDefault;
+    DEFAULT_PIN_TO_CPU = newDefault;
 }
 }

--- a/modules/c++/mt/unittests/ThreadGroupTest.cpp
+++ b/modules/c++/mt/unittests/ThreadGroupTest.cpp
@@ -80,9 +80,36 @@ TEST_CASE(ThreadGroupTest)
     TEST_ASSERT_EQ(numDeleted, 3);
 }
 
+TEST_CASE(PinToCPUTest)
+{
+    bool defaultValue;
+#if defined(MT_DEFAULT_PINNING)
+    defaultValue = true;
+#else
+    defaultValue = false;
+#endif
+    // Check the pinning settings for the default value
+    TEST_ASSERT_EQ(ThreadGroup::getDefaultPinToCPU(), defaultValue);
+    ThreadGroup threads1;
+    TEST_ASSERT_EQ(threads1.isPinToCPUEnabled(), defaultValue);
+
+    // Check the pinning settings when pinning is enabled
+    ThreadGroup::setDefaultPinToCPU(true);
+    TEST_ASSERT_EQ(ThreadGroup::getDefaultPinToCPU(), true);
+    ThreadGroup threads2;
+    TEST_ASSERT_EQ(threads2.isPinToCPUEnabled(), true);
+   
+    // Check the pinning settings when pinning is disabled
+    ThreadGroup::setDefaultPinToCPU(false);
+    TEST_ASSERT_EQ(ThreadGroup::getDefaultPinToCPU(), false);
+    ThreadGroup threads3;
+    TEST_ASSERT_EQ(threads3.isPinToCPUEnabled(), false);
+}
+
 int main(int, char**)
 {
     TEST_CHECK(ThreadGroupTest);
+    TEST_CHECK(PinToCPUTest)
 
     return 0;
 }

--- a/modules/c++/mt/unittests/ThreadGroupTest.cpp
+++ b/modules/c++/mt/unittests/ThreadGroupTest.cpp
@@ -109,7 +109,6 @@ TEST_CASE(PinToCPUTest)
 int main(int, char**)
 {
     TEST_CHECK(ThreadGroupTest);
-    TEST_CHECK(PinToCPUTest)
-
+    TEST_CHECK(PinToCPUTest);
     return 0;
 }

--- a/modules/c++/mt/wscript
+++ b/modules/c++/mt/wscript
@@ -11,7 +11,7 @@ def options(opt):
                    action='store_true',
                    dest='mt_default_cpu_pinning',
                    default=False,
-                   help='Default to affinity-based CPU pinning in MT')
+                   help='Use affinity-based CPU pinning by default in MT')
 
 def configure(conf):
     from build import writeConfig

--- a/modules/c++/mt/wscript
+++ b/modules/c++/mt/wscript
@@ -7,19 +7,19 @@ TEST_DEPS       = 'cli'
 distclean = lambda p: None
 
 def options(opt):
-    opt.add_option('--force-cpu-pinning',
+    opt.add_option('--default-cpu-pinning',
                    action='store_true',
-                   dest='mt_force_cpu_pinning',
+                   dest='mt_default_cpu_pinning',
                    default=False,
-                   help='Force affinity-based CPU pinning in MT')
+                   help='Default to affinity-based CPU pinning in MT')
 
 def configure(conf):
     from build import writeConfig
     from waflib import Options
 
     def pinning_callback(conf):
-        if Options.options.mt_force_cpu_pinning:
-            conf.define('MT_FORCE_PINNING', 1)
+        if Options.options.mt_default_cpu_pinning:
+            conf.define('MT_DEFAULT_PINNING', 1)
     writeConfig(conf, pinning_callback, NAME)
 
 def build(bld):


### PR DESCRIPTION
* Added a static variable to ThreadGroup to contain the default pinning option (along with getter and setter)
* Added a method to ThreadGroup to get the current pinning option (inferred from whether `mAffinityInit` is set or a null pointer)
* Add unit tests to validate the new behavior
* Changed `mt_force_cpu_pinning` to `mt_default_cpu_pinning` in the mt wscript to reflect the change in behavior, likewise change the internal define from `MT_FORCE_PINNING` to `MT_DEFAULT_PINNING`