### PR TITLE
Fail configuration if trying to use too-old SWIG

### DIFF
--- a/build/swig.py
+++ b/build/swig.py
@@ -195,7 +195,7 @@ def options(opt):
     opt.add_option('--disable-swig', action='store_false', dest='swig',
                    help='Disable swig')
     opt.add_option('--swig-version', action='store', dest='swigver',
-                   default=None, help='Specify the minimum swig version')
+                   default='3.0.0', help='Specify the minimum swig version')
     opt.add_option('--require-swig', action='store_true', dest='require_swig',
                    help='Require swig (configure option)', default=False)
 

--- a/wscript
+++ b/wscript
@@ -18,6 +18,7 @@ def options(opt):
     opt.recurse(DIRS)
 
 def configure(conf):
+    conf.options.swigver = '3.0.12'
     conf.load(TOOLS, tooldir='./build/')
     conf.recurse(DIRS)
 


### PR DESCRIPTION
Sometimes people try to build with SWIG with some ancient 1.x version, and the error messages aren't great when it inevitably fails. 

I just set it by major version, so if you want to use, say, 3.0.7 for your project you can, but it'll catch a setup that just doesn't make sense. 

Then I added at the top level-wscript that only gets called if you're building CODA-OSS itself, a check for the current version. Presumably if you're building with SWIG, that means you plan to change the Python bindings and check it in, so you should definitely be using the right version for that. 