### PR TITLE
8 bit integer to string

### DIFF
--- a/modules/c++/str/include/str/Convert.h
+++ b/modules/c++/str/include/str/Convert.h
@@ -1,7 +1,7 @@
 /* =========================================================================
- * This file is part of str-c++ 
+ * This file is part of str-c++
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2014, MDA Information Systems LLC
  *
  * str-c++ is free software; you can redistribute it and/or modify
@@ -14,8 +14,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -49,6 +49,10 @@ template<typename T> std::string toString(const T& value)
     buf << std::boolalpha << value;
     return buf.str();
 }
+
+template<> std::string toString(const uint8_t& value);
+
+template<> std::string toString(const int8_t& value);
 
 template<typename T> std::string toString(const T& real, const T& imag)
 {
@@ -103,7 +107,7 @@ template<typename T> T toType(const std::string& s, int base)
     char* end;
     errno = 0;
     const char* str = s.c_str();
-    
+
     T res;
     bool overflow = false;
     if (std::numeric_limits<T>::is_signed)
@@ -126,7 +130,7 @@ template<typename T> T toType(const std::string& s, int base)
         }
         res = static_cast<T>(longRes);
     }
-    
+
     if (overflow || errno == ERANGE)
         throw except::BadCastException(except::Context(__FILE__, __LINE__,
             std::string(""), std::string(""),
@@ -138,7 +142,7 @@ template<typename T> T toType(const std::string& s, int base)
             std::string(""), std::string(""),
             std::string("Conversion failed: '")
                 + s + std::string("' -> ") + typeid(T).name()));
-    
+
     return res;
 }
 

--- a/modules/c++/str/source/Convert.cpp
+++ b/modules/c++/str/source/Convert.cpp
@@ -27,6 +27,17 @@ template<> std::string str::toType<std::string>(const std::string& s)
 {
     return s;
 }
+
+template<> std::string str::toString(const uint8_t& value)
+{
+    return str::toString(static_cast<unsigned int>(value));
+}
+
+template<> std::string str::toString(const int8_t& value)
+{
+    return str::toString(static_cast<int>(value));
+}
+
 template<> bool str::toType<bool>(const std::string& s)
 {
     std::string ss = s;

--- a/modules/c++/str/unittests/test_base_convert.cpp
+++ b/modules/c++/str/unittests/test_base_convert.cpp
@@ -42,8 +42,23 @@ TEST_CASE(testBadConvert)
     TEST_EXCEPTION(str::toType<short>("0xFFFFF", 16));
 }
 
+TEST_CASE(testEightBitIntToString)
+{
+    TEST_ASSERT_EQ(str::toString<uint8_t>(1), "1");
+    TEST_ASSERT_EQ(str::toString<int8_t>(2), "2");
+    TEST_ASSERT_EQ(str::toString<int8_t>(-2), "-2");
+}
+
+TEST_CASE(testCharToString)
+{
+    TEST_ASSERT_EQ(str::toString<char>('a'), "a");
+    TEST_ASSERT_EQ(str::toString<char>(65), "A");
+}
+
 int main(int, char**)
 {
     TEST_CHECK(testConvert);
     TEST_CHECK(testBadConvert);
+    TEST_CHECK(testEightBitIntToString);
+    TEST_CHECK(testCharToString);
 }

--- a/modules/c++/sys/source/LocalDateTime.cpp
+++ b/modules/c++/sys/source/LocalDateTime.cpp
@@ -47,7 +47,7 @@ void LocalDateTime::toMillis()
     t.tm_year = mYear - 1900;
     t.tm_mon = mMonth - 1;
     t.tm_mday = mDayOfMonth;
-    t.tm_wday = mDayOfWeek + 1;
+    t.tm_wday = mDayOfWeek - 1;
     t.tm_yday = mDayOfYear - 1;
     t.tm_hour = mHour;
     t.tm_min = mMinute;

--- a/modules/c++/sys/source/UTCDateTime.cpp
+++ b/modules/c++/sys/source/UTCDateTime.cpp
@@ -123,7 +123,12 @@ void UTCDateTime::toMillis()
     mDayOfYear = numDaysThisYear + 1;
 
     /* January 1, 1970 was a Thursday (5) */
-    mDayOfWeek = (numDaysSinceEpoch + 5) % 7;
+    mDayOfWeek = ((numDaysSinceEpoch + 5) % 7);
+
+    if (mDayOfWeek == 0)
+    {
+        mDayOfWeek = 7;
+    }
 }
 
 void UTCDateTime::getTime(time_t numSecondsSinceEpoch, tm& t) const


### PR DESCRIPTION
Two bugs:

 - Calling `toString<uint8_t>` shouldn't try to interpret this as ASCII. This was causing garbage and segfaults downstream

- A couple issues with the dayOfWeek value in sys::DateTime. It should always be in [1,7] for us. `struct tm` has the value in [0,6], so we want to subtract 1 when converting to that. 

FYI @dstarinshak 