### PR TITLE
add sys::Byte

### DIFF
--- a/modules/c++/sys/include/import/sys.h
+++ b/modules/c++/sys/include/import/sys.h
@@ -52,6 +52,7 @@
 #include "sys/String.h"
 #include "sys/Filesystem.h"
 #include "sys/Bit.h"
+#include "sys/CStdDef.h"
 
 /*!
 

--- a/modules/c++/sys/include/sys/CStdDef.h
+++ b/modules/c++/sys/include/sys/CStdDef.h
@@ -1,0 +1,50 @@
+/* =========================================================================
+ * This file is part of sys-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2020, Maxar Technologies, Inc.
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not, http://www.gnu.org/licenses/.
+ *
+ */
+#ifndef CODA_OSS_sys_CStdDef_h_INCLUDED_
+#define CODA_OSS_sys_CStdDef_h_INCLUDED_
+#pragma once
+
+#include <cstddef>
+
+#include "Conf.h"
+
+namespace sys
+{
+	// https://en.cppreference.com/w/cpp/types/byte
+	enum class Byte : unsigned char {};
+}
+
+#ifndef CODA_OSS_DEFINE_std_byte_
+	#if CODA_OSS_cpp17
+		#define CODA_OSS_DEFINE_std_byte_ 0  // std::byte part of C++17
+	#else
+		#define CODA_OSS_DEFINE_std_byte_ CODA_OSS_AUGMENT_std_namespace  // maybe use our own
+	#endif  // CODA_OSS_cpp17
+#endif  // CODA_OSS_DEFINE_std_byte_
+
+#if CODA_OSS_DEFINE_std_byte_ == 1
+	namespace std // This is slightly uncouth: we're not supposed to augment "std".
+	{
+		using byte = sys::Byte;
+	}
+#endif  // CODA_OSS_DEFINE_std_byte_
+
+#endif  // CODA_OSS_sys_CStdDef_h_INCLUDED_

--- a/modules/c++/sys/unittests/test_byte_swap.cpp
+++ b/modules/c++/sys/unittests/test_byte_swap.cpp
@@ -21,8 +21,12 @@
  */
 
 #include "TestCase.h"
+
+#include <array>
+
 #include <sys/Conf.h>
 #include <sys/Bit.h>
+#include <sys/CStdDef.h>
 
 namespace
 {
@@ -114,6 +118,24 @@ TEST_CASE(testEndianness_std)
         TEST_FAIL("Mixed-endian not supported!");
     }
 }
+
+TEST_CASE(testSysByte)
+{
+    std::array<sys::Byte, 256> bytes;
+    for (size_t i = 0; i < bytes.size(); i++)
+    {
+        auto value = static_cast<sys::Byte>(i);
+        bytes[i] = value;
+    }
+
+    const auto actuals = bytes;  // copy
+    TEST_ASSERT_EQ(actuals.size(), bytes.size());
+    for (size_t i = 0; i < actuals.size(); i++)
+    {
+        const auto actual = static_cast<size_t>(actuals[i]);
+        TEST_ASSERT_EQ(i, actual);
+    }
+}
 }
 
 int main(int /*argc*/, char** /*argv*/)
@@ -121,5 +143,6 @@ int main(int /*argc*/, char** /*argv*/)
     TEST_CHECK(testByteSwap);
     TEST_CHECK(testEndianness);
     TEST_CHECK(testEndianness_std);
+    TEST_CHECK(testSysByte);
     return 0;
 }

--- a/modules/c++/sys/unittests/test_byte_swap.cpp
+++ b/modules/c++/sys/unittests/test_byte_swap.cpp
@@ -38,8 +38,9 @@ TEST_CASE(testByteSwap)
     std::vector<sys::Uint64_T> origValues(NUM_PIXELS);
     for (size_t ii = 0; ii < NUM_PIXELS; ++ii)
     {
-        origValues[ii] = static_cast<float>(::rand()) / RAND_MAX *
+        const auto value = static_cast<float>(::rand()) / RAND_MAX *
                 std::numeric_limits<sys::Uint64_T>::max();
+        origValues[ii] = static_cast<sys::Uint64_T>(value);
     }
 
     // Byte swap the old-fashioned way
@@ -62,8 +63,10 @@ TEST_CASE(testByteSwap)
 
 TEST_CASE(testEndianness)
 {
-    if (sys::Endian::native == sys::Endian::big) { }
-    else if (sys::Endian::native == sys::Endian::little) { }
+    /*const*/ auto native = sys::Endian::native; // "const" causes "conditional expression is constant."
+
+    if (native == sys::Endian::big) { }
+    else if (native == sys::Endian::little) { }
     else
     {
         TEST_FAIL("Mixed-endian not supported!");
@@ -71,7 +74,7 @@ TEST_CASE(testEndianness)
 
     const bool isBigEndianSystem = sys::isBigEndianSystem();
 
-    if (sys::Endian::native == sys::Endian::big)
+    if (native == sys::Endian::big)
     {
         TEST_ASSERT(isBigEndianSystem);
     }
@@ -79,7 +82,7 @@ TEST_CASE(testEndianness)
     {
         TEST_ASSERT(!isBigEndianSystem);    
     }
-    if (sys::Endian::native == sys::Endian::little)
+    if (native == sys::Endian::little)
     {
         TEST_ASSERT(!isBigEndianSystem);
     }
@@ -91,23 +94,24 @@ TEST_CASE(testEndianness)
 
     if (isBigEndianSystem)
     {
-        TEST_ASSERT(sys::Endian::native == sys::Endian::big);
+        TEST_ASSERT(native == sys::Endian::big);
     }
     else
     {
-        TEST_ASSERT(sys::Endian::native == sys::Endian::little);    
+        TEST_ASSERT(native == sys::Endian::little);    
     }
 }
 
 TEST_CASE(testEndianness_std)
 {
-    if (sys::Endian::native == sys::Endian::big)
+    /*const*/ auto native = sys::Endian::native; // "const" causes "conditional expression is constant."
+    if (native == sys::Endian::big)
     {
         #if CODA_OSS_cpp20 || CODA_OSS_DEFINE_std_endian_
         TEST_ASSERT(std::endian::native == std::endian::big);
         #endif
     }
-    else if (sys::Endian::native == sys::Endian::little)
+    else if (native == sys::Endian::little)
     {
         #if CODA_OSS_cpp20 || CODA_OSS_DEFINE_std_endian_
         TEST_ASSERT(std::endian::native == std::endian::little);


### PR DESCRIPTION
Create a `sys::Byte` that is the same as `std::byte` in C++17.

Clients can get `std::byte` w/o C++17 by using `CODA_OSS_DEFINE_std_byte_` or `CODA_OSS_AUGMENT_std_namespace`.