### PR TITLE
Add 'touches' member function to Range

### DIFF
--- a/modules/c++/types/include/types/Range.h
+++ b/modules/c++/types/include/types/Range.h
@@ -124,7 +124,7 @@ struct Range
     }
 
     /*!
-     * Determine if a range touches our range. Touching ranges do not
+     * Determine if a given range touches our range. Touching ranges do not
      * overlap, but can be placed next to one another (irrespective of order)
      * with no missing values in between.
      *

--- a/modules/c++/types/include/types/Range.h
+++ b/modules/c++/types/include/types/Range.h
@@ -124,6 +124,21 @@ struct Range
     }
 
     /*!
+     * Determine if a range touches our range. Touching ranges do not
+     * overlap, but can be placed next to one another (irrespective of order)
+     * with no missing values in between.
+     *
+     * \param rhs Range to compare with
+     *
+     * \return True if the ranges touch, false otherwise
+     */
+    bool touches(const types::Range& rhs) const
+    {
+        return (mStartElement == rhs.endElement()) ||
+               (rhs.mStartElement == endElement());
+    }
+
+    /*!
      * \param startElementToTest The start element
      * \param numElementsToTest The total number of elements to check
      *

--- a/modules/c++/types/unittests/test_range.cpp
+++ b/modules/c++/types/unittests/test_range.cpp
@@ -53,10 +53,38 @@ TEST_CASE(TestGetNumSharedElements)
     // Ranges are the same - should share [100, 150)
     TEST_ASSERT_EQ(range.getNumSharedElements(100, 50), 50);
 }
+
+TEST_CASE(TestTouches)
+{
+    // Ranges do not overlap or touch -- touches(...) returns false
+    {
+        const types::Range A(5, 4);  // [5, 8]
+        const types::Range B(12, 1); // [12, 12]
+        TEST_ASSERT_FALSE(A.touches(B));
+        TEST_ASSERT_FALSE(B.touches(A));
+    }
+
+    // Ranges overlap -- touches(...) returns false
+    {
+        const types::Range A(5, 4); // [5, 8]
+        const types::Range B(8, 1); // [8, 8]
+        TEST_ASSERT_FALSE(A.touches(B));
+        TEST_ASSERT_FALSE(B.touches(A));
+    }
+
+    // Ranges touch -- touches(...) returns true
+    {
+        const types::Range A(5, 4); // [5, 8]
+        const types::Range B(9, 1); // [9, 9]
+        TEST_ASSERT_TRUE(A.touches(B));
+        TEST_ASSERT_TRUE(B.touches(A));
+    }
+}
 }
 
 int main(int /*argc*/, char** /*argv*/)
 {
     TEST_CHECK(TestGetNumSharedElements);
+    TEST_CHECK(TestTouches);
     return 0;
 }


### PR DESCRIPTION
Determining if two disjoint ranges can be placed next to one another with no gap between them.

