### PR TITLE
Test build should be run with the same options as coda-oss

### DIFF
--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,6 +7,9 @@ class CodaOssTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+        for name, val in self.options['coda-oss'].items():
+            if name.isupper() and val is not None:
+                cmake.definitions[name] = val
         cmake.configure()
         cmake.build()
 


### PR DESCRIPTION
When building coda-oss with ENABLE_PYTHON='False', test_package fails complaining that it can't find Python. Options used for compiling coda-oss should also be used for test_package. 