### PR TITLE
Add explicit Python version check

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1199,6 +1199,9 @@ def configure(self):
     if self.env['DETECTED_BUILD_PY']:
         return
 
+    if sys.version_info < (2, 7, 0):
+        self.fatal('build.py requires at least Python 2.7')
+
     sys_platform = getPlatform(default=Options.platform)
     winRegex = r'win32'
 


### PR DESCRIPTION
Explicit check to make it less confusing if you try to configure with the wrong version.