### PR TITLE
make it easier to use xml.lite

### DIFF
--- a/modules/c++/xml.lite/include/xml/lite/Attributes.h
+++ b/modules/c++/xml.lite/include/xml/lite/Attributes.h
@@ -389,8 +389,18 @@ inline bool getValue_(const Attributes& attributes, const K& key, T& result)
     {
         return false;
     }
-
-    result = str::toType<T>(value);
+    if (value.empty())
+    {
+        return false;  // call Attributes::getValue() directly to get an empty string
+    }
+    try
+    {
+        result = str::toType<T>(value);
+    }
+    catch (const except::BadCastException&)
+    {
+        return false;
+    }
     return true;
 }
 

--- a/modules/c++/xml.lite/include/xml/lite/Attributes.h
+++ b/modules/c++/xml.lite/include/xml/lite/Attributes.h
@@ -22,6 +22,7 @@
 
 #ifndef __XML_LITE_ATTRIBUTES_H__
 #define __XML_LITE_ATTRIBUTES_H__
+#pragma once
 
 #include "sys/Conf.h"
 #include "except/Exception.h"
@@ -172,7 +173,7 @@ public:
      *  Adds an attribute to the list of attributes.
      *  \param attribute the attribute to add
      */
-    void add(const AttributeNode & attribute);
+    AttributeNode& add(const AttributeNode& attribute);
 
     /*!
      * Look up the index of an attribute by XML 1.0 qualified name.
@@ -223,6 +224,13 @@ public:
      * \throw IndexOutOfRangeException if the index is out of range
      */
     std::string getValue(int i) const;
+    /*!
+     * Look up an attribute's value by index.
+     * \param i  The index for the attribute we want
+     * \param result The value, if found
+     * \return If the index is out of range or not
+     */
+    bool getValue(int i, std::string& result) const;
 
     /*!
      * Look up an attribute's value by XML 1.0 qualified name.
@@ -231,16 +239,32 @@ public:
      * \throw NoSuchKeyException If the qname is not found
      */
     std::string getValue(const std::string & qname) const;
+    /*!
+     * Look up an attribute's value by XML 1.0 qualified name.
+     * \param qname The qualified name
+     * \param result The value, if found
+     * \return If the qname is not found or not
+     */
+    bool getValue(const std::string& qname, std::string& result) const;
 
     /*!
      * Look up an attribute's value by Namespace name.
      * \param uri The uri association
      * \param localName the local name of the object
      * \return The value
-     * \throw NoSuchKeyException If the qname is not found
+     * \throw NoSuchKeyException If the uri/localName is not found
      */
-    std::string getValue(const std::string & uri,
-                         const std::string & localName) const;
+    std::string getValue(const std::string & uri, const std::string & localName) const;
+    /*!
+     * Look up an attribute's value by Namespace name.
+     * \param uri The uri association
+     * \param localName the local name of the object
+     * \param result The value, if found
+     * \return If the uri/localName is not found or not
+     */
+    bool getValue(const std::string& uri, const std::string& localName,
+        std::string& result) const;
+
     /*!
      * Get an attribute note based on the index as a const ref
      * \param i The node index

--- a/modules/c++/xml.lite/include/xml/lite/Attributes.h
+++ b/modules/c++/xml.lite/include/xml/lite/Attributes.h
@@ -179,6 +179,13 @@ public:
     AttributeNode& add(const AttributeNode& attribute);
 
     /*!
+     * Look up the index of an index.
+     * \param i  The index of the attribute
+     * \return the index or -1 if none found
+     */
+    int getIndex(int i) const;
+
+    /*!
      * Look up the index of an attribute by XML 1.0 qualified name.
      * \param qname The fully qualified name of the attribute
      * \return the index or -1 if none found
@@ -192,6 +199,10 @@ public:
      * \return the index or -1 if none found
      */
     int getIndex(const std::string & uri, const std::string & localName) const;
+    int getIndex(const std::tuple<std::string, std::string>& name) const
+    {
+        return getIndex(std::get<0>(name), std::get<1>(name));
+    }
 
     /*!
      * Return the number of attributes in the list.
@@ -366,8 +377,8 @@ private:
 
 /*!
  * Look up an attribute's value by an arbitrary key.
- * \param i  The index for the attribute we want
- * \param result The value after calling std::toType(), if found
+ * \param key  The key for the attribute we want
+ * \param result The value after calling str::toType(), if found
  * \return If an attribute with the key is found or not
  */
 template <typename T, typename K>
@@ -386,7 +397,7 @@ inline bool getValue_(const Attributes& attributes, const K& key, T& result)
 /*!
  * Look up an attribute's value by index.
  * \param i  The index for the attribute we want
- * \param result The value after calling std::toType(), if found
+ * \param result The value after calling str::toType(), if found
  * \return If the index is out of range or not
  */
 template<typename T>
@@ -398,7 +409,7 @@ inline bool getValue(const Attributes& attributes, int i, T& result)
 /*!
  * Look up an attribute's value by XML 1.0 qualified name.
  * \param qname The qualified name
- * \param result The value after calling std::toType(), if found
+ * \param result The value after calling str::toType(), if found
  * \return If the qname is not found or not
  */
 template <typename T>
@@ -411,7 +422,7 @@ inline bool getValue(const Attributes& attributes, const std::string& qname, T& 
  * Look up an attribute's value by Namespace name.
  * \param uri The uri association
  * \param localName the local name of the object
- * \param result The value after calling std::toType(), if found
+ * \param result The value after calling str::toType(), if found
  * \return If the uri/localName is not found or not
  */
 template <typename T>
@@ -424,6 +435,68 @@ inline bool getValue(const Attributes& attributes, const std::string & uri, cons
 {
     return getValue(attributes, std::make_tuple(uri, localName), result);
 }
+
+/*!
+ * Set an attribute's value with an arbitrary key.
+ * \param key  The key for the attribute we want
+ * \param value The value to be converted by calling str::toString
+ * \return If an attribute with the key is found or not
+ */
+template <typename T, typename K>
+inline bool setValue_(Attributes& attributes, const K& key, const T& value)
+{
+    int index = attributes.getIndex(key);
+    if (index < 0)
+    {
+        return false; // not found
+    }
+
+    auto& node = attributes.getNode(index);
+    node.setValue(str::toString(value));
+    return true;
+}
+/*!
+ * Look up an attribute's value by index.
+ * \param i  The index for the attribute we want
+ * \param result The value after calling str::toType(), if found
+ * \return If the index is out of range or not
+ */
+template<typename T>
+inline bool setValue(Attributes& attributes, int i, const T& value)
+{
+    return setValue_(attributes, i, value);
+}
+
+/*!
+ * Look up an attribute's value by XML 1.0 qualified name.
+ * \param qname The qualified name
+ * \param result The value after calling str::toType(), if found
+ * \return If the qname is not found or not
+ */
+template <typename T>
+inline bool setValue(Attributes& attributes, const std::string& qname, const T& value)
+{
+    return setValue_(attributes, qname, value);
+}
+
+/*!
+ * Look up an attribute's value by Namespace name.
+ * \param uri The uri association
+ * \param localName the local name of the object
+ * \param result The value after calling str::toType(), if found
+ * \return If the uri/localName is not found or not
+ */
+template <typename T>
+inline bool setValue(Attributes& attributes, const std::tuple<std::string, std::string>& name, const T& value)
+{
+    return setValue_(attributes, name, value);
+}
+template <typename T>
+inline bool setValue(Attributes& attributes, const std::string & uri, const std::string & localName, const T& value)
+{
+    return setValue(attributes, std::make_tuple(uri, localName), value);
+}
+
 }
 }
 

--- a/modules/c++/xml.lite/include/xml/lite/Attributes.h
+++ b/modules/c++/xml.lite/include/xml/lite/Attributes.h
@@ -24,11 +24,14 @@
 #define __XML_LITE_ATTRIBUTES_H__
 #pragma once
 
+#include <string>
+#include <vector>
+#include <tuple>
+
 #include "sys/Conf.h"
 #include "except/Exception.h"
 #include "xml/lite/QName.h"
-#include <string>
-#include <vector>
+#include "str/Convert.h"
 
 /*!
  *  \file Attributes.h
@@ -262,8 +265,11 @@ public:
      * \param result The value, if found
      * \return If the uri/localName is not found or not
      */
-    bool getValue(const std::string& uri, const std::string& localName,
-        std::string& result) const;
+    bool getValue(const std::string& uri, const std::string& localName, std::string& result) const;
+    bool getValue(const std::tuple<std::string, std::string>& name, std::string& result) const
+    {
+        return getValue(std::get<0>(name), std::get<1>(name), result);
+    }
 
     /*!
      * Get an attribute note based on the index as a const ref
@@ -357,6 +363,67 @@ private:
     //! Underlying representation
     Attributes_T mAttributes;
 };
+
+/*!
+ * Look up an attribute's value by an arbitrary key.
+ * \param i  The index for the attribute we want
+ * \param result The value after calling std::toType(), if found
+ * \return If an attribute with the key is found or not
+ */
+template <typename T, typename K>
+inline bool getValue_(const Attributes& attributes, const K& key, T& result)
+{
+    std::string value;
+    if (!attributes.getValue(key, value))
+    {
+        return false;
+    }
+
+    result = str::toType<T>(value);
+    return true;
+}
+
+/*!
+ * Look up an attribute's value by index.
+ * \param i  The index for the attribute we want
+ * \param result The value after calling std::toType(), if found
+ * \return If the index is out of range or not
+ */
+template<typename T>
+inline bool getValue(const Attributes& attributes, int i, T& result)
+{
+    return getValue_(attributes, i, result);
+}
+
+/*!
+ * Look up an attribute's value by XML 1.0 qualified name.
+ * \param qname The qualified name
+ * \param result The value after calling std::toType(), if found
+ * \return If the qname is not found or not
+ */
+template <typename T>
+inline bool getValue(const Attributes& attributes, const std::string& qname, T& result)
+{
+    return getValue_(attributes, qname, result);
+}
+
+/*!
+ * Look up an attribute's value by Namespace name.
+ * \param uri The uri association
+ * \param localName the local name of the object
+ * \param result The value after calling std::toType(), if found
+ * \return If the uri/localName is not found or not
+ */
+template <typename T>
+inline bool getValue(const Attributes& attributes, const std::tuple<std::string, std::string>& name, T& result)
+{
+    return getValue_(attributes, name, result);
+}
+template <typename T>
+inline bool getValue(const Attributes& attributes, const std::string & uri, const std::string & localName, T& result)
+{
+    return getValue(attributes, std::make_tuple(uri, localName), result);
+}
 }
 }
 

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -459,6 +459,36 @@ protected:
         void depthPrint(io::OutputStream& stream, const string_encoding*, int depth,
                 const std::string& formatter) const;
 };
+
+/*!
+ *  Returns the character data of this element converted to the specified type.
+ *  \param value the charater data as T
+ *  \return whether or not there was a value of type T
+ */
+template<typename T>
+inline bool getValue(const Element& element, T& value)
+{
+    const auto characterData = element.getCharacterData();
+    if (characterData.empty())
+    {
+        return false; // call getCharacterData() to get an empty string
+    }
+
+    value = str::toType<T>(characterData);
+    return true;
+}
+
+
+/*!
+ *  Sets the character data for this element by calling str::toString() on the value.
+ *  \param value The data to add to this element
+ */
+template <typename T>
+inline void setValue(Element& element, const T& value)
+{
+    element.setCharacterData(str::toString(value));
+}
+
 }
 }
 

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -487,8 +487,14 @@ inline bool getValue(const Element& element, T& value)
     {
         return false; // call getCharacterData() to get an empty string
     }
-
-    value = str::toType<T>(characterData);
+    try
+    {
+        value = str::toType<T>(characterData);
+    }
+    catch (const except::BadCastException&)
+    {
+        return false;
+    }
     return true;
 }
 

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -173,10 +173,8 @@ public:
     /*!
      *  \param std::nothrow -- will still throw if MULTIPLE elements are found, returns NULL if none
      */
-    Element* getElementByTagNameNS(std::nothrow_t, const std::string& qname,
-                                bool recurse = false) const;
-    Element& getElementByTagNameNS(const std::string& qname,
-                                bool recurse = false) const
+    Element* getElementByTagNameNS(std::nothrow_t, const std::string& qname, bool recurse = false) const;
+    Element& getElementByTagNameNS(const std::string& qname, bool recurse = false) const
     {
         auto pElement = getElementByTagNameNS(std::nothrow, qname, recurse);
         if (pElement == nullptr)
@@ -190,8 +188,7 @@ public:
      *  Utility for people that dont like to pass by reference
      *
      */
-    std::vector<Element*> getElementsByTagNameNS(const std::string& qname,
-                                                 bool recurse = false) const
+    std::vector<Element*> getElementsByTagNameNS(const std::string& qname, bool recurse = false) const
     {
         std::vector<Element*> v;
         getElementsByTagNameNS(qname, v, recurse);
@@ -210,10 +207,8 @@ public:
     /*!
      *  \param std::nothrow -- will still throw if MULTIPLE elements are found, returns NULL if none
      */
-    Element* getElementByTagName(std::nothrow_t, const std::string& localName,
-                              bool recurse = false) const;
-    Element& getElementByTagName(const std::string& localName,
-                                 bool recurse = false) const
+    Element* getElementByTagName(std::nothrow_t, const std::string& localName, bool recurse = false) const;
+    Element& getElementByTagName(const std::string& localName, bool recurse = false) const
     {
         auto pElement = getElementByTagName(std::nothrow, localName, recurse);
         if (pElement == nullptr)
@@ -240,18 +235,15 @@ public:
      *  \param localName the local name
      *  \param elements the elements that match the QName
      */
-    void getElementsByTagName(const std::string& uri,
-                              const std::string& localName,
+    void getElementsByTagName(const std::string& uri, const std::string& localName,
                               std::vector<Element*>& elements,
                               bool recurse = false) const;
     /*!
      *  \param std::nothrow -- will still throw if MULTIPLE elements are found, returns NULL if none
      */
-    Element* getElementByTagName(std::nothrow_t, const std::string& uri,
-                                 const std::string& localName,
+    Element* getElementByTagName(std::nothrow_t, const std::string& uri, const std::string& localName,
                                  bool recurse = false) const;
-    Element& getElementByTagName(const std::string& uri,
-                                 const std::string& localName,
+    Element& getElementByTagName(const std::string& uri, const std::string& localName,
                                  bool recurse = false) const
     {
         auto pElement = getElementByTagName(std::nothrow, uri, localName, recurse);
@@ -260,6 +252,17 @@ public:
             throw XMLException(Ctxt("Element '" + localName + "' was not found (uri=" + uri + ")."));
         }
         return *pElement;
+    }
+
+    /*!
+     *  Utility for people that dont like to pass by reference
+     */
+    std::vector<Element*> getElementsByTagName(const std::string& uri, const std::string& localName,
+                                               bool recurse = false) const
+    {
+        std::vector<Element*> v;
+        getElementsByTagName(uri, localName, v, recurse);
+        return v;
     }
 
     /*!
@@ -306,8 +309,7 @@ public:
      *  \param localName the local name to search for
      *  \return true if it exists, false if not
      */
-    bool hasElement(const std::string& uri,
-                    const std::string& localName) const;
+    bool hasElement(const std::string& uri, const std::string& localName) const;
 
     /*!
      *  Returns the character data of this element.

--- a/modules/c++/xml.lite/include/xml/lite/Element.h
+++ b/modules/c++/xml.lite/include/xml/lite/Element.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <memory>
+#include <new> // std::nothrow_t
 
 #include <io/InputStream.h>
 #include <io/OutputStream.h>
@@ -168,6 +169,21 @@ public:
     void getElementsByTagNameNS(const std::string& qname,
                                 std::vector<Element*>& elements,
                                 bool recurse = false) const;
+    /*!
+     *  \param std::nothrow -- will still throw if MULTIPLE elements are found, returns NULL if none
+     */
+    Element* getElementByTagNameNS(std::nothrow_t, const std::string& qname,
+                                bool recurse = false) const;
+    Element& getElementByTagNameNS(const std::string& qname,
+                                bool recurse = false) const
+    {
+        auto pElement = getElementByTagNameNS(std::nothrow, qname, recurse);
+        if (pElement == nullptr)
+        {
+            throw XMLException(Ctxt("Element '" + qname + "' was not found."));
+        }
+        return *pElement;
+    }
 
     /*!
      *  Utility for people that dont like to pass by reference
@@ -190,6 +206,21 @@ public:
     void getElementsByTagName(const std::string& localName,
                               std::vector<Element*>& elements,
                               bool recurse = false) const;
+    /*!
+     *  \param std::nothrow -- will still throw if MULTIPLE elements are found, returns NULL if none
+     */
+    Element* getElementByTagName(std::nothrow_t, const std::string& localName,
+                              bool recurse = false) const;
+    Element& getElementByTagName(const std::string& localName,
+                                 bool recurse = false) const
+    {
+        auto pElement = getElementByTagName(std::nothrow, localName, recurse);
+        if (pElement == nullptr)
+        {
+            throw XMLException(Ctxt("Element '" + localName + "' was not found."));
+        }
+        return *pElement;
+    }
 
     /*!
      *  Utility for people that dont like to pass by reference
@@ -212,6 +243,23 @@ public:
                               const std::string& localName,
                               std::vector<Element*>& elements,
                               bool recurse = false) const;
+    /*!
+     *  \param std::nothrow -- will still throw if MULTIPLE elements are found, returns NULL if none
+     */
+    Element* getElementByTagName(std::nothrow_t, const std::string& uri,
+                                 const std::string& localName,
+                                 bool recurse = false) const;
+    Element& getElementByTagName(const std::string& uri,
+                                 const std::string& localName,
+                                 bool recurse = false) const
+    {
+        auto pElement = getElementByTagName(std::nothrow, uri, localName, recurse);
+        if (pElement == nullptr)
+        {
+            throw XMLException(Ctxt("Element '" + localName + "' was not found (uri=" + uri + ")."));
+        }
+        return *pElement;
+    }
 
     /*!
      *  1)  Find this child's attribute and change it

--- a/modules/c++/xml.lite/source/Attributes.cpp
+++ b/modules/c++/xml.lite/source/Attributes.cpp
@@ -65,6 +65,15 @@ std::string xml::lite::Attributes::getValue(int i) const
 {
     return mAttributes.at(i).getValue();
 }
+bool xml::lite::Attributes::getValue(int i, std::string& result) const
+{
+    if ((i >= 0) && (i < mAttributes.size()))
+    {
+        result = mAttributes[i].getValue();
+        return true; // index in range
+    }
+    return false; // index out-of-range
+}
 
 std::string xml::lite::Attributes::getUri(int i) const
 {
@@ -83,38 +92,61 @@ std::string xml::lite::Attributes::getQName(int i) const
 
 std::string xml::lite::Attributes::getValue(const std::string& qname) const
 {
+    std::string retval;
+    if (!getValue(qname, retval))
+    {
+        throw except::NoSuchKeyException(Ctxt(FmtX("QName '%s' could not be found",
+                                                   qname.c_str())));
+    }
+    
+    return retval;  
+}
+{
     for (size_t i = 0; i < mAttributes.size(); i++)
     {
         if (qname == mAttributes[i].getQName())
-            return mAttributes[i].getValue();
+        {
+            result = mAttributes[i].getValue();
+            return true; // found
+        }
     }
-    throw except::NoSuchKeyException(Ctxt(FmtX("QName '%s' could not be found",
-                                               qname.c_str())));
 
-    // We don't ever reach this but it keeps the compiler from complaining...
-    return mAttributes[mAttributes.size() - 1].getValue();
+    return false; // not found
 }
 
 std::string xml::lite::Attributes::getValue(
     const std::string& uri,
     const std::string& localName) const
 {
+    std::string retval;
+    if (!getValue(uri, localName, retval))
+    {
+        throw except::NoSuchKeyException(Ctxt(FmtX("(uri: %s, localName: %s",
+                                                   uri.c_str(), localName.c_str())));
+    }
+    return retval;
+}
+bool xml::lite::Attributes::getValue(
+    const std::string& uri,
+    const std::string& localName,
+    std::string& result) const
+{
     for (size_t i = 0; i < mAttributes.size(); i++)
     {
         if ((uri == mAttributes[i].getUri()) && (localName
                 == mAttributes[i].getLocalName()))
-            return mAttributes[i].getValue();
+        {
+            result = mAttributes[i].getValue();
+            return true; // found
+        }
     }
-    throw except::NoSuchKeyException(Ctxt(FmtX("(uri: %s, localName: %s",
-                                               uri.c_str(), localName.c_str())));
-
-    // We don't ever reach this but it keeps the compiler from complaining...
-    return mAttributes[mAttributes.size() - 1].getValue();
+    return false; // not found
 }
 
-void xml::lite::Attributes::add(const AttributeNode& attribute)
+xml::lite::AttributeNode& xml::lite::Attributes::add(const AttributeNode& attribute)
 {
     mAttributes.push_back(attribute);
+    return mAttributes.back();
 }
 
 void xml::lite::AttributeNode::setQName(const std::string& qname)

--- a/modules/c++/xml.lite/source/Attributes.cpp
+++ b/modules/c++/xml.lite/source/Attributes.cpp
@@ -39,6 +39,15 @@ xml::lite::AttributeNode::operator=(const xml::lite::AttributeNode& node)
     return *this;
 }
 
+int xml::lite::Attributes::getIndex(int i) const
+{
+    if ((i >= 0) && (i < mAttributes.size()))
+    {
+        return i;
+    }
+    return -1;
+}
+
 int xml::lite::Attributes::getIndex(const std::string& qname) const
 {
     for (size_t i = 0; i < mAttributes.size(); i++)

--- a/modules/c++/xml.lite/source/Attributes.cpp
+++ b/modules/c++/xml.lite/source/Attributes.cpp
@@ -101,6 +101,7 @@ std::string xml::lite::Attributes::getValue(const std::string& qname) const
     
     return retval;  
 }
+bool xml::lite::Attributes::getValue(const std::string& qname, std::string& result) const
 {
     for (size_t i = 0; i < mAttributes.size(); i++)
     {

--- a/modules/c++/xml.lite/source/Element.cpp
+++ b/modules/c++/xml.lite/source/Element.cpp
@@ -101,6 +101,25 @@ void xml::lite::Element::getElementsByTagName(const std::string& uri,
     }
 }
 
+xml::lite::Element* xml::lite::Element::getElementByTagName(std::nothrow_t, const std::string& uri,
+                                              const std::string& localName,
+                                              bool recurse) const
+{
+    std::vector<Element*> elements;
+    getElementsByTagName(uri, localName, elements, recurse);
+    if (elements.empty())
+    {
+        return nullptr;
+    }
+    if (elements.size() > 1)
+    {
+        // Yes, this is "nothrow" ... that's for found/non-found status.  We
+        // asked for an ELEMENT, not "elements".
+        throw XMLException(Ctxt("Multiple elements returned for '" + localName + "' (uri=" + uri + ")."));    
+    }
+    return elements[0];
+}
+
 void xml::lite::Element::getElementsByTagName(const std::string& localName,
                                               std::vector<Element*>& elements,
                                               bool recurse) const 
@@ -114,6 +133,24 @@ void xml::lite::Element::getElementsByTagName(const std::string& localName,
     }
 }
 
+xml::lite::Element* xml::lite::Element::getElementByTagName(std::nothrow_t, const std::string& localName,
+                            bool recurse) const
+{
+    std::vector<Element*> elements;
+    getElementsByTagName(localName, elements, recurse);
+    if (elements.empty())
+    {
+        return nullptr;
+    }
+    if (elements.size() > 1)
+    {
+        // Yes, this is "nothrow" ... that's for found/non-found status.  We
+        // asked for an ELEMENT, not "elements".
+        throw XMLException(Ctxt("Multiple elements returned for '" + localName + "'."));
+    }
+    return elements[0];
+}
+
 void xml::lite::Element::getElementsByTagNameNS(const std::string& qname,
                                                 std::vector<Element*>& elements,
                                                 bool recurse) const
@@ -125,6 +162,24 @@ void xml::lite::Element::getElementsByTagNameNS(const std::string& qname,
         if (recurse)
             mChildren[i]->getElementsByTagNameNS(qname, elements, recurse);
     }
+}
+
+xml::lite::Element* xml::lite::Element::getElementByTagNameNS(std::nothrow_t, const std::string& qname,
+                                                bool recurse) const
+{
+    std::vector<Element*> elements;
+    getElementsByTagNameNS(qname, elements, recurse);
+    if (elements.empty())
+    {
+        return nullptr;
+    }
+    if (elements.size() > 1)
+    {
+        // Yes, this is "nothrow" ... that's for found/non-found status.  We
+        // asked for an ELEMENT, not "elements".
+        throw XMLException(Ctxt("Multiple elements returned for '" + qname + "'."));
+    }
+    return elements[0];
 }
 
 void xml::lite::Element::destroyChildren()

--- a/modules/c++/xml.lite/unittests/test_xmlattribute.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlattribute.cpp
@@ -1,0 +1,113 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "io/StringStream.h"
+#include <TestCase.h>
+
+#include "xml/lite/MinidomParser.h"
+
+static const std::string strXml = R"(
+<root>
+    <doc name="doc">
+        <a a="a">TEXT</a>
+        <values int="314" double="3.14" string="314"/>
+    </doc>
+</root>)";
+
+struct test_MinidomParser final
+{
+    xml::lite::MinidomParser xmlParser;
+    const xml::lite::Element* getRootElement()
+    {
+        io::StringStream ss;
+        ss.stream() << strXml;
+
+        xmlParser.parse(ss);
+        const auto doc = xmlParser.getDocument();
+        return doc->getRootElement();    
+    }
+};
+
+TEST_CASE(test_getAttribute)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+
+    const auto& a = root->getElementByTagName("a", true /*recurse*/);
+    std::string value;
+    value = a.getAttributes().getValue("a");
+    TEST_ASSERT_EQ("a", value);
+
+    const auto result = a.getAttributes().getValue("a", value);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQ("a", value);
+}
+
+TEST_CASE(test_getAttributeNotFound)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    const auto& a = root->getElementByTagName("a", true /*recurse*/);
+    std::string value;
+    const auto result = a.getAttributes().getValue("not_found", value);
+    TEST_ASSERT_FALSE(result);
+
+    TEST_SPECIFIC_EXCEPTION(a.getAttributes().getValue("not_found"), except::NoSuchKeyException);
+}
+
+TEST_CASE(test_getAttributeValue)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    const auto& values = root->getElementByTagName("values", true /*recurse*/);
+
+    {
+        int value;
+        const auto result = getValue(values.getAttributes(), "int", value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ(314, value);
+    }
+    {
+        double value;
+        const auto result = getValue(values.getAttributes(), "double", value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ(3.14, value);
+    }
+    {
+        std::string value;
+        const auto result = getValue(values.getAttributes(), "string", value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ("314", value);
+    }
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(test_getAttribute);
+    TEST_CHECK(test_getAttributeNotFound);
+    TEST_CHECK(test_getAttributeValue);
+}

--- a/modules/c++/xml.lite/unittests/test_xmlelement.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlelement.cpp
@@ -27,8 +27,19 @@
 
 #include "xml/lite/MinidomParser.h"
 
-static const std::string text("TEXT");
-static const std::string strXml = "<root><doc><a>" + text + "</a><b/><b/></doc></root>";
+static const std::string text = "TEXT";
+static const std::string strXml1_ = R"(
+<root>
+    <doc name="doc">
+        <a a="a">)";
+static const std::string strXml2_ = R"(</a><b/><b/>
+        <values int="314" double="3.14" string="314"/>
+        <int>314</int>
+        <double>3.14</double>
+        <string>314</string>
+    </doc>
+</root>)";
+static const auto strXml = strXml1_ + text + strXml2_;
 
 struct test_MinidomParser final
 {
@@ -161,6 +172,65 @@ TEST_CASE(test_getElementByTagName_b)
     TEST_SPECIFIC_EXCEPTION(doc.getElementByTagName("b"), xml::lite::XMLException);
 }
 
+TEST_CASE(test_getValue)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    {
+        const auto& e = root->getElementByTagName("int", true /*recurse*/);
+        int value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ(314, value);
+    }
+    {
+        const auto& e = root->getElementByTagName("double", true /*recurse*/);
+        double value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ(3.14, value);
+    }
+    {
+        const auto& e = root->getElementByTagName("string", true /*recurse*/);
+        std::string value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ("314", value);
+    }
+}
+
+TEST_CASE(test_setValue)
+{
+    test_MinidomParser xmlParser;
+    auto root = xmlParser.getRootElement();
+
+    {
+        auto& e = root->getElementByTagName("int", true /*recurse*/);
+        setValue(e, 123);
+        int value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ(123, value);
+    }
+    {
+        auto& e = root->getElementByTagName("double", true /*recurse*/);
+        setValue(e, 1.23);
+        double value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ(1.23, value);
+    }
+    {
+        auto& e = root->getElementByTagName("string", true /*recurse*/);
+        setValue(e, "123");
+        std::string value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_TRUE(result);
+        TEST_ASSERT_EQ("123", value);
+    }
+}
+
 int main(int, char**)
 {
     TEST_CHECK(test_getRootElement);
@@ -169,4 +239,7 @@ int main(int, char**)
     TEST_CHECK(test_getElementByTagName);
     TEST_CHECK(test_getElementByTagName_nothrow);
     TEST_CHECK(test_getElementByTagName_b);
+
+    TEST_CHECK(test_getValue);
+    TEST_CHECK(test_setValue);
 }

--- a/modules/c++/xml.lite/unittests/test_xmlelement.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlelement.cpp
@@ -33,10 +33,11 @@ static const std::string strXml1_ = R"(
     <doc name="doc">
         <a a="a">)";
 static const std::string strXml2_ = R"(</a><b/><b/>
-        <values int="314" double="3.14" string="314"/>
+        <values int="314" double="3.14" string="abc"/>
         <int>314</int>
         <double>3.14</double>
-        <string>314</string>
+        <string>abc</string>
+        <empty></empty>
     </doc>
 </root>)";
 static const auto strXml = strXml1_ + text + strXml2_;
@@ -196,7 +197,35 @@ TEST_CASE(test_getValue)
         std::string value;
         const auto result = getValue(e, value);
         TEST_ASSERT_TRUE(result);
-        TEST_ASSERT_EQ("314", value);
+        TEST_ASSERT_EQ("abc", value);
+    }
+    {
+        const auto& e = root->getElementByTagName("empty", true /*recurse*/);
+        std::string value;
+        auto result = getValue(e, value);
+        TEST_ASSERT_FALSE(result);
+        value = e.getCharacterData();
+        TEST_ASSERT_TRUE(value.empty());
+    }
+}
+
+
+TEST_CASE(test_getValueFailure)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    {
+        const auto& e = root->getElementByTagName("string", true /*recurse*/);
+        int value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_FALSE(result);
+    }
+    {
+        const auto& e = root->getElementByTagName("string", true /*recurse*/);
+        double value;
+        const auto result = getValue(e, value);
+        TEST_ASSERT_FALSE(result);
     }
 }
 
@@ -223,11 +252,11 @@ TEST_CASE(test_setValue)
     }
     {
         auto& e = root->getElementByTagName("string", true /*recurse*/);
-        setValue(e, "123");
+        setValue(e, "xyz");
         std::string value;
         const auto result = getValue(e, value);
         TEST_ASSERT_TRUE(result);
-        TEST_ASSERT_EQ("123", value);
+        TEST_ASSERT_EQ("xyz", value);
     }
 }
 
@@ -241,5 +270,6 @@ int main(int, char**)
     TEST_CHECK(test_getElementByTagName_b);
 
     TEST_CHECK(test_getValue);
+    TEST_CHECK(test_getValueFailure);
     TEST_CHECK(test_setValue);
 }

--- a/modules/c++/xml.lite/unittests/test_xmlelement.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlelement.cpp
@@ -1,0 +1,172 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "io/StringStream.h"
+#include <TestCase.h>
+
+#include "xml/lite/MinidomParser.h"
+
+static const std::string text("TEXT");
+static const std::string strXml = "<root><doc><a>" + text + "</a><b/><b/></doc></root>";
+
+struct test_MinidomParser final
+{
+    xml::lite::MinidomParser xmlParser;
+    const xml::lite::Element* getRootElement()
+    {
+        io::StringStream ss;
+        ss.stream() << strXml;
+
+        xmlParser.parse(ss);
+        const auto doc = xmlParser.getDocument();
+        return doc->getRootElement();    
+    }
+};
+
+TEST_CASE(test_getRootElement)
+{
+    io::StringStream ss;
+    ss.stream() << strXml;
+    TEST_ASSERT_EQ(ss.stream().str(), strXml);
+
+    xml::lite::MinidomParser xmlParser;
+    xmlParser.parse(ss);
+    const auto doc = xmlParser.getDocument();
+    TEST_ASSERT(doc != nullptr);
+    const auto root = doc->getRootElement();
+    TEST_ASSERT(root != nullptr);
+}
+
+TEST_CASE(test_getElementsByTagName)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+    
+    {
+        const auto aElements = root->getElementsByTagName("a", true /*recurse*/);
+        TEST_ASSERT_EQ(aElements.size(), 1);
+        const auto& a = *(aElements[0]);
+
+        const auto characterData = a.getCharacterData();
+        TEST_ASSERT_EQ(characterData, text);
+    }
+    
+    const auto docElements = root->getElementsByTagName("doc");
+    TEST_ASSERT_FALSE(docElements.empty());
+    TEST_ASSERT_EQ(docElements.size(), 1);
+    {
+        const auto aElements = docElements[0]->getElementsByTagName("a");
+        TEST_ASSERT_EQ(aElements.size(), 1);
+        const auto& a = *(aElements[0]);
+
+        const auto characterData = a.getCharacterData();
+        TEST_ASSERT_EQ(characterData, text);
+        const auto pEncoding = a.getEncoding();
+        TEST_ASSERT_NULL(pEncoding);
+    }
+}
+
+TEST_CASE(test_getElementsByTagName_b)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    {
+        const auto bElements = root->getElementsByTagName("b", true /*recurse*/);
+        TEST_ASSERT_EQ(bElements.size(), 2);
+        const auto& b = *(bElements[0]);
+
+        const auto characterData = b.getCharacterData();
+        TEST_ASSERT_TRUE(characterData.empty());
+    }
+
+    const auto docElements = root->getElementsByTagName("doc");
+    TEST_ASSERT_FALSE(docElements.empty());
+    TEST_ASSERT_EQ(docElements.size(), 1);
+    {
+        const auto bElements = docElements[0]->getElementsByTagName("b");
+        TEST_ASSERT_EQ(bElements.size(), 2);
+        const auto& b = *(bElements[0]);
+
+        const auto characterData = b.getCharacterData();
+        TEST_ASSERT_TRUE(characterData.empty());
+    }
+}
+
+TEST_CASE(test_getElementByTagName)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    {
+        const auto& a = root->getElementByTagName("a", true /*recurse*/);
+        const auto characterData = a.getCharacterData();
+        TEST_ASSERT_EQ(characterData, text);
+    }
+
+    const auto& doc = root->getElementByTagName("doc");
+    {
+        const auto& a = doc.getElementByTagName("a");
+        const auto characterData = a.getCharacterData();
+        TEST_ASSERT_EQ(characterData, text);
+    }
+}
+
+TEST_CASE(test_getElementByTagName_nothrow)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+
+    {
+        const auto pNotFound = root->getElementByTagName(std::nothrow, "not_found", true /*recurse*/);
+        TEST_ASSERT_NULL(pNotFound);
+    }
+
+    const auto& doc = root->getElementByTagName("doc");
+    {
+        const auto pNotFound = doc.getElementByTagName(std::nothrow, "not_found");
+        TEST_ASSERT_NULL(pNotFound);
+    }
+}
+
+TEST_CASE(test_getElementByTagName_b)
+{
+    test_MinidomParser xmlParser;
+    const auto root = xmlParser.getRootElement();
+    
+    TEST_SPECIFIC_EXCEPTION(root->getElementByTagName("b", true /*recurse*/), xml::lite::XMLException);
+
+    const auto& doc = root->getElementByTagName("doc");
+    TEST_SPECIFIC_EXCEPTION(doc.getElementByTagName("b"), xml::lite::XMLException);
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(test_getRootElement);
+    TEST_CHECK(test_getElementsByTagName);
+    TEST_CHECK(test_getElementsByTagName_b);
+    TEST_CHECK(test_getElementByTagName);
+    TEST_CHECK(test_getElementByTagName_nothrow);
+    TEST_CHECK(test_getElementByTagName_b);
+}


### PR DESCRIPTION
A lot of client code does the exact same thing when using `xml.lite`.  This submission tries to incorporate some of the common use-cases, while still being "lite."

Also, add some more unittests for `xml.lite`, in particular to test the new featrues.