### PR TITLE
Add a .clang-format file based on GitLab style guide

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,10 @@
 BasedOnStyle: Google
 AccessModifierOffset: '0'
 AlignAfterOpenBracket: Align
-# AlignConsecutiveAssignments: 'false'
-# AlignConsecutiveDeclarations: 'false'
-# AlignOperands: 'false'
-# AlignTrailingComments: 'false'
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignOperands: 'false'
+AlignTrailingComments: 'false'
 AllowShortBlocksOnASingleLine: 'false'
 AllowShortCaseLabelsOnASingleLine: 'false'
 AllowShortIfStatementsOnASingleLine: 'false'
@@ -17,11 +17,12 @@ BinPackArguments: 'false'
 BinPackParameters: 'false'
 BreakConstructorInitializers: AfterColon
 BreakBeforeBraces: Allman
+PenaltyBreakBeforeFirstCallParameter: '100'
 ColumnLimit: '80'
 ContinuationIndentWidth: '8'
-ConstructorInitializerAllOnOneLineOrOnePerline: 'true'
 DerivePointerAlignment: 'false'
 FixNamespaceComments: 'false'
+IndentCaseLabels: 'false'
 IndentWidth: '4'
 Language: Cpp
 PointerAlignment: Left

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,30 @@
+BasedOnStyle: Google
+AccessModifierOffset: '0'
+AlignAfterOpenBracket: Align
+# AlignConsecutiveAssignments: 'false'
+# AlignConsecutiveDeclarations: 'false'
+# AlignOperands: 'false'
+# AlignTrailingComments: 'false'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'false'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakConstructorInitializers: AfterColon
+BreakBeforeBraces: Allman
+ColumnLimit: '80'
+ContinuationIndentWidth: '8'
+ConstructorInitializerAllOnOneLineOrOnePerline: 'true'
+DerivePointerAlignment: 'false'
+FixNamespaceComments: 'false'
+IndentWidth: '4'
+Language: Cpp
+PointerAlignment: Left
+SpacesInAngles: 'false'
+Standard: Cpp11
+UseTab: Never


### PR DESCRIPTION
This style file produces an empty/minimal diff on most files I ran it on. Most of the changes it makes/suggests are for issues that would have been a violation anyway. 

My intention is require this for "my" projects (SIX, NITRO). 

For wider CODA, I worry that this will be rather useless without widespread adoption, and I'm not sure how to make that happen.