### PR TITLE
add mem::auto_ptr for transition to C++17

### DIFF
--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -137,8 +137,16 @@ void unique(TArgs&&...) = delete;
 #if !CODA_OSS_cpp14 // C++14 has std::make_unique
 namespace std
 {
-    template<typename T>
-    using make_unique = mem::make::unique<T>;
+template <typename T, typename... TArgs>
+std::unique_ptr<T> make_unique(TArgs&&... args)
+{
+    return mem::make::unique<T>(std::forward<TArgs>(args)...);
+}
+template <typename T>
+std::unique_ptr<T> make_unique(size_t size)
+{
+    return mem::make::unique<T>(size);
+}
 }
 #endif //CODA_OSS_cpp14
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -140,12 +140,8 @@ namespace std
 template <typename T, typename... TArgs>
 std::unique_ptr<T> make_unique(TArgs&&... args)
 {
+    // let mem::make::unique to all the template magic
     return mem::make::unique<T>(std::forward<TArgs>(args)...);
-}
-template <typename T>
-std::unique_ptr<T> make_unique(size_t size)
-{
-    return mem::make::unique<T>(size);
 }
 }
 #endif //CODA_OSS_cpp14

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 
 #include "sys/Conf.h"
 
@@ -108,7 +109,38 @@ template <typename T>
 using auto_ptr = std::unique_ptr<T>;
 #endif
 
+// C++11 inadvertently ommitted make_unique; provide it here. (Swiped from <memory>.)
+namespace make
+{
+// Using a nested namespace in case somebody does both
+// "using namespace std" and "using namespace mem".
 
+template <typename T, typename... TArgs, typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
+std::unique_ptr<T> unique(TArgs&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<TArgs>(args)...));
 }
+
+template <typename T, typename std::enable_if<std::is_array<T>::value &&  std::extent<T>::value == 0, int>::type = 0>
+std::unique_ptr<T> unique(size_t size)
+{
+    using element_t = std::remove_extent<T>::type;
+    return unique_ptr<T>(new element_t[size]());
+}
+
+template <typename T, typename... TArgs, typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>
+void unique(TArgs&&...) = delete;
+}  // namespace make
+} // namespace mem
+
+#if CODA_OSS_AUGMENT_std_namespace
+#if !CODA_OSS_cpp14 // C++14 has std::make_unique
+namespace std
+{
+    template<typename T>
+    using make_unique = mem::make::unique<T>; // is this right ... ?
+}
+#endif //CODA_OSS_cpp14
+#endif
 
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -138,7 +138,7 @@ void unique(TArgs&&...) = delete;
 namespace std
 {
     template<typename T>
-    using make_unique = mem::make::unique<T>; // is this right ... ?
+    using make_unique = mem::make::unique<T>;
 }
 #endif //CODA_OSS_cpp14
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -22,8 +22,11 @@
 
 #ifndef __MEM_SHARED_PTR_CPP_11_H__
 #define __MEM_SHARED_PTR_CPP_11_H__
+#pragma once
 
 #include <memory>
+
+#include "sys/Conf.h"
 
 namespace mem
 {
@@ -51,6 +54,23 @@ public:
 
     using std::shared_ptr<T>::reset;
 
+    explicit SharedPtr(std::unique_ptr<T>&& ptr) :
+        std::shared_ptr<T>(ptr.release())
+    {
+    }
+
+    template <typename OtherT>
+    explicit SharedPtr(std::unique_ptr<OtherT>&& ptr) :
+        std::shared_ptr<T>(ptr.release())
+    {
+    }
+
+    void reset(std::unique_ptr<T>&& scopedPtr)
+    {
+        std::shared_ptr<T>::reset(scopedPtr.release());
+    }
+
+    #if !CODA_OSS_cpp17  // std::auto_ptr removed in C++17
     // The base class only handles auto_ptr<T>&&
     explicit SharedPtr(std::auto_ptr<T> ptr) :
         std::shared_ptr<T>(ptr.release())
@@ -68,6 +88,7 @@ public:
     {
         std::shared_ptr<T>::reset(scopedPtr.release());
     }
+    #endif
 
     // Implemented to support the legacy SharedPtr. Prefer use_count.
     long getCount() const
@@ -75,6 +96,19 @@ public:
         return std::shared_ptr<T>::use_count();
     }
 };
+
+// This won't work everywhere since C++11's std::unique_ptr<> often requries "&&" and std::move.
+// But for member data and the like it can reduce some boiler-plate code; note that it's often
+// possible to just use std::unique_ptr directly.  This is mostly needed to support existing interfaces.
+#if !CODA_OSS_cpp17  // std::auto_ptr removed in C++17
+template<typename T>
+using auto_ptr = std::auto_ptr<T>;
+#else
+template <typename T>
+using auto_ptr = std::unique_ptr<T>;
+#endif
+
+
 }
 
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -124,8 +124,8 @@ std::unique_ptr<T> unique(TArgs&&... args)
 template <typename T, typename std::enable_if<std::is_array<T>::value &&  std::extent<T>::value == 0, int>::type = 0>
 std::unique_ptr<T> unique(size_t size)
 {
-    using element_t = std::remove_extent<T>::type;
-    return unique_ptr<T>(new element_t[size]());
+    using element_t = typename std::remove_extent<T>::type;
+    return std::unique_ptr<T>(new element_t[size]());
 }
 
 template <typename T, typename... TArgs, typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -60,6 +60,8 @@ TEST_CASE(testStdUniquePtr)
     {
         auto pFoos = mem::make::unique<Foo[]>(123);  // 123 instances of Foo
         TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+        TEST_ASSERT_EQ(0, pFoos[0].mVal);
+        TEST_ASSERT_EQ(0, pFoos[122].mVal);
     }
 
 #if CODA_OSS_AUGMENT_std_namespace || CODA_OSS_cpp14
@@ -71,6 +73,8 @@ TEST_CASE(testStdUniquePtr)
     {
         auto pFoos = std::make_unique<Foo[]>(123); // 123 instances of Foo
         TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+        TEST_ASSERT_EQ(0, pFoos[0].mVal);
+        TEST_ASSERT_EQ(0, pFoos[122].mVal);
     }
 #endif
 }

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -1,0 +1,82 @@
+/* =========================================================================
+ * This file is part of mem-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * mem-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define CODA_OSS_AUGMENT_std_namespace 1 // get std::make_unique
+
+#include <config/coda_oss_config.h>
+#include <mem/SharedPtr.h>
+
+#include "TestCase.h"
+
+namespace
+{
+struct Foo final
+{
+    Foo() = default;
+    Foo(size_t val) :
+        mVal(val)
+    {
+    }
+
+    size_t mVal = 0;
+};
+
+TEST_CASE(testStdUniquePtr)
+{
+    {
+        std::unique_ptr<Foo> fooCtor;
+        TEST_ASSERT_NULL(fooCtor.get());
+
+        fooCtor.reset(new Foo(123));
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        auto fooCtor = mem::make::unique<Foo>(123);
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        auto pFoos = mem::make::unique<Foo[]>(123);  // 123 instances of Foo
+        TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+    }
+
+#if CODA_OSS_AUGMENT_std_namespace
+    {
+        auto fooCtor = std::make_unique<Foo>(123);
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        auto pFoos = std::make_unique<Foo[]>(123); // 123 instances of Foo
+        TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+    }
+#endif
+}
+}
+
+int main(int, char**)
+{
+   TEST_CHECK(testStdUniquePtr);
+
+   return 0;
+}

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -20,7 +20,9 @@
  *
  */
 
+#if !defined(CODA_OSS_AUGMENT_std_namespace)
 #define CODA_OSS_AUGMENT_std_namespace 1 // get std::make_unique
+#endif
 
 #include <config/coda_oss_config.h>
 #include <mem/SharedPtr.h>
@@ -60,7 +62,7 @@ TEST_CASE(testStdUniquePtr)
         TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
     }
 
-#if CODA_OSS_AUGMENT_std_namespace
+#if CODA_OSS_AUGMENT_std_namespace || CODA_OSS_cpp14
     {
         auto fooCtor = std::make_unique<Foo>(123);
         TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());

--- a/modules/c++/mem/wscript
+++ b/modules/c++/mem/wscript
@@ -1,5 +1,4 @@
 NAME            = 'mem'
-MAINTAINER      = 'asylvest@users.sourceforge.net'
 VERSION         = '1.0'
 MODULE_DEPS     = 'sys'
 TEST_DEPS       = 'cli'


### PR DESCRIPTION
`std::auto_ptr` has been removed in C++17 (it has been depreciated since C++11, use `std::unique_ptr`).

For return values and member data, `std::unique_ptr` is often a drop-in replacement for `std::auto_ptr`, no code changes needed.  By providing `mem::auto_ptr` as an alias for one or the other; code can build with C++17 while still supporting C++11.

Note that parameters often need to be `std::unique_ptr&&` and used with `std::move`.  But since `std::unique_ptr` is part of C++11, overloading works:
```
    void foo(std::unique_ptr<T>&&); // explicit support for std::unique_ptr
    void foo(mem::auto_ptr<T>); // existing code
