### PR TITLE
Place default short_paths location within user directory

### DIFF
--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -9,6 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
     - name: configure
       run: |
         ls env:
@@ -35,6 +39,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
     - name: configure
       run: |
         env

--- a/conanfile.py
+++ b/conanfile.py
@@ -10,6 +10,8 @@ https://docs.conan.io/en/latest/reference/conanfile/attributes.html#short-paths
 """
 
 from conans import ConanFile, CMake, tools
+import os
+import sys
 
 class CodaOssConan(ConanFile):
     name = "coda-oss"
@@ -42,9 +44,13 @@ class CodaOssConan(ConanFile):
     license = "GNU LESSER GENERAL PUBLIC LICENSE Version 3"
 
     # default to short_paths mode (Windows only)
-    # check .conan/conan.conf in your home directory to make sure the setting
-    # user_home_short points to a writable location
     short_paths = True
+    # default the short_paths home to ~/.conan_short
+    # this may be overridden by setting the environment variable
+    # CONAN_USER_HOME_SHORT or setting user_home_short in ~/.conan/conan.conf
+    if sys.platform.startswith('win32') and os.getenv("CONAN_USER_HOME_SHORT") is None:
+        os.environ["CONAN_USER_HOME_SHORT"] = os.path.join(
+            os.path.expanduser("~"), ".conan_short")
 
     def set_version(self):
         git = tools.Git(folder=self.recipe_folder)


### PR DESCRIPTION
closes #355 

This changes the default location for Conan builds on Windows, to work around path length limitations in the Visual Studio compiler and, in some cases, Windows.

Normally this is configured by the `user_home_short` setting in ~/.conan/conan.conf or the environment variable `CONAN_USER_HOME_SHORT`. If these are not selected, it defaults to `C:\.conan` which may require admin privileges to create.

There is no documented way to change this default within the recipe, but this solution seems to work well. This change configures the Conan recipe to detect whether `CONAN_USER_HOME_SHORT` is set and if not, set it to `~/.conan_short`. This is Conan's default for Cygwin builds.

This also avoids overriding `conan.conf`, since a value configured there is just copied to the environment variable `CONAN_USER_HOME_SHORT` before the recipe is loaded, and the recipe will see that it is already set.
