### PR TITLE
Change 'raise StopIteration' in GlobDirectoryWalker to 'return'

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -649,7 +649,7 @@ class GlobDirectoryWalker:
             except IndexError:
                 # pop next directory from stack
                 if len(self.stack) == 0:
-                    raise StopIteration
+                    return
                 self.directory = self.stack.pop()
                 if isdir(self.directory):
                     self.files = os.listdir(self.directory)


### PR DESCRIPTION
Attempting to build with Python 3.7.2 on Linux results in mishandled exceptions inside `GlobDirectoryWalker.next()` (see trace below). 

Based on PEP479, fix is to simply `return` instead of using `raise StopIteration`. One could also catch `StopIteration` inside of `__iter__` and `return None`, but this appears cleaner. May be overlooking something.

Tested with Python 2.7.12 and 3.7.2.

```
Traceback (most recent call last):
  File "/xxx/code/coda-oss/build/build.py", line 647, in next
    file = self.files[self.index]
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/xxx/code/coda-oss/build/build.py", line 652, in next
    raise StopIteration
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Scripting.py", line 97, in waf_entry_point
    run_commands()
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Scripting.py", line 153, in run_commands
    ctx=run_command(cmd_name)
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Scripting.py", line 146, in run_command
    ctx.execute()
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Configure.py", line 128, in execute
    super(ConfigurationContext,self).execute()
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Context.py", line 84, in execute
    self.recurse([os.path.dirname(g_module.root_path)])
  File "/xxx/code/coda-oss/build/build.py", line 75, in recurse
    super(CPPContext, self).recurse(dirsWithWscripts)
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Context.py", line 125, in recurse
    user_function(self)
  File "/xxx/code/coda-oss/wscript", line 22, in configure
    conf.load(TOOLS, tooldir='./build/')
  File "/xxx/code/coda-oss/build/.waf3-1.7.14-872d6f34b84e4daf914a1e2b7fe333fd/waflib/Configure.py", line 193, in load
    if type(func)is type(Utils.readf):func(self)
  File "/xxx/code/coda-oss/build/build.py", line 1205, in configure
    sys_platform = getPlatform(default=Options.platform)
  File "/xxx/code/coda-oss/build/build.py", line 682, in getPlatform
    for loc in locs:
RuntimeError: generator raised StopIteration
```