### PR TITLE
add an optional parameter to io::OutputStream::write() for UTF-8 encoding

### DIFF
--- a/modules/c++/io/include/io/BidirectionalStream.h
+++ b/modules/c++/io/include/io/BidirectionalStream.h
@@ -40,6 +40,8 @@ namespace io
  */
 struct BidirectionalStream: public InputStream, public OutputStream
 {
+    BidirectionalStream(const TextEncoding* pEncoding = nullptr) : OutputStream(pEncoding) { }
+    virtual ~BidirectionalStream() { }
 };
 
 }

--- a/modules/c++/io/include/io/OutputStream.h
+++ b/modules/c++/io/include/io/OutputStream.h
@@ -22,6 +22,7 @@
 
 #ifndef __IO_OUTPUT_STREAM_H__
 #define __IO_OUTPUT_STREAM_H__
+#pragma once
 
 #include "sys/Dbg.h"
 #include "sys/Conf.h"
@@ -35,6 +36,22 @@
 
 namespace io
 {
+    /*!
+     * \class TextEncoding
+     * \brief Specify how to encode text for various write() routines
+     *
+     */
+    enum class TextEncoding
+    {
+        Utf8
+        // There could be more here, but there's no need for them right now.
+        /*
+        , Iso8859_1
+       , Windows_1252 = Iso8859_1 // close enough for our purposes?
+        , Ascii
+        */
+    };
+
 /*!
  * \class OutputStream
  * \brief Class for handling output streams
@@ -69,19 +86,24 @@ public:
      *  Write a string
      *  \param str
      */
-    void write(const std::string& str)
+    void write(const std::string& str, const TextEncoding* pEncoding = nullptr);
+    void write(const std::string& str, TextEncoding encoding)
     {
-        write((sys::byte*) str.c_str(), (sys::Size_T) str.length());
+        write(str, &encoding);
     }
 
     /*!
      *  Write a string with a newline at the end
      *  \param str
      */
-    void writeln(const std::string& str)
+    void writeln(const std::string& str, const TextEncoding* pEncoding = nullptr)
     {
-        write(str);
+        write(str, pEncoding);
         write('\n');
+    }
+    void writeln(const std::string& str, TextEncoding encoding)
+    {
+        writeln(str, &encoding);
     }
 
     /*!

--- a/modules/c++/io/include/io/OutputStream.h
+++ b/modules/c++/io/include/io/OutputStream.h
@@ -77,8 +77,11 @@ protected:
     }
 
 public:
-    OutputStream() = default;
-
+public:
+    //! Default constructor
+    OutputStream()
+    {
+    }
     //! Destructor
     virtual ~OutputStream()
     {

--- a/modules/c++/io/include/io/OutputStream.h
+++ b/modules/c++/io/include/io/OutputStream.h
@@ -24,6 +24,9 @@
 #define __IO_OUTPUT_STREAM_H__
 #pragma once
 
+#include <string>
+#include <memory>
+
 #include "sys/Dbg.h"
 #include "sys/Conf.h"
 
@@ -63,11 +66,19 @@ namespace io
 
 class OutputStream
 {
-public:
-    //! Default constructor
-    OutputStream()
+    std::shared_ptr<const TextEncoding> pEncoding;  // i.e., std::optional<>
+protected:
+    OutputStream(const TextEncoding* pEncoding) 
     {
+        if (pEncoding != nullptr)
+        {
+            this->pEncoding = std::make_shared<const TextEncoding>(*pEncoding);
+        }
     }
+
+public:
+    OutputStream() = default;
+
     //! Destructor
     virtual ~OutputStream()
     {
@@ -86,24 +97,16 @@ public:
      *  Write a string
      *  \param str
      */
-    void write(const std::string& str, const TextEncoding* pEncoding = nullptr);
-    void write(const std::string& str, TextEncoding encoding)
-    {
-        write(str, &encoding);
-    }
+    void write(const std::string& str);
 
     /*!
      *  Write a string with a newline at the end
      *  \param str
      */
-    void writeln(const std::string& str, const TextEncoding* pEncoding = nullptr)
+    void writeln(const std::string& str)
     {
-        write(str, pEncoding);
+        write(str);
         write('\n');
-    }
-    void writeln(const std::string& str, TextEncoding encoding)
-    {
-        writeln(str, &encoding);
     }
 
     /*!

--- a/modules/c++/io/include/io/SeekableStreams.h
+++ b/modules/c++/io/include/io/SeekableStreams.h
@@ -66,7 +66,7 @@ class SeekableBidirectionalStream :
             public BidirectionalStream, public Seekable
 {
 public:
-    SeekableBidirectionalStream()
+    SeekableBidirectionalStream(const TextEncoding* pEncoding = nullptr) : BidirectionalStream(pEncoding)
     {}
     virtual ~SeekableBidirectionalStream()
     {}

--- a/modules/c++/io/include/io/StringStream.h
+++ b/modules/c++/io/include/io/StringStream.h
@@ -49,7 +49,7 @@ class StringStream : public SeekableBidirectionalStream
 public:
 
     //! Default constructor
-    StringStream() : SeekableBidirectionalStream(pEncoding),
+    StringStream(const io::TextEncoding* pEncoding = nullptr) : SeekableBidirectionalStream(pEncoding),
         mData(std::stringstream::in | std::stringstream::out
                 | std::stringstream::binary)
     {

--- a/modules/c++/io/include/io/StringStream.h
+++ b/modules/c++/io/include/io/StringStream.h
@@ -47,13 +47,11 @@ namespace io
 class StringStream : public SeekableBidirectionalStream
 {
 public:
-
     //! Default constructor
-    StringStream() :
-        mData(std::stringstream::in | std::stringstream::out
-                | std::stringstream::binary)
-    {
-    }
+    StringStream(const TextEncoding* pEncoding = nullptr) : SeekableBidirectionalStream(pEncoding),
+        mData(std::stringstream::in | std::stringstream::out | std::stringstream::binary) { }
+
+    StringStream(TextEncoding encoding) : StringStream(&encoding) { }
 
     /*!
      *  Returns the stringstream associated with this StringStream

--- a/modules/c++/io/include/io/StringStream.h
+++ b/modules/c++/io/include/io/StringStream.h
@@ -47,9 +47,13 @@ namespace io
 class StringStream : public SeekableBidirectionalStream
 {
 public:
+
     //! Default constructor
-    StringStream(const TextEncoding* pEncoding = nullptr) : SeekableBidirectionalStream(pEncoding),
-        mData(std::stringstream::in | std::stringstream::out | std::stringstream::binary) { }
+    StringStream() : SeekableBidirectionalStream(pEncoding),
+        mData(std::stringstream::in | std::stringstream::out
+                | std::stringstream::binary)
+    {
+    }
 
     StringStream(TextEncoding encoding) : StringStream(&encoding) { }
 

--- a/modules/c++/io/source/OutputStream.cpp
+++ b/modules/c++/io/source/OutputStream.cpp
@@ -1,0 +1,84 @@
+/* =========================================================================
+ * This file is part of io-c++ 
+ * =========================================================================
+ * 
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this program; If not, 
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <stdexcept>
+
+#include <sys/Conf.h>
+#include <except/Exception.h>
+#include <io/OutputStream.h>
+
+// Convert a single ISO8859-1 character to UTF-8
+// // https://en.wikipedia.org/wiki/ISO/IEC_8859-1
+static std::string to_utf8_(std::string::value_type ch)
+{
+    if ((ch >= '\x00') && (ch <= '\x7f'))  // ASCII
+    {
+        return std::string{ch};
+    }
+
+    if ((ch >= '\xC0' /*À*/) && (ch <= '\xFF' /*y*/))  // ISO8859-1 letters
+    {
+        std::string retval{'\xC3'};
+        ch -= 0x40;  // 0xC0 -> 0x80
+        retval.push_back(ch);
+        return retval;
+    }
+    
+    return std::string{ch}; // ???
+}
+
+static std::string to_utf8(const std::string& str)
+{
+    std::string retval;
+    // Assume the input string is ISO8859-1 (western European) and convert to UTF-8
+    for (const auto& ch : str)
+    {
+        retval += to_utf8_(ch);
+    }
+    return retval;
+}
+
+static std::string convert(const std::string& str, io::TextEncoding encoding)
+{
+    if (encoding == io::TextEncoding::Utf8)
+    {
+        return to_utf8(str);    
+    }
+
+    throw std::invalid_argument("Unexpected 'encoding' value.");
+}
+
+void io::OutputStream::write(const std::string& str_, const io::TextEncoding* pEncoding /*= nullptr*/)
+{
+    const std::string* pStr = &str_;
+    std::string str; // keep any result from convert() in-scope so we use its address
+    if (pEncoding != nullptr)
+    {
+        str = convert(str_, *pEncoding);
+        pStr = &str; // stays in-scope, above
+    }
+     
+    auto buffer = reinterpret_cast<const sys::byte*>(pStr->c_str());
+    const sys::Size_T len{pStr->length()};
+    write(buffer, len);
+}

--- a/modules/c++/io/source/OutputStream.cpp
+++ b/modules/c++/io/source/OutputStream.cpp
@@ -20,65 +20,39 @@
  *
  */
 
+#include "io/OutputStream.h"
+
 #include <string>
 #include <stdexcept>
 
-#include <sys/Conf.h>
-#include <except/Exception.h>
-#include <io/OutputStream.h>
+#include <sys/String.h>
 
-// Convert a single ISO8859-1 character to UTF-8
-// // https://en.wikipedia.org/wiki/ISO/IEC_8859-1
-static std::string to_utf8_(std::string::value_type ch)
-{
-    if ((ch >= '\x00') && (ch <= '\x7f'))  // ASCII
-    {
-        return std::string{ch};
-    }
-
-    if ((ch >= '\xC0' /*À*/) && (ch <= '\xFF' /*y*/))  // ISO8859-1 letters
-    {
-        std::string retval{'\xC3'};
-        ch -= 0x40;  // 0xC0 -> 0x80
-        retval.push_back(ch);
-        return retval;
-    }
-    
-    return std::string{ch}; // ???
-}
-
-static std::string to_utf8(const std::string& str)
-{
-    std::string retval;
-    // Assume the input string is ISO8859-1 (western European) and convert to UTF-8
-    for (const auto& ch : str)
-    {
-        retval += to_utf8_(ch);
-    }
-    return retval;
-}
-
-static std::string convert(const std::string& str, io::TextEncoding encoding)
+static sys::u8string convert(const std::string& str, io::TextEncoding encoding)
 {
     if (encoding == io::TextEncoding::Utf8)
     {
-        return to_utf8(str);    
+        return str::toUtf8(str);
     }
 
     throw std::invalid_argument("Unexpected 'encoding' value.");
 }
 
-void io::OutputStream::write(const std::string& str_, const io::TextEncoding* pEncoding /*= nullptr*/)
+template<typename T>
+inline static void write(io::OutputStream& stream, const T& str)
 {
-    const std::string* pStr = &str_;
-    std::string str; // keep any result from convert() in-scope so we use its address
-    if (pEncoding != nullptr)
+    const auto buffer = reinterpret_cast<const sys::byte*>(str.c_str());
+    const sys::Size_T len{str.length()};
+    stream.write(buffer, len);
+}
+void io::OutputStream::write(const std::string& str)
+{
+    if (pEncoding == nullptr)
     {
-        str = convert(str_, *pEncoding);
-        pStr = &str; // stays in-scope, above
+        ::write(*this, str);
     }
-     
-    auto buffer = reinterpret_cast<const sys::byte*>(pStr->c_str());
-    const sys::Size_T len{pStr->length()};
-    write(buffer, len);
+    else
+    {
+        const auto u8str = convert(str, *pEncoding);
+        ::write(*this, u8str);
+    }
 }

--- a/modules/c++/io/unittests/test_streams.cpp
+++ b/modules/c++/io/unittests/test_streams.cpp
@@ -53,6 +53,23 @@ TEST_CASE(testStringStream)
     TEST_ASSERT_EQ(std::string(buf), "test");
 }
 
+TEST_CASE(testStringStreamUtf8)
+{
+    io::StringStream stream;
+    const std::string input = "|I\xc9|"; // ISO8859-1, "|IÉ|"
+    stream.writeln(input, io::TextEncoding::Utf8);
+
+    stream.seek(0, io::Seekable::START);
+    sys::byte buf[255];
+    stream.read(buf, input.size()+1); // +1 for the new UTF-8 byte, *NOT* trailing '\0'
+    buf[input.size()+1] = '\0';
+    const std::string actual(buf);
+    TEST_ASSERT_EQ(actual.size(), input.size() + 1);
+
+     const auto expected = "|I\xc3\x89|"; // UTF-8,  "|IÉ|"
+    TEST_ASSERT_EQ(actual, expected);
+}
+
 TEST_CASE(testByteStream)
 {
     io::ByteStream stream;
@@ -299,6 +316,7 @@ TEST_CASE(testRotateReset)
 int main(int, char**)
 {
     TEST_CHECK(testStringStream);
+    TEST_CHECK(testStringStreamUtf8);
     TEST_CHECK(testByteStream);
     TEST_CHECK(testProxyOutputStream);
     TEST_CHECK(testCountingOutputStream);

--- a/modules/c++/io/unittests/test_streams.cpp
+++ b/modules/c++/io/unittests/test_streams.cpp
@@ -55,9 +55,9 @@ TEST_CASE(testStringStream)
 
 TEST_CASE(testStringStreamUtf8)
 {
-    io::StringStream stream;
+    io::StringStream stream(io::TextEncoding::Utf8);
     const std::string input = "|I\xc9|"; // ISO8859-1, "|IÉ|"
-    stream.writeln(input, io::TextEncoding::Utf8);
+    stream.writeln(input);
 
     stream.seek(0, io::Seekable::START);
     sys::byte buf[255];

--- a/modules/c++/str/include/str/Convert.h
+++ b/modules/c++/str/include/str/Convert.h
@@ -22,6 +22,7 @@
 
 #ifndef __STR_CONVERT_H__
 #define __STR_CONVERT_H__
+#pragma once
 
 #include <import/except.h>
 #include <cerrno>
@@ -34,6 +35,23 @@
 #include <sstream>
 #include <string>
 #include <typeinfo>
+
+// This is a fairly low-level file, so don't #include a lot of our other files
+//#include "sys/String.h"
+#if !defined(CODA_OSS_sys_u8string_DEFINED_)
+#define CODA_OSS_sys_u8string_DEFINED_ 1
+namespace sys
+{
+    // Char8_T for UTF-8 characters
+    #if __cplusplus >= 202002L  // C++20
+    using Char8_T = char8_t;
+    using u8string = std::u8string;
+    #else
+    enum Char8_T : unsigned char { }; // https://en.cppreference.com/w/cpp/language/types
+    using u8string = std::basic_string<Char8_T>; // https://en.cppreference.com/w/cpp/string
+    #endif  // __cplusplus
+}
+#endif  // CODA_OSS_sys_u8string_DEFINED_
 
 namespace str
 {
@@ -63,6 +81,8 @@ std::string toString(const T& real, const T& imag)
 {
     return toString(std::complex<T>(real, imag));
 }
+
+sys::u8string toUtf8(const std::string&);
 
 template <typename T>
 T toType(const std::string& s)

--- a/modules/c++/str/unittests/test_base_convert.cpp
+++ b/modules/c++/str/unittests/test_base_convert.cpp
@@ -55,10 +55,25 @@ TEST_CASE(testCharToString)
     TEST_ASSERT_EQ(str::toString<char>(65), "A");
 }
 
+static inline sys::u8string::value_type cast(std::string::value_type ch)
+{
+    static_assert(sizeof(sys::u8string::value_type) == sizeof(std::string::value_type),
+        "sizeof(Char8_T) != sizeof(char)");
+    return static_cast<sys::u8string::value_type>(ch);
+}
+TEST_CASE(test_string_to_u8string)
+{
+    const std::string input = "|I\xc9|";  // ISO8859-1, "|IÉ|"
+    const auto actual = str::toUtf8(input);
+    const sys::u8string expected { cast('|'), cast('I'), cast('\xc3'), cast('\x89'), cast('|') };  // UTF-8,  "|IÉ|"
+    TEST_ASSERT(actual == expected);
+}
+
 int main(int, char**)
 {
     TEST_CHECK(testConvert);
     TEST_CHECK(testBadConvert);
     TEST_CHECK(testEightBitIntToString);
     TEST_CHECK(testCharToString);
+    TEST_CHECK(test_string_to_u8string);
 }

--- a/modules/c++/sys/include/import/sys.h
+++ b/modules/c++/sys/include/import/sys.h
@@ -48,6 +48,7 @@
 #include "sys/Thread.h"
 #include "sys/UTCDateTime.h"
 //#include "sys/Process.h"
+#include "sys/String.h"
 
 /*!
 

--- a/modules/c++/sys/include/sys/String.h
+++ b/modules/c++/sys/include/sys/String.h
@@ -1,0 +1,40 @@
+/* =========================================================================
+ * This file is part of sys-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <string>
+
+#if !defined(CODA_OSS_sys_u8string_DEFINED_)
+#define CODA_OSS_sys_u8string_DEFINED_ 1
+namespace sys
+{
+    // Char8_T for UTF-8 characters
+    #if __cplusplus >= 202002L  // C++20
+    using Char8_T = char8_t;
+    using u8string = std::u8string;
+    #else
+    enum Char8_T : unsigned char { }; // https://en.cppreference.com/w/cpp/language/types
+    using u8string = std::basic_string<Char8_T>; // https://en.cppreference.com/w/cpp/string
+    #endif  // __cplusplus
+}
+#endif  // CODA_OSS_sys_u8string_DEFINED_

--- a/modules/c++/xml.lite/CMakeLists.txt
+++ b/modules/c++/xml.lite/CMakeLists.txt
@@ -16,3 +16,9 @@ coda_add_tests(
     DIRECTORY "tests"
     DEPS cli-c++
     FILTER_LIST "MMParserTest1.cpp" "MinidomParserTest2.cpp")
+
+coda_add_tests(
+    MODULE_NAME ${MODULE_NAME}
+    DIRECTORY "unittests"
+    UNITTEST)
+

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -316,7 +316,7 @@ public:
      *  Adds a child element to this element
      *  \param node the child element to add
      */
-    virtual void addChild(std::unique_ptr <Element>&& node);
+    virtual void addChild(std::auto_ptr<Element> node);
 
     /*!
      *  Returns all of the children of this element

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -203,24 +203,8 @@ public:
      *  \param formatter  The formatter
      *  \todo Add format capability
      */
-    void print(io::OutputStream& stream, const io::TextEncoding* pEncoding = nullptr) const;
-    void print(io::OutputStream& stream, io::TextEncoding encoding) const
-    {
-        print(stream, &encoding);
-    }
-
-    void prettyPrint(io::OutputStream& stream, const std::string& formatter, io::TextEncoding encoding) const
-    {
-        prettyPrint(stream, formatter, &encoding);
-    }
-    void prettyPrint(io::OutputStream& stream, const std::string& formatter = "    ") const
-    {
-        prettyPrint(stream, formatter, nullptr /*pEncoding*/);
-    }
-    void prettyPrint(io::OutputStream& stream, io::TextEncoding encoding) const
-    {
-        prettyPrint(stream, "    ", encoding);
-    }
+    void print(io::OutputStream& stream) const;
+    void prettyPrint(io::OutputStream& stream, const std::string& formatter = "    ") const;
 
     /*!
      *  Determines if a child element exists
@@ -361,7 +345,7 @@ protected:
                    const std::string& uri);
 
     void depthPrint(io::OutputStream& stream, int depth,
-                    const std::string& formatter, const io::TextEncoding* pEncoding = nullptr) const;
+                    const std::string& formatter) const;
     
     Element* mParent;
     //! The children of this element
@@ -371,9 +355,6 @@ protected:
     xml::lite::Attributes mAttributes;
     //! The character data
     std::string mCharacterData;
-
-private:
-    void prettyPrint(io::OutputStream& stream, const std::string& formatter, const io::TextEncoding* pEncoding) const;
 
 };
 }

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -204,6 +204,10 @@ public:
      *  \todo Add format capability
      */
     void print(io::OutputStream& stream, const io::TextEncoding* pEncoding = nullptr) const;
+    void print(io::OutputStream& stream, io::TextEncoding encoding) const
+    {
+        print(stream, &encoding);
+    }
 
     void prettyPrint(io::OutputStream& stream, const std::string& formatter, io::TextEncoding encoding) const
     {

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -203,10 +203,20 @@ public:
      *  \param formatter  The formatter
      *  \todo Add format capability
      */
-    void print(io::OutputStream& stream) const;
+    void print(io::OutputStream& stream, const io::TextEncoding* pEncoding = nullptr) const;
 
-    void prettyPrint(io::OutputStream& stream,
-                     const std::string& formatter = "    ") const;
+    void prettyPrint(io::OutputStream& stream, const std::string& formatter, io::TextEncoding encoding) const
+    {
+        prettyPrint(stream, formatter, &encoding);
+    }
+    void prettyPrint(io::OutputStream& stream, const std::string& formatter = "    ") const
+    {
+        prettyPrint(stream, formatter, nullptr /*pEncoding*/);
+    }
+    void prettyPrint(io::OutputStream& stream, io::TextEncoding encoding) const
+    {
+        prettyPrint(stream, "    ", encoding);
+    }
 
     /*!
      *  Determines if a child element exists
@@ -306,7 +316,7 @@ public:
      *  Adds a child element to this element
      *  \param node the child element to add
      */
-    virtual void addChild(std::auto_ptr<Element> node);
+    virtual void addChild(std::unique_ptr <Element>&& node);
 
     /*!
      *  Returns all of the children of this element
@@ -347,7 +357,7 @@ protected:
                    const std::string& uri);
 
     void depthPrint(io::OutputStream& stream, int depth,
-                    const std::string& formatter) const;
+                    const std::string& formatter, const io::TextEncoding* pEncoding = nullptr) const;
     
     Element* mParent;
     //! The children of this element
@@ -357,6 +367,10 @@ protected:
     xml::lite::Attributes mAttributes;
     //! The character data
     std::string mCharacterData;
+
+private:
+    void prettyPrint(io::OutputStream& stream, const std::string& formatter, const io::TextEncoding* pEncoding) const;
+
 };
 }
 }

--- a/modules/c++/xml.lite/source/Element.cpp
+++ b/modules/c++/xml.lite/source/Element.cpp
@@ -142,22 +142,21 @@ void xml::lite::Element::destroyChildren()
     }
 }
 
-void xml::lite::Element::print(io::OutputStream& stream, const io::TextEncoding* pEncoding) const
+void xml::lite::Element::print(io::OutputStream& stream) const
 {
-    depthPrint(stream, 0, "", pEncoding);
+    depthPrint(stream, 0, "");
 }
 
 void xml::lite::Element::prettyPrint(io::OutputStream& stream,
-                                     const std::string& formatter,
-                                     const io::TextEncoding* pEncoding) const
+                                     const std::string& formatter) const
 {
-    depthPrint(stream, 0, formatter, pEncoding);
+    depthPrint(stream, 0, formatter);
     stream.writeln("");
 }
 
 void xml::lite::Element::depthPrint(io::OutputStream& stream,
                                     int depth,
-                                    const std::string& formatter, const io::TextEncoding* pEncoding) const
+                                    const std::string& formatter) const
 {
     std::string prefix = "";
     for (int i = 0; i < depth; ++i)
@@ -186,13 +185,13 @@ void xml::lite::Element::depthPrint(io::OutputStream& stream,
     else
     {
         stream.write(acc + rBrack);
-        stream.write(mCharacterData, pEncoding);
+        stream.write(mCharacterData);
 
         for (unsigned int i = 0; i < mChildren.size(); i++)
         {
             if (!formatter.empty())
                 stream.write("\n");
-            mChildren[i]->depthPrint(stream, depth + 1, formatter, pEncoding);
+            mChildren[i]->depthPrint(stream, depth + 1, formatter);
         }
 
         if (!mChildren.empty() && !formatter.empty())

--- a/modules/c++/xml.lite/source/Element.cpp
+++ b/modules/c++/xml.lite/source/Element.cpp
@@ -142,21 +142,22 @@ void xml::lite::Element::destroyChildren()
     }
 }
 
-void xml::lite::Element::print(io::OutputStream& stream) const
+void xml::lite::Element::print(io::OutputStream& stream, const io::TextEncoding* pEncoding) const
 {
-    depthPrint(stream, 0, "");
+    depthPrint(stream, 0, "", pEncoding);
 }
 
 void xml::lite::Element::prettyPrint(io::OutputStream& stream,
-                                     const std::string& formatter) const
+                                     const std::string& formatter,
+                                     const io::TextEncoding* pEncoding) const
 {
-    depthPrint(stream, 0, formatter);
+    depthPrint(stream, 0, formatter, pEncoding);
     stream.writeln("");
 }
 
 void xml::lite::Element::depthPrint(io::OutputStream& stream,
                                     int depth,
-                                    const std::string& formatter) const
+                                    const std::string& formatter, const io::TextEncoding* pEncoding) const
 {
     std::string prefix = "";
     for (int i = 0; i < depth; ++i)
@@ -185,13 +186,13 @@ void xml::lite::Element::depthPrint(io::OutputStream& stream,
     else
     {
         stream.write(acc + rBrack);
-        stream.write(mCharacterData);
+        stream.write(mCharacterData, pEncoding);
 
         for (unsigned int i = 0; i < mChildren.size(); i++)
         {
             if (!formatter.empty())
                 stream.write("\n");
-            mChildren[i]->depthPrint(stream, depth + 1, formatter);
+            mChildren[i]->depthPrint(stream, depth + 1, formatter, pEncoding);
         }
 
         if (!mChildren.empty() && !formatter.empty())
@@ -210,14 +211,10 @@ void xml::lite::Element::addChild(xml::lite::Element * node)
     node->setParent(this);
 }
 
-void xml::lite::Element::addChild(std::auto_ptr<xml::lite::Element> node)
+void xml::lite::Element::addChild(std::unique_ptr<xml::lite::Element>&& node)
 {
-    // Always take ownership
-    std::auto_ptr<xml::lite::Element> scopedValue(node);
-    addChild(scopedValue.get());
-    scopedValue.release();
+    addChild(node.release()); // addChild() now owns node
 }
-
 void xml::lite::Element::changePrefix(Element* element,
     const std::string& prefix, const std::string& uri)
 {

--- a/modules/c++/xml.lite/source/Element.cpp
+++ b/modules/c++/xml.lite/source/Element.cpp
@@ -211,10 +211,14 @@ void xml::lite::Element::addChild(xml::lite::Element * node)
     node->setParent(this);
 }
 
-void xml::lite::Element::addChild(std::unique_ptr<xml::lite::Element>&& node)
+void xml::lite::Element::addChild(std::auto_ptr<xml::lite::Element> node)
 {
-    addChild(node.release()); // addChild() now owns node
+    // Always take ownership
+    std::auto_ptr<xml::lite::Element> scopedValue(node);
+    addChild(scopedValue.get());
+    scopedValue.release();
 }
+
 void xml::lite::Element::changePrefix(Element* element,
     const std::string& prefix, const std::string& uri)
 {

--- a/modules/c++/xml.lite/unittests/test_xmlparser.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlparser.cpp
@@ -1,0 +1,122 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <clocale>
+
+#include "io/StringStream.h"
+#include <TestCase.h>
+
+#include "xml/lite/MinidomParser.h"
+
+TEST_CASE(testXmlParseSimple)
+{
+    const std::string text("text");
+    const std::string strXml = "<root><doc><a>" + text + "</a></doc></root>";
+    io::StringStream ss;
+    ss.stream() << strXml;
+    TEST_ASSERT_EQ(ss.stream().str(), strXml);
+
+    xml::lite::MinidomParser xmlParser;
+    xmlParser.parse(ss);
+    const auto doc = xmlParser.getDocument();
+    TEST_ASSERT(doc != nullptr);
+    const auto root = doc->getRootElement();
+    TEST_ASSERT(root != nullptr);
+    
+    {
+        const auto aElements = root->getElementsByTagName("a", true /*recurse*/);
+        TEST_ASSERT_FALSE(aElements.empty());
+        TEST_ASSERT_EQ(aElements.size(), 1);
+        const auto& a = *(aElements[0]);
+        const auto characterData = a.getCharacterData();
+        TEST_ASSERT_EQ(characterData, text);
+    }
+    
+    const auto docElements = root->getElementsByTagName("doc");
+    TEST_ASSERT_FALSE(docElements.empty());
+    TEST_ASSERT_EQ(docElements.size(), 1);
+    {
+        const auto aElements = docElements[0]->getElementsByTagName("a");
+        TEST_ASSERT_FALSE(aElements.empty());
+        TEST_ASSERT_EQ(aElements.size(), 1);
+        const auto& a = *(aElements[0]);
+        const auto characterData = a.getCharacterData();
+        TEST_ASSERT_EQ(characterData, text);
+    }
+}
+
+TEST_CASE(testXmlPreserveCharacterData)
+{
+    const std::string utf8Text("I\xc3\x89");  // UTF-8,  "IÉ"
+    const std::string strXml = "<root><doc><a>" + utf8Text + "</a></doc></root>";
+    io::StringStream stream;
+    stream.stream() << strXml;
+    TEST_ASSERT_EQ(stream.stream().str(), strXml);
+
+    // On *ix, this won't throw because the default "C" locale is UTF-8 enabled.
+    // There don't seem to be non-UTF-8 locales available (a "good thing" in 2020, I guess).
+    xml::lite::MinidomParser xmlParser;
+    #ifdef _WIN32
+    // This is needed in Windows, but not *ix, because the default locale is *.1252 (more-or-less ISO8859-1)
+    // Unfortunately, there doesn't seem to be a way of testing this ...
+    // calling parse() w/o preserveCharacterData() throws ASSERTs, even after calling
+    // _set_error_mode(_OUT_TO_STDERR) so there's no way to use TEST_EXCEPTION
+    xmlParser.preserveCharacterData(true);
+    #endif
+    xmlParser.parse(stream);
+    TEST_ASSERT_TRUE(true);
+}
+
+TEST_CASE(testXmlUtf8)
+{
+    const std::string text("I\xc9");  // ISO8859-1, "IÉ"
+    const std::string utf8Text("I\xc3\x89");  // UTF-8,  "IÉ"
+    const std::string strXml = "<root><doc><a>" + utf8Text + "</a></doc></root>";
+    io::StringStream stream;
+    stream.stream() << strXml;
+    TEST_ASSERT_EQ(stream.stream().str(), strXml);
+
+    xml::lite::MinidomParser xmlParser;
+    //xmlParser.preserveCharacterData(true);
+    xmlParser.parse(stream);
+
+    const auto aElements =
+            xmlParser.getDocument()->getRootElement()->getElementsByTagName("a", true /*recurse*/);
+    TEST_ASSERT_EQ(aElements.size(), 1);
+    const auto& a = *(aElements[0]);
+    const std::string characterData = a.getCharacterData();
+    TEST_ASSERT_EQ(characterData.length(), 2);
+    const std::string actual = ">" + characterData + "<";
+    #ifdef _WIN32
+    TEST_ASSERT_EQ(actual, text);
+    #else
+    TEST_ASSERT_EQ(actual, utf8Text);
+    #endif
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(testXmlParseSimple);
+    TEST_CHECK(testXmlPreserveCharacterData);
+    //TEST_CHECK(testXmlUtf8);
+}

--- a/modules/c++/xml.lite/unittests/test_xmlparser.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlparser.cpp
@@ -67,7 +67,7 @@ TEST_CASE(testXmlParseSimple)
 
 TEST_CASE(testXmlPreserveCharacterData)
 {
-    const std::string utf8Text("T\xc3\x89XT");  // UTF-8,  "TÉXT"
+    const std::string utf8Text("T\xc3\x89XT");  // UTF-8,  "Tï¿½XT"
     const std::string strXml = "<root><doc><a>" + utf8Text + "</a></doc></root>";
     io::StringStream stream;
     stream.stream() << strXml;
@@ -91,8 +91,9 @@ TEST_CASE(testXmlUtf8)
 {
     //auto prev = std::setlocale(LC_ALL, "C");
 
-    const std::string text("T\xc9XT");  // ISO8859-1, "TÉXT"
-    const std::string utf8Text("T\xc3\x89XT");  // UTF-8,  "TÉXT"
+    const std::string text("T\xc9XT");  // ISO8859-1, "Tï¿½XT"
+    const std::string utf8Text("T\xc3\x89XT");  // UTF-8,  "Tï¿½XT"
+    //const std::string utf8Text("TEXT");  // UTF-8,  "Tï¿½XT"
     const std::string strXml = "<root><doc><a>" + utf8Text + "</a></doc></root>";
     io::StringStream stream;
     stream.stream() << strXml;
@@ -109,13 +110,12 @@ TEST_CASE(testXmlUtf8)
             xmlParser.getDocument()->getRootElement()->getElementsByTagName("a", true /*recurse*/);
     TEST_ASSERT_EQ(aElements.size(), 1);
     const auto& a = *(aElements[0]);
-    const std::string actual = a.getCharacterData();
+    const auto actual = a.getCharacterData();
     TEST_ASSERT_EQ(actual.length(), 4);
     #ifdef _WIN32
     TEST_ASSERT_EQ(actual, text);
     #else
-    std::cout << "'" << actual << "'\n";
-    TEST_ASSERT(actual == utf8Text);
+    //std::cout << "'" << actual << "'\n";
     TEST_ASSERT_EQ(actual, utf8Text);
     #endif
 


### PR DESCRIPTION
There is a bug in SIX where a UTF-8 encoded character did not make it to the output XML, even though it was in the input XML (embedded in the NITF).  It turns out that our XML parsing routines convert UTF-8 characters to ISO8859-1 (Windows-1252), but the reverse did not happen on writing.

This is mostly a point-solution to fix this particular bug ... w/o doing thing in a way that is a big hack.  No attempt is made to fix other write() routines.