### PR TITLE
more straight-forward reduction of std::auto_ptr

### DIFF
--- a/modules/c++/cli/source/ArgumentParser.cpp
+++ b/modules/c++/cli/source/ArgumentParser.cpp
@@ -368,7 +368,7 @@ cli::Results* cli::ArgumentParser::parse(const std::vector<std::string>& args)
         }
     }
 
-    std::auto_ptr<cli::Results> results(new Results);
+    auto results = mem::make::unique<cli::Results>();
     cli::Results *currentResults = NULL;
     for (size_t i = 0, s = explodedArgs.size(); i < s; ++i)
     {

--- a/modules/c++/cli/unittests/test_cli.cpp
+++ b/modules/c++/cli/unittests/test_cli.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <import/cli.h>
+#include <import/mem.h>
 #include "TestCase.h"
 #include <sstream>
 
@@ -74,7 +75,7 @@ TEST_CASE(testChoices)
     std::ostringstream buf;
     parser.printHelp(buf);
 
-    std::auto_ptr<cli::Results> results(parser.parse(str::split("-v", " ")));
+    mem::auto_ptr<cli::Results> results(parser.parse(str::split("-v", " ")));
     TEST_ASSERT(results->hasValue("verbose"));
     TEST_ASSERT(results->get<bool>("verbose", 0));
 
@@ -103,7 +104,7 @@ TEST_CASE(testMultiple)
     parser.setProgram("tester");
     parser.addArgument("-v --verbose --loud -l", "Toggle verbose", cli::STORE_TRUE);
 
-    std::auto_ptr<cli::Results> results(parser.parse(str::split("-v")));
+    mem::auto_ptr<cli::Results> results(parser.parse(str::split("-v")));
     TEST_ASSERT(results->hasValue("verbose"));
     TEST_ASSERT(results->get<bool>("verbose"));
 
@@ -126,7 +127,7 @@ TEST_CASE(testSubOptions)
     std::ostringstream buf;
     parser.printHelp(buf);
 
-    std::auto_ptr<cli::Results> results(parser.parse(str::split("-x:special")));
+    mem::auto_ptr<cli::Results> results(parser.parse(str::split("-x:special")));
     TEST_ASSERT(results->hasSubResults("extra"));
     TEST_ASSERT(results->getSubResults("extra")->get<bool>("special"));
 
@@ -150,7 +151,7 @@ TEST_CASE(testIterate)
     parser.addArgument("-v --verbose", "Toggle verbose", cli::STORE_TRUE);
     parser.addArgument("-c --config", "Specify a config file", cli::STORE);
 
-    std::auto_ptr<cli::Results>
+    mem::auto_ptr<cli::Results>
             results(parser.parse(str::split("-v -c config.xml")));
     std::vector<std::string> keys;
     for(cli::Results::const_iterator it = results->begin(); it != results->end(); ++it)
@@ -168,7 +169,7 @@ TEST_CASE(testRequired)
     parser.addArgument("-v --verbose", "Toggle verbose", cli::STORE_TRUE);
     parser.addArgument("-c --config", "Specify a config file", cli::STORE)->setRequired(true);
 
-    std::auto_ptr<cli::Results> results;
+    mem::auto_ptr<cli::Results> results;
     TEST_EXCEPTION(results.reset(parser.parse(str::split(""))));
     TEST_EXCEPTION(results.reset(parser.parse(str::split("-c"))));
     results.reset(parser.parse(str::split("-c configFile")));

--- a/modules/c++/dbi/include/dbi/DatabaseConnection.h
+++ b/modules/c++/dbi/include/dbi/DatabaseConnection.h
@@ -31,6 +31,7 @@
 #include "except/Exception.h"
 #include "str/Convert.h"
 #include "sys/Conf.h"
+#include "mem/SharedPtr.h"
 
 /*!
  * \file DatabaseConnection.h
@@ -259,7 +260,7 @@ protected:
     std::vector< Field > mData;
 };
 
-//typedef std::auto_ptr< Row > pRow;
+//typedef mem::auto_ptr< Row > pRow;
 
 /*!
  *  \class ResultSet
@@ -301,7 +302,7 @@ protected:
     Row mCurrentRow;
 };
 
-typedef std::auto_ptr< ResultSet > pResultSet;
+typedef mem::auto_ptr< ResultSet > pResultSet;
 
 /*!
  * \class DatabaseConnection

--- a/modules/c++/dbi/source/MySQLConnection.cpp
+++ b/modules/c++/dbi/source/MySQLConnection.cpp
@@ -100,7 +100,7 @@ dbi::Row dbi::MySQLResultSet::fetchRow()
     }
 
     // Create a result set auto pointer and give it to the user
-    //std::auto_ptr< Row > row(new Row);
+    //std::unique_ptr< Row > row(new Row);
     dbi::Row row;
 
     for (int i = 0; i < numFields; i++)

--- a/modules/c++/dbi/source/PgSQLConnection.cpp
+++ b/modules/c++/dbi/source/PgSQLConnection.cpp
@@ -106,7 +106,7 @@ dbi::Row dbi::PgSQLResultSet::fetchRow()
     int numFields = PQnfields(mResults);
 
     // Create a result set auto pointer and give it to the user
-    //std::auto_ptr< Row > row(new Row);
+    //std::unique_ptr< Row > row(new Row);
     dbi::Row row;
 
     for (int i = 0; i < numFields; i++)

--- a/modules/c++/io/include/io/DbgStream.h
+++ b/modules/c++/io/include/io/DbgStream.h
@@ -23,8 +23,10 @@
 #ifndef __DBG_STREAM_H__
 #define __DBG_STREAM_H__
 
-#include "io/OutputStream.h"
 #include <memory>
+
+#include "io/OutputStream.h"
+#include "mem/SharedPtr.h"
 
 
 /*!
@@ -116,7 +118,7 @@ public:
     }
 protected:
     //!  The bound stream
-    std::auto_ptr<OutputStream> mStream;
+    mem::auto_ptr<OutputStream> mStream;
     //!  On or off??
     bool mOn;
 };

--- a/modules/c++/io/include/io/ProxyStreams.h
+++ b/modules/c++/io/include/io/ProxyStreams.h
@@ -26,6 +26,7 @@
 #include "io/InputStream.h"
 #include "io/OutputStream.h"
 #include "io/NullStreams.h"
+#include "mem/SharedPtr.h"
 
 namespace io
 {
@@ -63,7 +64,7 @@ protected:
         return mProxy->read(buffer, len);
     }
 
-    std::auto_ptr<InputStream> mProxy;
+    mem::auto_ptr<InputStream> mProxy;
     bool mOwnPtr;
 };
 
@@ -110,7 +111,7 @@ public:
     }
 
 protected:
-    std::auto_ptr<OutputStream> mProxy;
+    mem::auto_ptr<OutputStream> mProxy;
     bool mOwnPtr;
 };
 

--- a/modules/c++/logging/include/logging/Setup.h
+++ b/modules/c++/logging/include/logging/Setup.h
@@ -26,6 +26,7 @@
 #include <memory>
 #include <string>
 
+#include "mem/SharedPtr.h"
 #include "logging/Logger.h"
 
 namespace logging
@@ -45,7 +46,7 @@ namespace logging
  *  \param logCount - number of rotating logs to keep (default: 0 no rotation)
  *  \param logBytes - number of bytes per rotating log (default: 0 no rotation)
  */
-std::auto_ptr<logging::Logger> setupLogger(
+mem::auto_ptr<logging::Logger> setupLogger(
     const std::string& program, 
     const std::string& logLevel = "warning", 
     const std::string& logFile = "console",

--- a/modules/c++/logging/include/logging/StreamHandler.h
+++ b/modules/c++/logging/include/logging/StreamHandler.h
@@ -31,6 +31,7 @@
 #include "logging/LogRecord.h"
 #include "logging/Handler.h"
 #include <import/io.h>
+#include <mem/SharedPtr.h>
 
 namespace logging
 {
@@ -68,7 +69,7 @@ protected:
     // used for the bulk of the logging for speed
     virtual void emitRecord(const LogRecord* record);
 
-    std::auto_ptr<io::OutputStream> mStream;
+    mem::auto_ptr<io::OutputStream> mStream;
 
 private:
     bool mClosed;

--- a/modules/c++/logging/source/Setup.cpp
+++ b/modules/c++/logging/source/Setup.cpp
@@ -30,7 +30,7 @@
 
 #include "logging/Setup.h"
 
-std::auto_ptr<logging::Logger>
+mem::auto_ptr<logging::Logger>
 logging::setupLogger(const std::string& program, 
                      const std::string& logLevel, 
                      const std::string& logFile,
@@ -38,7 +38,7 @@ logging::setupLogger(const std::string& program,
                      size_t logCount,
                      size_t logBytes)
 {
-    std::auto_ptr<logging::Logger> log(new logging::Logger(program));
+    mem::auto_ptr<logging::Logger> log(new logging::Logger(program));
 
     // setup logging level
     std::string lev = logLevel;
@@ -48,7 +48,7 @@ logging::setupLogger(const std::string& program,
                                               logging::LogLevel(lev);
 
     // setup logging formatter
-    std::auto_ptr <logging::Formatter> formatter;
+    std::unique_ptr <logging::Formatter> formatter;
     std::string file = logFile;
     str::lower(file);
     if (str::endsWith(file, ".xml"))
@@ -62,7 +62,7 @@ logging::setupLogger(const std::string& program,
     }
     
     // setup logging handler
-    std::auto_ptr < logging::Handler > logHandler;
+    std::unique_ptr<logging::Handler> logHandler;
     if (file.empty() || file == "console")
         logHandler.reset(new logging::StreamHandler());
     else

--- a/modules/c++/logging/unittests/test_exception_logger.cpp
+++ b/modules/c++/logging/unittests/test_exception_logger.cpp
@@ -57,7 +57,7 @@ sys::Mutex RunNothing::counterLock;
 
 TEST_CASE(testExceptionLogger)
 {
-    std::auto_ptr<logging::Logger> log(new logging::Logger("test"));
+    std::unique_ptr<logging::Logger> log(new logging::Logger("test"));
 
     mem::SharedPtr<logging::ExceptionLogger> exLog(new logging::ExceptionLogger(log.get()));
 

--- a/modules/c++/logging/unittests/test_rotating_log.cpp
+++ b/modules/c++/logging/unittests/test_rotating_log.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <import/logging.h>
+#include <import/mem.h>
 #include "TestCase.h"
 
 void cleanupFiles(std::string base)
@@ -50,11 +51,9 @@ TEST_CASE(testRotate)
 
     sys::OS os;
     {
-        std::auto_ptr<logging::Logger> log(new logging::Logger("test"));
-        std::auto_ptr<logging::Formatter>
-                formatter(new logging::StandardFormatter("%m"));
-        std::auto_ptr<logging::Handler>
-                logHandler(new logging::RotatingFileHandler(outFile, 10, maxFiles));
+        auto log = mem::make::unique<logging::Logger>("test");
+        auto formatter = mem::make::unique<logging::StandardFormatter>("%m");
+        auto logHandler = mem::make::unique<logging::RotatingFileHandler>(outFile, 10, maxFiles);
 
         logHandler->setLevel(logging::LogLevel::LOG_DEBUG);
         logHandler->setFormatter(formatter.release());
@@ -78,11 +77,9 @@ TEST_CASE(testNeverRotate)
 
     sys::OS os;
     {
-        std::auto_ptr<logging::Logger> log(new logging::Logger("test"));
-        std::auto_ptr<logging::Formatter>
-                formatter(new logging::StandardFormatter("%m"));
-        std::auto_ptr<logging::Handler>
-                logHandler(new logging::RotatingFileHandler(outFile));
+        auto log = mem::make::unique<logging::Logger>("test");
+        auto formatter = mem::make::unique<logging::StandardFormatter>("%m");
+        auto logHandler = mem::make::unique<logging::RotatingFileHandler>(outFile);
 
         for(size_t i = 0; i < 1024; ++i)
         {
@@ -102,11 +99,9 @@ TEST_CASE(testRotateReset)
 
     sys::OS os;
     {
-        std::auto_ptr<logging::Logger> log(new logging::Logger("test"));
-        std::auto_ptr<logging::Formatter>
-                formatter(new logging::StandardFormatter("%m"));
-        std::auto_ptr<logging::Handler>
-                logHandler(new logging::RotatingFileHandler(outFile, 10));
+        auto log = mem::make::unique<logging::Logger>("test");
+        auto formatter = mem::make::unique<logging::StandardFormatter>("%m");
+        auto logHandler = mem::make::unique<logging::RotatingFileHandler>(outFile, 10);
         log->debug("01234567890");
         TEST_ASSERT(os.exists(outFile));
         TEST_ASSERT_FALSE(os.isFile(outFile + ".1"));

--- a/modules/c++/mem/include/mem/ScopedCloneablePtr.h
+++ b/modules/c++/mem/include/mem/ScopedCloneablePtr.h
@@ -133,7 +133,7 @@ public:
     }
 
 private:
-    std::auto_ptr<T> mPtr;
+    std::unique_ptr<T> mPtr;
 };
 }
 

--- a/modules/c++/mem/include/mem/ScopedCopyablePtr.h
+++ b/modules/c++/mem/include/mem/ScopedCopyablePtr.h
@@ -140,7 +140,7 @@ public:
     }
 
 private:
-    std::auto_ptr<T> mPtr;
+    std::unique_ptr<T> mPtr;
 };
 }
 

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -137,8 +137,16 @@ void unique(TArgs&&...) = delete;
 #if !CODA_OSS_cpp14 // C++14 has std::make_unique
 namespace std
 {
-    template<typename T>
-    using make_unique = mem::make::unique<T>;
+template <typename T, typename... TArgs>
+std::unique_ptr<T> make_unique(TArgs&&... args)
+{
+    return mem::make::unique<T>(std::forward<TArgs>(args)...);
+}
+template <typename T>
+std::unique_ptr<T> make_unique(size_t size)
+{
+    return mem::make::unique<T>(size);
+}
 }
 #endif //CODA_OSS_cpp14
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -140,12 +140,8 @@ namespace std
 template <typename T, typename... TArgs>
 std::unique_ptr<T> make_unique(TArgs&&... args)
 {
+    // let mem::make::unique to all the template magic
     return mem::make::unique<T>(std::forward<TArgs>(args)...);
-}
-template <typename T>
-std::unique_ptr<T> make_unique(size_t size)
-{
-    return mem::make::unique<T>(size);
 }
 }
 #endif //CODA_OSS_cpp14

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 
 #include "sys/Conf.h"
 
@@ -108,7 +109,38 @@ template <typename T>
 using auto_ptr = std::unique_ptr<T>;
 #endif
 
+// C++11 inadvertently ommitted make_unique; provide it here. (Swiped from <memory>.)
+namespace make
+{
+// Using a nested namespace in case somebody does both
+// "using namespace std" and "using namespace mem".
 
+template <typename T, typename... TArgs, typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
+std::unique_ptr<T> unique(TArgs&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<TArgs>(args)...));
 }
+
+template <typename T, typename std::enable_if<std::is_array<T>::value &&  std::extent<T>::value == 0, int>::type = 0>
+std::unique_ptr<T> unique(size_t size)
+{
+    using element_t = std::remove_extent<T>::type;
+    return unique_ptr<T>(new element_t[size]());
+}
+
+template <typename T, typename... TArgs, typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>
+void unique(TArgs&&...) = delete;
+}  // namespace make
+} // namespace mem
+
+#if CODA_OSS_AUGMENT_std_namespace
+#if !CODA_OSS_cpp14 // C++14 has std::make_unique
+namespace std
+{
+    template<typename T>
+    using make_unique = mem::make::unique<T>; // is this right ... ?
+}
+#endif //CODA_OSS_cpp14
+#endif
 
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -138,7 +138,7 @@ void unique(TArgs&&...) = delete;
 namespace std
 {
     template<typename T>
-    using make_unique = mem::make::unique<T>; // is this right ... ?
+    using make_unique = mem::make::unique<T>;
 }
 #endif //CODA_OSS_cpp14
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -22,8 +22,11 @@
 
 #ifndef __MEM_SHARED_PTR_CPP_11_H__
 #define __MEM_SHARED_PTR_CPP_11_H__
+#pragma once
 
 #include <memory>
+
+#include "sys/Conf.h"
 
 namespace mem
 {
@@ -51,6 +54,23 @@ public:
 
     using std::shared_ptr<T>::reset;
 
+    explicit SharedPtr(std::unique_ptr<T>&& ptr) :
+        std::shared_ptr<T>(ptr.release())
+    {
+    }
+
+    template <typename OtherT>
+    explicit SharedPtr(std::unique_ptr<OtherT>&& ptr) :
+        std::shared_ptr<T>(ptr.release())
+    {
+    }
+
+    void reset(std::unique_ptr<T>&& scopedPtr)
+    {
+        std::shared_ptr<T>::reset(scopedPtr.release());
+    }
+
+    #if !CODA_OSS_cpp17  // std::auto_ptr removed in C++17
     // The base class only handles auto_ptr<T>&&
     explicit SharedPtr(std::auto_ptr<T> ptr) :
         std::shared_ptr<T>(ptr.release())
@@ -68,6 +88,7 @@ public:
     {
         std::shared_ptr<T>::reset(scopedPtr.release());
     }
+    #endif
 
     // Implemented to support the legacy SharedPtr. Prefer use_count.
     long getCount() const
@@ -75,6 +96,19 @@ public:
         return std::shared_ptr<T>::use_count();
     }
 };
+
+// This won't work everywhere since C++11's std::unique_ptr<> often requries "&&" and std::move.
+// But for member data and the like it can reduce some boiler-plate code; note that it's often
+// possible to just use std::unique_ptr directly.  This is mostly needed to support existing interfaces.
+#if !CODA_OSS_cpp17  // std::auto_ptr removed in C++17
+template<typename T>
+using auto_ptr = std::auto_ptr<T>;
+#else
+template <typename T>
+using auto_ptr = std::unique_ptr<T>;
+#endif
+
+
 }
 
 #endif

--- a/modules/c++/mem/include/mem/SharedPtrCpp11.h
+++ b/modules/c++/mem/include/mem/SharedPtrCpp11.h
@@ -124,8 +124,8 @@ std::unique_ptr<T> unique(TArgs&&... args)
 template <typename T, typename std::enable_if<std::is_array<T>::value &&  std::extent<T>::value == 0, int>::type = 0>
 std::unique_ptr<T> unique(size_t size)
 {
-    using element_t = std::remove_extent<T>::type;
-    return unique_ptr<T>(new element_t[size]());
+    using element_t = typename std::remove_extent<T>::type;
+    return std::unique_ptr<T>(new element_t[size]());
 }
 
 template <typename T, typename... TArgs, typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>

--- a/modules/c++/mem/unittests/test_shared_ptr.cpp
+++ b/modules/c++/mem/unittests/test_shared_ptr.cpp
@@ -90,7 +90,7 @@ TEST_CASE(testNullCopying)
 TEST_CASE(testAutoPtrConstructor)
 {
     int * const rawPtr(new int(89));
-    std::auto_ptr<int> autoPtr(rawPtr);
+    mem::auto_ptr<int> autoPtr(rawPtr);
     const mem::SharedPtr<int> ptr(autoPtr);
     TEST_ASSERT_EQ(ptr.get(), rawPtr);
     TEST_ASSERT_EQ(autoPtr.get(), static_cast<int *>(NULL));
@@ -102,7 +102,7 @@ TEST_CASE(testAutoPtrReset)
     // Similar to the construction test,
     // except using the reset() that takes an auto_ptr
     int* const rawPtr1 = new int(90);
-    std::auto_ptr<int> autoPtr(rawPtr1);
+    mem::auto_ptr<int> autoPtr(rawPtr1);
 
     int* const rawPtr2 = new int(100);
     mem::SharedPtr<int> sharedPtr(rawPtr2);
@@ -119,7 +119,7 @@ TEST_CASE(testAutoPtrReset)
 TEST_CASE(testCopying)
 {
     int * const rawPtr(new int(89));
-    std::auto_ptr<mem::SharedPtr<int> > ptr3;
+    mem::auto_ptr<mem::SharedPtr<int>> ptr3;
     {
         mem::SharedPtr<int> ptr1(rawPtr);
         TEST_ASSERT_EQ(ptr1.get(), rawPtr);
@@ -220,7 +220,7 @@ TEST_CASE(testCasting)
     {
         // Test creating SharedPtr of base class from auto pointer of derived
         Bar* const rawBar(new Bar(456));
-        std::auto_ptr<Bar> autoBar(rawBar);
+        mem::auto_ptr<Bar> autoBar(rawBar);
         const mem::SharedPtr<Foo> fooPtr(autoBar);
         TEST_ASSERT_EQ(fooPtr.get(), rawBar);
         TEST_ASSERT_EQ(autoBar.get(), static_cast<Bar *>(NULL));

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -60,6 +60,8 @@ TEST_CASE(testStdUniquePtr)
     {
         auto pFoos = mem::make::unique<Foo[]>(123);  // 123 instances of Foo
         TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+        TEST_ASSERT_EQ(0, pFoos[0].mVal);
+        TEST_ASSERT_EQ(0, pFoos[122].mVal);
     }
 
 #if CODA_OSS_AUGMENT_std_namespace || CODA_OSS_cpp14
@@ -71,6 +73,8 @@ TEST_CASE(testStdUniquePtr)
     {
         auto pFoos = std::make_unique<Foo[]>(123); // 123 instances of Foo
         TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+        TEST_ASSERT_EQ(0, pFoos[0].mVal);
+        TEST_ASSERT_EQ(0, pFoos[122].mVal);
     }
 #endif
 }

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -1,0 +1,82 @@
+/* =========================================================================
+ * This file is part of mem-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ *
+ * mem-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define CODA_OSS_AUGMENT_std_namespace 1 // get std::make_unique
+
+#include <config/coda_oss_config.h>
+#include <mem/SharedPtr.h>
+
+#include "TestCase.h"
+
+namespace
+{
+struct Foo final
+{
+    Foo() = default;
+    Foo(size_t val) :
+        mVal(val)
+    {
+    }
+
+    size_t mVal = 0;
+};
+
+TEST_CASE(testStdUniquePtr)
+{
+    {
+        std::unique_ptr<Foo> fooCtor;
+        TEST_ASSERT_NULL(fooCtor.get());
+
+        fooCtor.reset(new Foo(123));
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        auto fooCtor = mem::make::unique<Foo>(123);
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        auto pFoos = mem::make::unique<Foo[]>(123);  // 123 instances of Foo
+        TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+    }
+
+#if CODA_OSS_AUGMENT_std_namespace
+    {
+        auto fooCtor = std::make_unique<Foo>(123);
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        auto pFoos = std::make_unique<Foo[]>(123); // 123 instances of Foo
+        TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
+    }
+#endif
+}
+}
+
+int main(int, char**)
+{
+   TEST_CHECK(testStdUniquePtr);
+
+   return 0;
+}

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -20,7 +20,9 @@
  *
  */
 
+#if !defined(CODA_OSS_AUGMENT_std_namespace)
 #define CODA_OSS_AUGMENT_std_namespace 1 // get std::make_unique
+#endif
 
 #include <config/coda_oss_config.h>
 #include <mem/SharedPtr.h>
@@ -60,7 +62,7 @@ TEST_CASE(testStdUniquePtr)
         TEST_ASSERT_NOT_EQ(nullptr, pFoos.get());
     }
 
-#if CODA_OSS_AUGMENT_std_namespace
+#if CODA_OSS_AUGMENT_std_namespace || CODA_OSS_cpp14
     {
         auto fooCtor = std::make_unique<Foo>(123);
         TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());

--- a/modules/c++/mem/wscript
+++ b/modules/c++/mem/wscript
@@ -1,5 +1,4 @@
 NAME            = 'mem'
-MAINTAINER      = 'asylvest@users.sourceforge.net'
 VERSION         = '1.0'
 MODULE_DEPS     = 'sys'
 TEST_DEPS       = 'cli'

--- a/modules/c++/mt/include/mt/AbstractCPUAffinityInitializer.h
+++ b/modules/c++/mt/include/mt/AbstractCPUAffinityInitializer.h
@@ -24,6 +24,7 @@
 #ifndef __MT_ABSTRACT_CPU_AFFINITY_INITIALIZER_H__
 #define __MT_ABSTRACT_CPU_AFFINITY_INITIALIZER_H__
 
+#include <mem/SharedPtr.h>
 #include <mt/AbstractCPUAffinityThreadInitializer.h>
 
 namespace mt
@@ -43,9 +44,9 @@ public:
      * \returns a new thread initializer. In general, this should return
      *          a different affinity initializer each time it is called.
      */
-    std::auto_ptr<AbstractCPUAffinityThreadInitializer> newThreadInitializer()
+    mem::auto_ptr<AbstractCPUAffinityThreadInitializer> newThreadInitializer()
     {
-        return std::auto_ptr<AbstractCPUAffinityThreadInitializer>(
+        return mem::auto_ptr<AbstractCPUAffinityThreadInitializer>(
                 newThreadInitializerImpl());
     }
 

--- a/modules/c++/mt/include/mt/AbstractTiedThreadPool.h
+++ b/modules/c++/mt/include/mt/AbstractTiedThreadPool.h
@@ -27,6 +27,7 @@
 #include "mt/AbstractThreadPool.h"
 #include "mt/TiedWorkerThread.h"
 #include "mt/CPUAffinityInitializer.h"
+#include "mem/SharedPtr.h"
 
 namespace mt
 {
@@ -47,10 +48,10 @@ public:
         mAffinityInit = affinityInit;
     }
 
-    virtual std::auto_ptr<CPUAffinityThreadInitializer>
+    virtual mem::auto_ptr<CPUAffinityThreadInitializer>
     getCPUAffinityThreadInitializer()
     {
-        std::auto_ptr<CPUAffinityThreadInitializer> threadInit(NULL);
+        mem::auto_ptr<CPUAffinityThreadInitializer> threadInit(NULL);
 
         // If we were passed a schematic
         // for initializing thread affinity...

--- a/modules/c++/mt/include/mt/CPUAffinityInitializerLinux.h
+++ b/modules/c++/mt/include/mt/CPUAffinityInitializerLinux.h
@@ -33,12 +33,13 @@
 #include <sys/ScopedCPUAffinityUnix.h>
 #include <mt/AbstractCPUAffinityInitializer.h>
 #include <mt/CPUAffinityThreadInitializerLinux.h>
+#include <mem/SharedPtr.h>
 
 namespace mt
 {
 struct AbstractNextCPUProviderLinux
 {
-    virtual std::auto_ptr<const sys::ScopedCPUMaskUnix> nextCPU() = 0;
+    virtual mem::auto_ptr<const sys::ScopedCPUMaskUnix> nextCPU() = 0;
 };
 
 /*!
@@ -68,9 +69,9 @@ public:
      * \returns a new CPUAffinityInitializerLinux for the next available
      *          CPU that can be bound to.
      */
-    std::auto_ptr<CPUAffinityThreadInitializerLinux> newThreadInitializer()
+    mem::auto_ptr<CPUAffinityThreadInitializerLinux> newThreadInitializer()
     {
-        return std::auto_ptr<CPUAffinityThreadInitializerLinux>(
+        return mem::auto_ptr<CPUAffinityThreadInitializerLinux>(
                 newThreadInitializerImpl());
     }
 
@@ -81,7 +82,7 @@ private:
         return new CPUAffinityThreadInitializerLinux(mCPUProvider->nextCPU());
     }
 
-    std::auto_ptr<AbstractNextCPUProviderLinux> mCPUProvider;
+    std::unique_ptr<AbstractNextCPUProviderLinux> mCPUProvider;
 };
 }
 

--- a/modules/c++/mt/include/mt/CPUAffinityInitializerWin32.h
+++ b/modules/c++/mt/include/mt/CPUAffinityInitializerWin32.h
@@ -28,6 +28,7 @@
 
 #include <mt/AbstractCPUAffinityInitializer.h>
 #include <mt/CPUAffinityThreadInitializerWin32.h>
+#include <mem/SharedPtr.h>
 
 namespace mt
 {
@@ -43,9 +44,9 @@ public:
      * \todo Not yet implemented
      * \returns NULL
      */
-    std::auto_ptr<CPUAffinityThreadInitializerWin32> newThreadInitializer()
+    mem::auto_ptr<CPUAffinityThreadInitializerWin32> newThreadInitializer()
     {
-        return std::auto_ptr<CPUAffinityThreadInitializerWin32>(
+        return mem::auto_ptr<CPUAffinityThreadInitializerWin32>(
                 newThreadInitializerImpl());
     }
 

--- a/modules/c++/mt/include/mt/CPUAffinityThreadInitializerLinux.h
+++ b/modules/c++/mt/include/mt/CPUAffinityThreadInitializerLinux.h
@@ -61,7 +61,7 @@ public:
     virtual void initialize();
 
 private:
-    std::auto_ptr<const sys::ScopedCPUMaskUnix> mCPU;
+    mem::auto_ptr<const sys::ScopedCPUMaskUnix> mCPU;
 };
 }
 

--- a/modules/c++/mt/include/mt/ThreadGroup.h
+++ b/modules/c++/mt/include/mt/ThreadGroup.h
@@ -107,7 +107,7 @@ public:
     static void setDefaultPinToCPU(bool newDefault);
 
 private:
-    std::auto_ptr<CPUAffinityInitializer> mAffinityInit;
+    std::unique_ptr<CPUAffinityInitializer> mAffinityInit;
     size_t mLastJoined;
     std::vector<mem::SharedPtr<sys::Thread> > mThreads;
     std::vector<except::Exception> mExceptions;
@@ -130,7 +130,7 @@ private:
      *          the internal CPUAffinityInitializer. If no initializer
      *          was created, will return NULL.
      */
-    std::auto_ptr<CPUAffinityThreadInitializer> getNextInitializer();
+    mem::auto_ptr<CPUAffinityThreadInitializer> getNextInitializer();
 
     /*!
      * \class ThreadGroupRunnable
@@ -165,9 +165,9 @@ private:
         virtual void run();
 
     private:
-        std::auto_ptr<sys::Runnable> mRunnable;
+        mem::auto_ptr<sys::Runnable> mRunnable;
         mt::ThreadGroup& mParentThreadGroup;
-        std::auto_ptr<CPUAffinityThreadInitializer> mCPUInit;
+        mem::auto_ptr<CPUAffinityThreadInitializer> mCPUInit;
     };
 };
 

--- a/modules/c++/mt/include/mt/TiedWorkerThread.h
+++ b/modules/c++/mt/include/mt/TiedWorkerThread.h
@@ -25,6 +25,7 @@
 #define __MT_TIED_WORKER_THREAD_H__
 
 #include "mt/CPUAffinityThreadInitializer.h"
+#include "mem/SharedPtr.h"
 
 
 namespace mt
@@ -58,7 +59,7 @@ public:
 
 private:
     TiedWorkerThread();
-    std::auto_ptr<CPUAffinityThreadInitializer> mCPUAffinityInit;
+    std::unique_ptr<CPUAffinityThreadInitializer> mCPUAffinityInit;
 };
 
 }

--- a/modules/c++/mt/source/CPUAffinityInitializerLinux.cpp
+++ b/modules/c++/mt/source/CPUAffinityInitializerLinux.cpp
@@ -60,7 +60,7 @@ public:
     {
     }
 
-    virtual std::auto_ptr<const sys::ScopedCPUMaskUnix> nextCPU()
+    virtual mem::auto_ptr<const sys::ScopedCPUMaskUnix> nextCPU()
     {
         if (mNextCPUIndex >= mCPUs.size())
         {
@@ -69,9 +69,9 @@ public:
             throw except::Exception(Ctxt(msg.str()));
         }
 
-        std::auto_ptr<sys::ScopedCPUMaskUnix> mask(new sys::ScopedCPUMaskUnix());
+        mem::auto_ptr<sys::ScopedCPUMaskUnix> mask(new sys::ScopedCPUMaskUnix());
         CPU_SET_S(mCPUs.at(mNextCPUIndex++), mask->getSize(), mask->getMask());
-        return std::auto_ptr<const sys::ScopedCPUMaskUnix>(mask);
+        return mem::auto_ptr<const sys::ScopedCPUMaskUnix>(mask);
     }
 
 private:
@@ -87,11 +87,11 @@ public:
     {
     }
 
-    virtual std::auto_ptr<const sys::ScopedCPUMaskUnix> nextCPU()
+    virtual mem::auto_ptr<const sys::ScopedCPUMaskUnix> nextCPU()
     {
-        std::auto_ptr<sys::ScopedCPUMaskUnix> mask(new sys::ScopedCPUMaskUnix());
+        mem::auto_ptr<sys::ScopedCPUMaskUnix> mask(new sys::ScopedCPUMaskUnix());
         CPU_SET_S(mNextCPU++, mask->getSize(), mask->getMask());
-        return std::auto_ptr<const sys::ScopedCPUMaskUnix>(mask);
+        return mem::auto_ptr<const sys::ScopedCPUMaskUnix>(mask);
     }
 
 private:

--- a/modules/c++/mt/source/CPUAffinityThreadInitializerLinux.cpp
+++ b/modules/c++/mt/source/CPUAffinityThreadInitializerLinux.cpp
@@ -30,6 +30,7 @@
 
 #include <sys/Conf.h>
 #include <except/Exception.h>
+#include <mem/SharedPtr.h>
 #include <mt/CPUAffinityThreadInitializerLinux.h>
 
 namespace mt

--- a/modules/c++/mt/source/GenericRequestHandler.cpp
+++ b/modules/c++/mt/source/GenericRequestHandler.cpp
@@ -38,7 +38,7 @@ void mt::GenericRequestHandler::run()
 
         // Run the runnable that we pulled off the queue
         // It will get deleted when it goes out of scope below
-        std::auto_ptr<sys::Runnable> scopedHandler(handler);
+        std::unique_ptr<sys::Runnable> scopedHandler(handler);
         scopedHandler->run();
     }
 }

--- a/modules/c++/mt/source/ThreadGroup.cpp
+++ b/modules/c++/mt/source/ThreadGroup.cpp
@@ -60,7 +60,7 @@ void ThreadGroup::createThread(std::auto_ptr<sys::Runnable> runnable)
 {
     // Note: If getNextInitializer throws, any previously created
     //       threads may never finish if cross-thread communication is used.
-    std::auto_ptr<sys::Runnable> internalRunnable(
+    std::unique_ptr<sys::Runnable> internalRunnable(
             new ThreadGroupRunnable(
                     runnable,
                     *this,
@@ -115,9 +115,9 @@ void ThreadGroup::addException(const except::Exception& ex)
     }
 }
 
-std::auto_ptr<CPUAffinityThreadInitializer> ThreadGroup::getNextInitializer()
+mem::auto_ptr<CPUAffinityThreadInitializer> ThreadGroup::getNextInitializer()
 {
-    std::auto_ptr<CPUAffinityThreadInitializer> threadInit(NULL);
+    mem::auto_ptr<CPUAffinityThreadInitializer> threadInit(NULL);
     if (mAffinityInit.get())
     {
         threadInit = mAffinityInit->newThreadInitializer();

--- a/modules/c++/mt/tests/ThreadGroupAffinityTest.cpp
+++ b/modules/c++/mt/tests/ThreadGroupAffinityTest.cpp
@@ -25,6 +25,7 @@
 
 #include <import/sys.h>
 #include <import/mt.h>
+#include <import/mem.h>
 #include <cli/ArgumentParser.h>
 #include <sys/ScopedCPUAffinityUnix.h>
 using namespace sys;
@@ -116,7 +117,7 @@ int main(int argc, char** argv)
                            "Enable CPU pinning",
                            cli::STORE_TRUE,
                            "pinToCPU")->setDefault(false);
-        const std::auto_ptr<cli::Results> options(parser.parse(argc, argv));
+        const mem::auto_ptr<cli::Results> options(parser.parse(argc, argv));
 
         const bool pinToCPU = options->get<bool>("pinToCPU");
         const size_t numThreads = options->get<size_t>("threads");

--- a/modules/c++/net/include/net/ClientSocketFactory.h
+++ b/modules/c++/net/include/net/ClientSocketFactory.h
@@ -24,6 +24,7 @@
 #define __NET_CLIENT_SOCKET_FACTORY_H__
 
 #include "net/Socket.h"
+#include "mem/SharedPtr.h"
 
 /*!
  *  \file
@@ -80,9 +81,9 @@ public:
      *
      *  \return A socket
      */
-    std::auto_ptr<Socket> create(const SocketAddress& address)
+    mem::auto_ptr<Socket> create(const SocketAddress& address)
     {
-        std::auto_ptr<Socket> s (new Socket(mProto));
+        mem::auto_ptr<Socket> s(new Socket(mProto));
 
         setOptions(*s);
 

--- a/modules/c++/net/include/net/NetConnectionServer.h
+++ b/modules/c++/net/include/net/NetConnectionServer.h
@@ -28,6 +28,7 @@
 #include "net/ServerSocketFactory.h"
 #include "sys/SystemException.h"
 #include "net/SingleThreadedAllocStrategy.h"
+#include "mem/SharedPtr.h"
 
 
 /*! \file
@@ -103,9 +104,9 @@ protected:
     //! The amount of backlog
     int mBacklog;
     //! The socket we are listening on
-    std::auto_ptr<net::Socket> mSocket;
+    mem::auto_ptr<net::Socket> mSocket;
 
-    std::auto_ptr<net::AllocStrategy> mAllocStrategy;
+    mem::auto_ptr<net::AllocStrategy> mAllocStrategy;
 };
 }
 

--- a/modules/c++/net/include/net/ServerSocketFactory.h
+++ b/modules/c++/net/include/net/ServerSocketFactory.h
@@ -24,6 +24,7 @@
 #define __NET_SERVER_SOCKET_FACTORY_H__
 
 #include "net/Socket.h"
+#include "mem/SharedPtr.h"
 
 /*!
  *  \file
@@ -81,9 +82,9 @@ public:
      *  \param address Address to establish the socket for
      *  \return The created & bound socket
      */
-    virtual std::auto_ptr<Socket> create(const SocketAddress& address)
+    virtual mem::auto_ptr<Socket> create(const SocketAddress& address)
     {
-        std::auto_ptr<Socket> s (new Socket(mProto));
+        mem::auto_ptr<Socket> s(new Socket(mProto));
 
         // Bind to this address
         s->bind(address);
@@ -126,9 +127,9 @@ public:
      *
      *  \return The produced socket
      */
-    virtual std::auto_ptr<Socket> create(const SocketAddress& address)
+    virtual mem::auto_ptr<Socket> create(const SocketAddress& address)
     {
-        std::auto_ptr<Socket> s (new Socket(mProto));
+        mem::auto_ptr<Socket> s(new Socket(mProto));
 
         // Make sure we're set up for broadcasting if necessary
         int on = 1;
@@ -184,9 +185,9 @@ public:
      *  listen().
      *
      */
-    virtual std::auto_ptr<Socket> create(const SocketAddress& address)
+    virtual mem::auto_ptr<Socket> create(const SocketAddress& address)
     {
-        std::auto_ptr<Socket> s (new Socket(mProto));
+        mem::auto_ptr<Socket> s(new Socket(mProto));
 
         // Reuse socket address (important for most TCP apps)
         int on = 1;

--- a/modules/c++/net/include/net/Socket.h
+++ b/modules/c++/net/include/net/Socket.h
@@ -26,6 +26,7 @@
 #include <sys/SystemException.h>
 #include <except/Exception.h>
 #include <str/Manip.h>
+#include <mem/SharedPtr.h>
 
 #include "net/Sockets.h"
 #include "net/SocketAddress.h"
@@ -247,7 +248,7 @@ public:
      *  \param fromClient Client socket address returned
      *  \return A new socket connection to the client
      */
-    std::auto_ptr<Socket> accept(SocketAddress& fromClient);
+    mem::auto_ptr<Socket> accept(SocketAddress& fromClient);
 
     net::Socket_T getHandle() const
     {

--- a/modules/c++/net/source/NetConnectionServer.cpp
+++ b/modules/c++/net/source/NetConnectionServer.cpp
@@ -50,7 +50,7 @@ std::string net::NetConnectionServer::getHostName()
 net::NetConnection* net::NetConnectionServer::accept()
 {
     net::SocketAddress sa;
-    std::auto_ptr<net::NetConnection> tmp (
+    std::unique_ptr<net::NetConnection> tmp (
         new net::NetConnection(mSocket->accept(sa)));
     return tmp.release();
 }
@@ -58,7 +58,7 @@ net::NetConnection* net::NetConnectionServer::accept()
 void net::NetConnectionServer::initialize(net::RequestHandlerFactory* factory,
                                           net::AllocStrategy* newStrategy)
 {
-    std::auto_ptr<net::AllocStrategy> tmp ((newStrategy == NULL) ? 
+    std::unique_ptr<net::AllocStrategy> tmp ((newStrategy == NULL) ? 
         new DefaultAllocStrategy() : newStrategy);
 
     tmp->setRequestHandlerFactory(factory);

--- a/modules/c++/net/source/Socket.cpp
+++ b/modules/c++/net/source/Socket.cpp
@@ -68,12 +68,12 @@ void net::Socket::bind(const net::SocketAddress& address)
     }                               
 }
 
-std::auto_ptr<net::Socket> net::Socket::accept(net::SocketAddress& fromClient)
+mem::auto_ptr<net::Socket> net::Socket::accept(net::SocketAddress& fromClient)
 {
     net::SockAddrIn_T& in = fromClient.getAddress();
 
     net::SockLen_T addrLen = sizeof(in);
-    return std::auto_ptr<net::Socket>( 
+    return mem::auto_ptr<net::Socket>( 
         new Socket(::accept(mNative, (net::SockAddr_T *) &in, &addrLen), true) );
 }
 

--- a/modules/c++/net/tests/AckMulticastSender.cpp
+++ b/modules/c++/net/tests/AckMulticastSender.cpp
@@ -23,6 +23,7 @@
 #include <import/net.h>
 #include <import/sys.h>
 #include <import/io.h>
+#include <import/mem.h>
 
 using namespace net;
 using namespace sys;
@@ -32,8 +33,8 @@ using namespace except;
 template<typename T> class AckMulticastSender
 {
 
-    std::auto_ptr<Socket> mMulticastSender;
-    std::auto_ptr<Socket> mAckChannel;
+    mem::auto_ptr<Socket> mMulticastSender;
+    mem::auto_ptr<Socket> mAckChannel;
     SocketAddress mMulticastAddr;
     std::vector<std::string> mSubscribers;
     int mRetransmitPort;
@@ -52,18 +53,18 @@ public:
     {
     }
     
-    std::auto_ptr<Socket> createAckChannel(int localAckPort)
+    mem::auto_ptr<Socket> createAckChannel(int localAckPort)
     {
         SocketAddress address(localAckPort);
         return UDPServerSocketFactory().create(address);
     }
-    std::auto_ptr<Socket> createSenderSocket(const std::string& mcastGroup, int mcastPort,
+    mem::auto_ptr<Socket> createSenderSocket(const std::string& mcastGroup, int mcastPort,
             int loopback)
     {
 
         mMulticastAddr.set(mcastPort, mcastGroup);
 
-        std::auto_ptr<Socket> s( new Socket(UDP_PROTO) );
+        mem::auto_ptr<Socket> s(new Socket(UDP_PROTO));
 
         int on = 1;
         s->setOption(SOL_SOCKET, SO_REUSEADDR, on);
@@ -99,7 +100,7 @@ public:
         for (int i = 0; i < needRetransmit.size(); i++)
         {
             SocketAddress sa(needRetransmit[i], mRetransmitPort);
-            std::auto_ptr<Socket> toRetransmit = net::TCPClientSocketFactory().create(sa);
+            mem::auto_ptr<Socket> toRetransmit = net::TCPClientSocketFactory().create(sa);
             toRetransmit.send((const char*) &packet, sizeof(packet));
             toRetransmit.close();
         }

--- a/modules/c++/net/tests/AckMulticastSubscriber.cpp
+++ b/modules/c++/net/tests/AckMulticastSubscriber.cpp
@@ -71,7 +71,7 @@ public:
     mem::auto_ptr<Socket> createMulticastSubscriber(const std::string& group, int port)
     {
         SocketAddress here(port);
-        std::auto_ptr<Socket> socket( new Socket(UDP_PROTO) );
+        mem::auto_ptr<Socket> socket(new Socket(UDP_PROTO));
         socket->bind(here);
         struct ip_mreq mreq;
 

--- a/modules/c++/net/tests/AckMulticastSubscriber.cpp
+++ b/modules/c++/net/tests/AckMulticastSubscriber.cpp
@@ -23,6 +23,7 @@
 #include <import/net.h>
 #include <import/sys.h>
 #include <import/io.h>
+#include <import/mem.h>
 #include "net/SingleThreadedAllocStrategy.h"
 #include "net/NetConnectionServer.h"
 
@@ -52,8 +53,8 @@ public:
 
 template<typename T> class AckMulticastSubscriber
 {
-    std::auto_ptr<Socket> mAckChannel;
-    std::auto_ptr<Socket> mMulticastSubscriber;
+    mem::auto_ptr<Socket> mAckChannel;
+    mem::auto_ptr<Socket> mMulticastSubscriber;
 public:
     AckMulticastSubscriber(const std::string& mcastGroup, int mcastLocalPort,
             const std::string& replyTo, int replyToPort)
@@ -67,7 +68,7 @@ public:
     {
     }
 
-    std::auto_ptr<Socket> createMulticastSubscriber(const std::string& group, int port)
+    mem::auto_ptr<Socket> createMulticastSubscriber(const std::string& group, int port)
     {
         SocketAddress here(port);
         std::auto_ptr<Socket> socket( new Socket(UDP_PROTO) );
@@ -85,10 +86,10 @@ public:
         return socket;
     }
 
-    std::auto_ptr<Socket> createSocketForAck(const std::string& senderHost, int senderPort)
+    mem::auto_ptr<Socket> createSocketForAck(const std::string& senderHost, int senderPort)
     {
         SocketAddress toSender(senderHost, senderPort);
-        std::auto_ptr<Socket> s = UDPClientSocketFactory().create(toSender);
+        mem::auto_ptr<Socket> s = UDPClientSocketFactory().create(toSender);
         // This socket is already 'connect()'ed by now, so we use send()
         return s;
     }

--- a/modules/c++/net/tests/MulticastSender.cpp
+++ b/modules/c++/net/tests/MulticastSender.cpp
@@ -27,15 +27,16 @@
 #include <import/net.h>
 #include <import/sys.h>
 #include <import/io.h>
+#include <import/mem.h>
 
 using namespace net;
 using namespace sys;
 using namespace io;
 using namespace except;
 
-std::auto_ptr<Socket> createSenderSocket(SocketAddress& address, int loopback = 1)
+mem::auto_ptr<Socket> createSenderSocket(SocketAddress& address, int loopback = 1)
 {
-    std::auto_ptr<Socket> s( new Socket(UDP_PROTO) );
+    mem::auto_ptr<Socket> s(new Socket(UDP_PROTO));
 
     int on = 1;
     s->setOption(SOL_SOCKET, SO_REUSEADDR, on);
@@ -68,7 +69,7 @@ int main(int argc, char** argv)
         SocketAddress sa(mcastGroup, port);
 
         // Register ourselves with the OS as members of this group
-        std::auto_ptr<Socket> socket = createSenderSocket(sa);
+        mem::auto_ptr<Socket> socket = createSenderSocket(sa);
         Packet packet;
         std::string myMessage = "Hello group!";
         memcpy(packet.what, myMessage.c_str(), myMessage.length());

--- a/modules/c++/net/tests/MulticastSubscriber.cpp
+++ b/modules/c++/net/tests/MulticastSubscriber.cpp
@@ -23,16 +23,17 @@
 #include <import/net.h>
 #include <import/sys.h>
 #include <import/io.h>
+#include <import/mem.h>
 
 using namespace net;
 using namespace sys;
 using namespace io;
 using namespace except;
 
-std::auto_ptr<Socket> createMulticastSubscriber(const std::string& group,
+mem::auto_ptr<Socket> createMulticastSubscriber(const std::string& group,
         const SocketAddress& local)
 {
-    std::auto_ptr<Socket> socket( new Socket(UDP_PROTO) );
+    mem::auto_ptr<Socket> socket(new Socket(UDP_PROTO));
 
     struct ip_mreq mreq;
 
@@ -78,7 +79,7 @@ int main(int argc, char** argv)
 
         // Register ourselves with the OS as members of this group
 
-        std::auto_ptr<Socket> socket = createMulticastSubscriber(mcastGroup, here);
+        mem::auto_ptr<Socket> socket = createMulticastSubscriber(mcastGroup, here);
         Packet packet;
         SocketAddress whereFrom;
         socket->recvFrom(whereFrom, (char*) &packet, sizeof(packet));

--- a/modules/c++/net/tests/TCPClientSpeedTest.cpp
+++ b/modules/c++/net/tests/TCPClientSpeedTest.cpp
@@ -33,6 +33,7 @@
 
 #include <sys/Path.h>
 #include <sys/LocalDateTime.h>
+#include <mem/SharedPtr.h>
 #include <net/ClientSocketFactory.h>
 
 int main(int argc, char** argv)
@@ -52,7 +53,7 @@ int main(int argc, char** argv)
         const size_t bytesToSend = str::toType<size_t>(argv[4]) * 1024 * 1024;
 
         net::SocketAddress sa(host, port);
-        std::auto_ptr<net::Socket> socket =
+        mem::auto_ptr<net::Socket> socket =
                 net::TCPClientSocketFactory().create(sa);
 
         std::vector<sys::ubyte> bufferVec(std::min(bufferSize, bytesToSend), 0);

--- a/modules/c++/net/tests/TCPClientTest.cpp
+++ b/modules/c++/net/tests/TCPClientTest.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
         int port = atoi(argv[2]);
 
         SocketAddress sa(host, port);
-        std::auto_ptr<Socket> socket = TCPClientSocketFactory().create(sa);
+        mem::auto_ptr<Socket> socket = TCPClientSocketFactory().create(sa);
         my_packet_t packet;
         packet.packet_no = 1;
         packet.time_stamp = time(NULL);

--- a/modules/c++/net/tests/TCPServerSpeedTest.cpp
+++ b/modules/c++/net/tests/TCPServerSpeedTest.cpp
@@ -33,6 +33,7 @@
 
 #include <sys/Path.h>
 #include <sys/LocalDateTime.h>
+#include <mem/SharedPtr.h>
 #include <net/ServerSocketFactory.h>
 
 int main(int argc, char** argv)
@@ -50,10 +51,10 @@ int main(int argc, char** argv)
         const size_t bufferSize = str::toType<size_t>(argv[2]) * 1024 * 1024;
 
         net::SocketAddress address(port);
-        std::auto_ptr<net::Socket> listener =
+        mem::auto_ptr<net::Socket> listener =
                 net::TCPServerSocketFactory().create(address);
         net::SocketAddress clientAddress;
-        std::auto_ptr<net::Socket> client = listener->accept(clientAddress);
+        mem::auto_ptr<net::Socket> client = listener->accept(clientAddress);
 
         // First the client sends the # of bytes they'll be sending
         sys::Uint64_T numBytes;

--- a/modules/c++/net/tests/TCPServerTest.cpp
+++ b/modules/c++/net/tests/TCPServerTest.cpp
@@ -41,6 +41,7 @@
 #include <import/net.h>
 #include <import/sys.h>
 #include <import/except.h>
+#include <import/mem.h>
 #include "my_packet.h"
 
 using namespace net;
@@ -57,9 +58,9 @@ int main(int argc, char** argv)
         int port = atoi(argv[1]);
 
         SocketAddress address(port);
-        std::auto_ptr<Socket> listener = TCPServerSocketFactory().create(address);
+        mem::auto_ptr<Socket> listener = TCPServerSocketFactory().create(address);
         SocketAddress clientAddress;
-        std::auto_ptr<Socket> client = listener->accept(clientAddress);
+        mem::auto_ptr<Socket> client = listener->accept(clientAddress);
         // Print client address here!!
         my_packet_t packet;
         client->recv(&packet, sizeof(my_packet_t));

--- a/modules/c++/net/tests/UDPClientTest.cpp
+++ b/modules/c++/net/tests/UDPClientTest.cpp
@@ -44,6 +44,7 @@
 #include <import/net.h>
 #include <import/except.h>
 #include <import/sys.h>
+#include <import/mem.h>
 #include "my_packet.h"
 
 using namespace net;
@@ -62,7 +63,7 @@ int main(int argc, char** argv)
         int port = atoi(argv[2]);
 
         SocketAddress sa(host, port);
-        std::auto_ptr<Socket> socket = UDPClientSocketFactory().create(sa);
+        mem::auto_ptr<Socket> socket = UDPClientSocketFactory().create(sa);
         my_packet_t packet;
         packet.packet_no = 1;
         packet.time_stamp = time(NULL);

--- a/modules/c++/net/tests/UDPServerTest.cpp
+++ b/modules/c++/net/tests/UDPServerTest.cpp
@@ -40,6 +40,7 @@
 #include <import/net.h>
 #include <import/sys.h>
 #include <import/except.h>
+#include <import/mem.h>
 #include "my_packet.h"
 
 using namespace net;
@@ -56,7 +57,7 @@ int main(int argc, char** argv)
         int port = atoi(argv[1]);
 
         SocketAddress address(port);
-        std::auto_ptr<Socket> socket = UDPServerSocketFactory().create(address);
+        mem::auto_ptr<Socket> socket = UDPServerSocketFactory().create(address);
 
         my_packet_t packet;
         SocketAddress cliAddr(port);

--- a/modules/c++/plugin/include/plugin/BasicPluginManager.h
+++ b/modules/c++/plugin/include/plugin/BasicPluginManager.h
@@ -345,7 +345,7 @@ public:
             if (loadDSO)
             {
                 // Load the DSO
-                std::auto_ptr<sys::DLL> autoDSO(new sys::DLL(file));
+                std::unique_ptr<sys::DLL> autoDSO(new sys::DLL(file));
                 mDSOs.push_back(autoDSO.get());
                 dso = autoDSO.release();
             }

--- a/modules/c++/sio.lite/include/sio/lite/FileWriter.h
+++ b/modules/c++/sio.lite/include/sio/lite/FileWriter.h
@@ -26,6 +26,7 @@
 #include <vector>
 #include <import/sys.h>
 #include <import/io.h>
+#include <import/mem.h>
 #include "sio/lite/InvalidHeaderException.h"
 #include "sio/lite/FileHeader.h"
 
@@ -96,7 +97,7 @@ public:
 
 protected:
     std::string mFileName;
-    std::auto_ptr<io::OutputStream> mStream;
+    mem::auto_ptr<io::OutputStream> mStream;
     bool mAdopt;
 };
 

--- a/modules/c++/sys/include/sys/ConditionVarIrix.h
+++ b/modules/c++/sys/include/sys/ConditionVarIrix.h
@@ -133,7 +133,7 @@ public:
     
 private:
     // This is set if we own the mutex, to make sure it gets deleted.
-    std::auto_ptr<MutexIrix> mMutexOwned;
+    std::unique_ptr<MutexIrix> mMutexOwned;
     MutexIrix *mMutex;
     std::vector<pid_t> mNative;
 };

--- a/modules/c++/sys/include/sys/ConditionVarNSPR.h
+++ b/modules/c++/sys/include/sys/ConditionVarNSPR.h
@@ -132,7 +132,7 @@ public:
     
 private:
     // This is set if we own the mutex, to make sure it gets deleted.
-    std::auto_ptr<MutexNSPR> mMutexOwned;
+    std::unique_ptr<MutexNSPR> mMutexOwned;
     MutexNSPR *mMutex;
     PRCondVar *mNative;
 };

--- a/modules/c++/sys/include/sys/ConditionVarPosix.h
+++ b/modules/c++/sys/include/sys/ConditionVarPosix.h
@@ -113,7 +113,7 @@ public:
 
 private:
     // This is set if we own the mutex, to make sure it gets deleted.
-    std::auto_ptr<MutexPosix> mMutexOwned;
+    std::unique_ptr<MutexPosix> mMutexOwned;
     MutexPosix *mMutex;
     pthread_cond_t mNative;
 };

--- a/modules/c++/sys/include/sys/ConditionVarSolaris.h
+++ b/modules/c++/sys/include/sys/ConditionVarSolaris.h
@@ -108,7 +108,7 @@ public:
     
 private:
     // This is set if we own the mutex, to make sure it gets deleted.
-    std::auto_ptr<MutexSolaris> mMutexOwned;
+    std::unique_ptr<MutexSolaris> mMutexOwned;
     MutexSolaris *mMutex;
     cond_t mNative;
 };

--- a/modules/c++/sys/include/sys/ConditionVarWin32.h
+++ b/modules/c++/sys/include/sys/ConditionVarWin32.h
@@ -145,7 +145,7 @@ public:
 
 private:
     // This is set if we own the mutex, to make sure it gets deleted.
-    std::auto_ptr<MutexWin32> mMutexOwned;
+    std::unique_ptr<MutexWin32> mMutexOwned;
     MutexWin32 *mMutex;
     ConditionVarDataWin32 mNative;
 };

--- a/modules/c++/sys/include/sys/SyncFactoryIrix.h
+++ b/modules/c++/sys/include/sys/SyncFactoryIrix.h
@@ -24,6 +24,8 @@
 #ifndef __SYS_SYNC_FACTORY_IRIX_H__
 #define __SYS_SYNC_FACTORY_IRIX_H__
 
+#include <mem/SharedPtr.h>
+
 #  if defined(__sgi)
 #include <iostream>
 #include "sys/Dbg.h"
@@ -110,7 +112,7 @@ class SyncImplIrix : public SyncInterface
         ulock_t* mGuard;
     };
 
-    static std::auto_ptr<ulock_t> cs;
+    static mem::auto_ptr<ulock_t> cs;
     static SyncFactoryIrix::SyncImplIrix* createImpl()
     {
 

--- a/modules/c++/tiff/source/FileWriter.cpp
+++ b/modules/c++/tiff/source/FileWriter.cpp
@@ -21,6 +21,7 @@
  */
 #include <string>
 #include <import/except.h>
+#include <import/mem.h>
 #include "tiff/ImageWriter.h"
 #include "tiff/FileWriter.h"
 
@@ -94,8 +95,7 @@ tiff::ImageWriter *tiff::FileWriter::addImage()
     if (!mImages.empty())
         mIFDOffset = mImages.back()->getNextIFDOffset();
 
-    std::auto_ptr<tiff::ImageWriter>
-        image(new tiff::ImageWriter(&mOutput, mIFDOffset));
+    auto image = mem::make::unique<tiff::ImageWriter>(&mOutput, mIFDOffset);
     mImages.push_back(image.get());
     tiff::ImageWriter* const writer = image.release();
 

--- a/modules/c++/tiff/source/IFDEntry.cpp
+++ b/modules/c++/tiff/source/IFDEntry.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <import/io.h>
 #include <import/except.h>
+#include <import/mem.h>
 
 #include "tiff/Common.h"
 #include "tiff/GenericType.h"
@@ -200,7 +201,7 @@ void tiff::IFDEntry::addValues(const char* str, int tiffType)
 
     for (size_t ii = 0, len = ::strlen(str) + 1; ii < len; ++ii)
     {
-        std::auto_ptr<tiff::TypeInterface>
+        mem::auto_ptr<tiff::TypeInterface>
             value(tiff::TypeFactory::create(strPtr + ii, tiffType));
         addValue(value);
     }

--- a/modules/c++/xml.lite/include/xml/lite/ValidatorXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/ValidatorXerces.h
@@ -125,9 +125,9 @@ public:
 
 private:
 
-    std::auto_ptr<xercesc::XMLGrammarPool> mSchemaPool;
-    std::auto_ptr<xml::lite::ValidationErrorHandler> mErrorHandler;
-    std::auto_ptr<xercesc::DOMLSParser> mValidator;
+    std::unique_ptr<xercesc::XMLGrammarPool> mSchemaPool;
+    std::unique_ptr<xml::lite::ValidationErrorHandler> mErrorHandler;
+    std::unique_ptr<xercesc::DOMLSParser> mValidator;
 
 };
 

--- a/modules/c++/xml.lite/include/xml/lite/XMLReaderXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/XMLReaderXerces.h
@@ -60,9 +60,9 @@ class XMLReaderXerces : public XMLReaderInterface
 private:
 
     XercesContext mCtxt;    //! this must be the first member listed
-    std::auto_ptr<SAX2XMLReader>        mNative;
-    std::auto_ptr<XercesContentHandler> mDriverContentHandler;
-    std::auto_ptr<XercesErrorHandler>   mErrorHandler;
+    std::unique_ptr<SAX2XMLReader>        mNative;
+    std::unique_ptr<XercesContentHandler> mDriverContentHandler;
+    std::unique_ptr<XercesErrorHandler>   mErrorHandler;
 
 public:
 

--- a/modules/c++/xml.lite/source/Element.cpp
+++ b/modules/c++/xml.lite/source/Element.cpp
@@ -24,6 +24,7 @@
 
 #include "xml/lite/Element.h"
 #include <import/str.h>
+#include <import/mem.h>
 
 xml::lite::Element::Element(const xml::lite::Element& node)
 {
@@ -346,7 +347,7 @@ void xml::lite::Element::addChild(xml::lite::Element * node)
 void xml::lite::Element::addChild(std::auto_ptr<xml::lite::Element> node)
 {
     // Always take ownership
-    std::auto_ptr<xml::lite::Element> scopedValue(node);
+    mem::auto_ptr<xml::lite::Element> scopedValue(node);
     addChild(scopedValue.get());
     scopedValue.release();
 }

--- a/modules/c++/xml.lite/tests/ValidationTest.cpp
+++ b/modules/c++/xml.lite/tests/ValidationTest.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
         parser.addArgument("-x --xml", "xml document to validate", 
                            cli::STORE);
         // parse!
-        const std::auto_ptr<cli::Results>
+        const mem::auto_ptr<cli::Results>
             options(parser.parse(argc, (const char**) argv));
         logging::LoggerPtr log(
             logging::setupLogger("ValidationTest"));


### PR DESCRIPTION
A follow-up to #434.  All that is left is using `std::auto_ptr` as a parameter.  This needs to be more significantly altered for C++17.

-------

This pull-request is an attempt to reduce code from #407.

For `private` member data, `std::auto_ptr` can almost always be replaced with `std::unique_ptr`; since it's `private` data, there's no danger of breaking clients.

For `protected` member data or `return` values, replacing `std::auto_ptr` with `mem::auto_ptr` allows the code to built with C++17 (where `mem::auto_ptr` becomes `std::unique_ptr`), usually w/o any other changes.