### PR TITLE
remove trailing underscore from macro

### DIFF
--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -22,9 +22,11 @@
 
 #ifndef __EXCEPT_THROWABLE_H__
 #define __EXCEPT_THROWABLE_H__
+#pragma once
 
 #include <string>
 #include <sstream>
+#include <exception>
 #include "except/Trace.h"
 
 /*!
@@ -43,17 +45,14 @@ namespace except
  *
  * This class provides the base interface for exceptions and errors.
  */
-class Throwable
+class Throwable : public std::exception
 {
 public:
 
     /*!
      * Default Constructor
      */
-    Throwable() :
-        mMessage("")
-    {
-    }
+    Throwable() = default;
 
     /*!
      * Constructor.  Takes a message
@@ -131,11 +130,20 @@ public:
         return s.str();
     }
 
+    const char* what() const noexcept override final // derived classes override toString()
+    {
+        mWhat = toString(); // call any derived toString()
+        return mWhat.c_str();
+    }
+
 protected:
     //! The name of exception trace
     Trace mTrace;
     //! The name of the message the exception was thrown
     std::string mMessage;
+
+private:
+    mutable std::string mWhat;
 };
 }
 

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -52,12 +52,12 @@ namespace except
  * break existing code as "catch (const std::exception&)" will catch
  * except::Throwable when it didn't before.
  */
-#ifndef CODA_OSS_Throwable_isa_std_exception_
-#define CODA_OSS_Throwable_isa_std_exception_ 0 // preserve existing behavior
-//#define CODA_OSS_Throwable_isa_std_exception_ 1
+#ifndef CODA_OSS_Throwable_isa_std_exception
+#define CODA_OSS_Throwable_isa_std_exception 0  // preserve existing behavior
+//#define CODA_OSS_Throwable_isa_std_exception 1
 #endif
 class Throwable
-#if CODA_OSS_Throwable_isa_std_exception_
+#if CODA_OSS_Throwable_isa_std_exception
     : public std::exception
 #endif
 {
@@ -141,7 +141,7 @@ public:
     }
 
     const char* what() const noexcept
-#if CODA_OSS_Throwable_isa_std_exception_
+#if CODA_OSS_Throwable_isa_std_exception
         override final // derived classes override toString()
 #endif
     {

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -53,6 +53,7 @@ namespace except
  * except::Throwable when it didn't before.
  */
 #ifndef CODA_OSS_Throwable_isa_std_exception_
+#define CODA_OSS_Throwable_isa_std_exception_ 0 // preserve existing behavior
 //#define CODA_OSS_Throwable_isa_std_exception_ 1
 #endif
 class Throwable

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -45,13 +45,22 @@ namespace except
  *
  * This class provides the base interface for exceptions and errors.
  */
-class Throwable : public std::exception
+
+/*
+ * It can be quite convenient to derive from std::exception as often one less
+ * "catch" will be needed and we'll have standard what().  But doing so could
+ * break existing code as "catch (const std::exception&)" will catch
+ * except::Throwable when it didn't before.
+ */
+#ifndef CODA_OSS_Throwable_isa_std_exception_
+//#define CODA_OSS_Throwable_isa_std_exception_ 1
+#endif
+class Throwable
+#if CODA_OSS_Throwable_isa_std_exception_
+    : public std::exception
+#endif
 {
 public:
-
-    /*!
-     * Default Constructor
-     */
     Throwable() = default;
 
     /*!
@@ -130,7 +139,10 @@ public:
         return s.str();
     }
 
-    const char* what() const noexcept override final // derived classes override toString()
+    const char* what() const noexcept
+#if CODA_OSS_Throwable_isa_std_exception_
+        override final // derived classes override toString()
+#endif
     {
         mWhat = toString(); // call any derived toString()
         return mWhat.c_str();

--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -57,7 +57,6 @@
 #  define TEST_CASE(X) void X(std::string testName)
 
 #define TEST_MAIN(X) int main(int argc, char** argv) {  try { X;  return EXIT_SUCCESS; } \
-catch (const except::Exception& ex) { std::cerr << ex.toString() << std::endl; } \
 catch (const std::exception& e)  { std::cerr << e.what() << std::endl; } \
 catch (...) { std::cerr << "Unknown exception\n"; } \
 return EXIT_FAILURE; }

--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -57,7 +57,7 @@
 #  define TEST_CASE(X) void X(std::string testName)
 
 #define TEST_MAIN_catch_std_exception_ catch (const std::exception& e)  { std::cerr << e.what() << std::endl; }
-#if CODA_OSS_Throwable_isa_std_exception_
+#if CODA_OSS_Throwable_isa_std_exception
 #define TEST_MAIN_catch_ TEST_MAIN_catch_std_exception_
 #else
 #define TEST_MAIN_catch_ catch (const except::Exception& ex) { std::cerr << ex.toString() << std::endl; } \

--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -56,9 +56,15 @@
 #  define TEST_SPECIFIC_EXCEPTION(X,Y) try{ (X); die_printf("%s (%s,%s,%d): FAILED: Should have thrown exception: " # Y ,  testName.c_str(), __FILE__, SYS_FUNC, __LINE__); } catch(Y&) { }  catch (except::Throwable&){ die_printf("%s (%s,%s,%d): FAILED: Should have thrown exception: " # Y ,  testName.c_str(), __FILE__, SYS_FUNC, __LINE__);}
 #  define TEST_CASE(X) void X(std::string testName)
 
+#define TEST_MAIN_catch_std_exception_ catch (const std::exception& e)  { std::cerr << e.what() << std::endl; }
+#if CODA_OSS_Throwable_isa_std_exception_
+#define TEST_MAIN_catch_ TEST_MAIN_catch_std_exception_
+#else
+#define TEST_MAIN_catch_ catch (const except::Exception& ex) { std::cerr << ex.toString() << std::endl; } \
+    TEST_MAIN_catch_std_exception_
+#endif
 #define TEST_MAIN(X) int main(int argc, char** argv) {  try { X;  return EXIT_SUCCESS; } \
-catch (const std::exception& e)  { std::cerr << e.what() << std::endl; } \
-catch (...) { std::cerr << "Unknown exception\n"; } \
+TEST_MAIN_catch_ catch (...) { std::cerr << "Unknown exception\n"; } \
 return EXIT_FAILURE; }
 
 #else /* C only */


### PR DESCRIPTION
Clients can determine whether `Throwable` derives from `std::exception`, so the macro shouldn't be "private."