### PR TITLE
Fix incorrect checking in unittest

### DIFF
--- a/modules/c++/mem/source/ScratchMemory.cpp
+++ b/modules/c++/mem/source/ScratchMemory.cpp
@@ -60,6 +60,10 @@ ScratchMemory::Segment::Segment(size_t numBytes,
 void ScratchMemory::release(const std::string& key)
 {
     std::map<std::string, Segment>::const_iterator iterSeg = mSegments.find(key);
+    if (iterSeg == mSegments.end())
+    {
+        throw except::Exception(Ctxt("Key " + key + " does not exist"));
+    }
     mReleasedKeys.insert(key);
 
     if (mKeyOrder.back() == key)

--- a/modules/c++/mem/source/ScratchMemory.cpp
+++ b/modules/c++/mem/source/ScratchMemory.cpp
@@ -71,12 +71,12 @@ void ScratchMemory::release(const std::string& key)
     {
         const Segment& segment = iterSeg->second;
 
+        mKeyOrder.push_back(key);
         std::vector<std::string>::iterator keyIter = std::find(mKeyOrder.begin(),
                                                                mKeyOrder.end(),
                                                                key);
         std::vector<std::string>::iterator nextKeyIter = mKeyOrder.erase(keyIter);
         const std::string nextKey = *nextKeyIter;
-        mKeyOrder.push_back(key);
 
 
         //  The next two if blocks handle the edge case in which there are two

--- a/modules/c++/mem/source/ScratchMemory.cpp
+++ b/modules/c++/mem/source/ScratchMemory.cpp
@@ -75,9 +75,9 @@ void ScratchMemory::release(const std::string& key)
                                                                mKeyOrder.end(),
                                                                key);
         std::vector<std::string>::iterator nextKeyIter = mKeyOrder.erase(keyIter);
+        const std::string nextKey = *nextKeyIter;
         mKeyOrder.push_back(key);
 
-        const std::string nextKey = *nextKeyIter;
 
         //  The next two if blocks handle the edge case in which there are two
         //  segments at the same offset: one that has been released
@@ -204,14 +204,13 @@ void ScratchMemory::setup(const BufferView<sys::ubyte>& scratchBuffer)
         mBuffer = scratchBuffer;
     }
 
-    size_t currentOffset = 0;
     for (std::map<std::string, Segment>::iterator iterSeg = mSegments.begin();
          iterSeg != mSegments.end();
          ++iterSeg)
     {
         Segment& segment = iterSeg->second;
         segment.buffers.resize(segment.numBuffers);
-        currentOffset = segment.offset;
+        size_t currentOffset = segment.offset;
         for (size_t i = 0; i < segment.numBuffers; ++i)
         {
             segment.buffers[i] = mBuffer.data + currentOffset;

--- a/modules/c++/mem/unittests/test_scratch_memory.cpp
+++ b/modules/c++/mem/unittests/test_scratch_memory.cpp
@@ -25,6 +25,7 @@
 #include <mem/BufferView.h>
 #include <sys/Conf.h>
 #include <cstdlib>
+#include <algorithm>
 #include <vector>
 #include <set>
 #include "TestCase.h"

--- a/modules/c++/mem/unittests/test_scratch_memory.cpp
+++ b/modules/c++/mem/unittests/test_scratch_memory.cpp
@@ -187,59 +187,59 @@ TEST_CASE(testReleaseInteriorBuffers)
     mem::BufferView<unsigned char> bufViewE = scratch.getBufferView<sys::ubyte>("e");
     mem::BufferView<unsigned char> bufViewF = scratch.getBufferView<sys::ubyte>("f");
 
-    for (size_t i = 0; i < bufViewA.size; ++i) 
+    for (size_t i = 0; i < bufViewA.size; ++i)
     {
         bufViewA.data[i] = 'a';
     }
-    for (size_t i = 0; i < bufViewB.size; ++i) 
+    for (size_t i = 0; i < bufViewB.size; ++i)
     {
         bufViewB.data[i] = 'b';
     }
-    for (size_t i = 0; i < bufViewC.size; ++i) 
+    for (size_t i = 0; i < bufViewC.size; ++i)
     {
         bufViewC.data[i] = 'c';
     }
-    for (size_t i = 0; i < bufViewB.size; ++i) 
+    for (size_t i = 0; i < bufViewB.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewB.data[i], 'b');
     }
-    for (size_t i = 0; i < bufViewD.size; ++i) 
+    for (size_t i = 0; i < bufViewD.size; ++i)
     {
         bufViewD.data[i] = 'd';
     }
-    for (size_t i = 0; i < bufViewA.size; ++i) 
+    for (size_t i = 0; i < bufViewA.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewA.data[i], 'a');
     }
-    for (size_t i = 0; i < bufViewC.size; ++i) 
+    for (size_t i = 0; i < bufViewC.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewC.data[i], 'c');
     }
-    for (size_t i = 0; i < bufViewD.size; ++i) 
+    for (size_t i = 0; i < bufViewD.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewD.data[i], 'd');
     }
-    for (size_t i = 0; i < bufViewE.size; ++i) 
+    for (size_t i = 0; i < bufViewE.size; ++i)
     {
         bufViewE.data[i] = 'e';
     }
-    for (size_t i = 0; i < bufViewF.size; ++i) 
+    for (size_t i = 0; i < bufViewF.size; ++i)
     {
         bufViewF.data[i] = 'f';
     }
-    for (size_t i = 0; i < bufViewC.size; ++i) 
+    for (size_t i = 0; i < bufViewC.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewC.data[i], 'c');
     }
-    for (size_t i = 0; i < bufViewD.size; ++i) 
+    for (size_t i = 0; i < bufViewD.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewD.data[i], 'd');
     }
-    for (size_t i = 0; i < bufViewE.size; ++i) 
+    for (size_t i = 0; i < bufViewE.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewE.data[i], 'e');
     }
-    for (size_t i = 0; i < bufViewF.size; ++i) 
+    for (size_t i = 0; i < bufViewF.size; ++i)
     {
         TEST_ASSERT_EQ(bufViewF.data[i], 'f');
     }
@@ -437,7 +437,8 @@ TEST_CASE(testGenerateBuffersForRelease)
 {
     srand((unsigned)time(0));
 
-    for (unsigned int run = 0; run < 50; ++run) {
+    for (unsigned int run = 0; run < 50; ++run)
+    {
         mem::ScratchMemory scratch;
         std::vector<Operation> operations;
         std::vector<unsigned char> notReleased;
@@ -481,7 +482,8 @@ TEST_CASE(testGenerateBuffersForRelease)
             Operation currentOp = operations.at(jj);
             std::string key = std::string(1, currentOp.name);
 
-            if (currentOp.op == "put")
+            if (currentOp.op == "put" &&
+                    std::find(notReleased.begin(), notReleased.end(), currentOp.name) != notReleased.end())
             {
                 mem::BufferView<unsigned char> bufView = scratch.getBufferView<sys::ubyte>(key);
                 for (size_t i = 0; i < bufView.size; ++i)


### PR DESCRIPTION
This test was intermittently failing. Writing into erased segments was causing it to overwrite the expected data.

Is this correct? I'm not sure of the intended usage of this class, so possibly the original behavior was the desired operation and should have passed. 

The changes in ScratchBuffer.cpp were problems flagged by cppcheck while debugging.