### PR TITLE
Updates to Range::touches for empty ranges

### DIFF
--- a/modules/c++/types/include/types/Range.h
+++ b/modules/c++/types/include/types/Range.h
@@ -128,12 +128,19 @@ struct Range
      * overlap, but can be placed next to one another (irrespective of order)
      * with no missing values in between.
      *
+     * If either of the ranges is empty, touching is defined as always false.
+     *
      * \param rhs Range to compare with
      *
      * \return True if the ranges touch, false otherwise
      */
     bool touches(const types::Range& rhs) const
     {
+        if (empty() || rhs.empty())
+        {
+            return false;
+        }
+
         return (mStartElement == rhs.endElement()) ||
                (rhs.mStartElement == endElement());
     }

--- a/modules/c++/types/unittests/test_range.cpp
+++ b/modules/c++/types/unittests/test_range.cpp
@@ -79,6 +79,22 @@ TEST_CASE(TestTouches)
         TEST_ASSERT_TRUE(A.touches(B));
         TEST_ASSERT_TRUE(B.touches(A));
     }
+
+    // One of the ranges is empty -- touches(...) returns false
+    {
+        const types::Range A(10, 0);  // [10, 0)
+        const types::Range B(10, 10); // [10, 20)
+        TEST_ASSERT_FALSE(A.touches(B));
+        TEST_ASSERT_FALSE(B.touches(A));
+    }
+
+    // Both of the ranges are empty -- touches(...) returns false
+    {
+        const types::Range A(10, 0);  // [10, 0)
+        const types::Range B(10, 0); // [10, 20)
+        TEST_ASSERT_FALSE(A.touches(B));
+        TEST_ASSERT_FALSE(B.touches(A));
+    }
 }
 }
 


### PR DESCRIPTION
Define touching as false if either of the ranges are empty.