### PR TITLE
produce a new Path::expandEnviromentVariables() function

### DIFF
--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -203,8 +203,14 @@ public:
     bool getEnvIfSet(const std::string& envVar, std::string& value) const;
 
     // A variable like PATH is often several directories, return each one that exists.
-    bool splitEnv(const std::string& s, std::vector<std::string>&) const;
-    bool splitEnv(const std::string& s, std::vector<std::string>&, Filesystem::FileType) const;
+    bool splitEnv(const std::string& envVar, std::vector<std::string>&) const;
+    bool splitEnv(const std::string& envVar, std::vector<std::string>&, Filesystem::FileType) const;
+
+    // Modify the specified env-var as indicated.
+    // If the variable doesn't already exists and overwrite=false, false is returned.
+    // Otherwise, true: 1) variable is new (overwrite doesn't matter) or 2) overwrite = true
+    bool prependEnv(const std::string& envVar, const std::vector<std::string>&, bool overwrite);
+    bool appendEnv(const std::string& envVar, const std::vector<std::string>&, bool overwrite);
 
     /*!
      *  Set an environment variable

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -30,6 +30,7 @@
 #include "sys/SystemException.h"
 #include "str/Tokenizer.h"
 
+
 /*!
  *  \file
  *  \brief This class is the interface for an OS Abstraction layer.
@@ -198,6 +199,10 @@ public:
      *  Returns true if environment variable is set, false otherwise
      */
     bool getEnvIfSet(const std::string& envVar, std::string& value) const;
+
+    // A variable like PATH is often several directories, return each one that exists.
+    bool splitEnv(const std::string& s, std::vector<std::string>&) const;
+    bool splitEnv(const std::string& s, std::vector<std::string>&, Filesystem::FileType) const;
 
     /*!
      *  Set an environment variable

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -20,8 +20,9 @@
  *
  */
 
-#ifndef __SYS_ABSTRACT_OS_H__
-#define __SYS_ABSTRACT_OS_H__
+#ifndef CODA_OSS_sys_AbstractOS_h_INCLUDED_
+#define CODA_OSS_sys_AbstractOS_h_INCLUDED_
+#pragma once
 
 #include <vector>
 #include <string>
@@ -29,6 +30,7 @@
 #include "sys/FileFinder.h"
 #include "sys/SystemException.h"
 #include "str/Tokenizer.h"
+#include "sys/Filesystem.h"
 
 
 /*!
@@ -318,5 +320,4 @@ public:
 
 }
 
-#endif
-
+#endif  // CODA_OSS_sys_AbstractOS_h_INCLUDED_

--- a/modules/c++/sys/include/sys/FileFinder.h
+++ b/modules/c++/sys/include/sys/FileFinder.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <utility>
 
+#include "sys/Filesystem.h"
+
 namespace sys
 {
 

--- a/modules/c++/sys/include/sys/Filesystem.h
+++ b/modules/c++/sys/include/sys/Filesystem.h
@@ -46,6 +46,16 @@ namespace Filesystem
     extern std::ostream& Ostream(std::ostream& os, const path& p);
   }
 
+  // https://en.cppreference.com/w/cpp/filesystem/file_type
+  enum class FileType
+  {
+      None = 0,
+      NotFound = 1,
+      Regular,
+      Directory,
+      Unknown
+  };
+
 // http://en.cppreference.com/w/cpp/filesystem/path
 struct path final // N.B. this is an INCOMPLETE and NON-STANDARD implementation!
 {

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -20,14 +20,19 @@
  *
  */
 
-#ifndef __SYS_PATH_H__
-#define __SYS_PATH_H__
+#ifndef CODA_OSS_sys_Path_h_INCLUDED_
+#define CODA_OSS_sys_Path_h_INCLUDED_
+#pragma once
 
-#include "sys/OS.h"
-#include <import/str.h>
 #include <string>
 #include <deque>
 #include <utility>
+
+#include <import/str.h>
+
+#include "sys/OS.h"
+#include "sys/Filesystem.h"
+
 
 /*!
  *  \file
@@ -71,7 +76,8 @@ public:
     * Expands the enviroment variables in a string
     * c.f., https://docs.microsoft.com/en-us/dotnet/api/system.environment.expandenvironmentvariables?view=net-5.0
     */
-    static std::string expandEnvironmentVariables(const std::string& path);
+    static std::string expandEnvironmentVariables(const std::string& path, bool checkIfExists = true);
+    static std::string expandEnvironmentVariables(const std::string& path, Filesystem::FileType);
 
     /*!
      * Joins two paths together, using the OS-specific delimiter.
@@ -287,4 +293,4 @@ std::ostream& operator<<(std::ostream& os, const sys::Path& path);
 std::istream& operator>>(std::istream& os, sys::Path& path);
 }
 
-#endif
+#endif // CODA_OSS_sys_Path_h_INCLUDED_

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -68,6 +68,12 @@ public:
     }
 
     /*!
+    * Expands the enviroment variables in a string
+    * c.f., https://docs.microsoft.com/en-us/dotnet/api/system.environment.expandenvironmentvariables?view=net-5.0
+    */
+    static std::string expandEnvironmentVariables(const std::string& path);
+
+    /*!
      * Joins two paths together, using the OS-specific delimiter.
      */
     static std::string joinPaths(const std::string& path1,
@@ -114,6 +120,11 @@ public:
     {
         return separate(mPathName);
     }
+
+    /*!
+     *  Reverses separate()
+     */
+    static std::string merge(const std::vector<std::string>&);
 
     /*!
      * Splits the path into two components: head & tail.

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -73,7 +73,7 @@ public:
     }
 
     /*!
-    * Expands the enviroment variables in a string
+    * Expands the environment variables in a string
     * c.f., https://docs.microsoft.com/en-us/dotnet/api/system.environment.expandenvironmentvariables?view=net-5.0
     */
     static std::string expandEnvironmentVariables(const std::string& path, bool checkIfExists = true);
@@ -91,7 +91,7 @@ public:
     }
 
     /*!
-     * Return a normalized absolutized verion of the pathname supplied.
+     * Return a normalized absolutized version of the pathname supplied.
      */
     static std::string absolutePath(const std::string& path);
 
@@ -131,7 +131,7 @@ public:
     /*!
      *  Reverses separate()
      */
-    static std::string merge(const std::vector<std::string>&, bool isRooted);
+    static std::string merge(const std::vector<std::string>&, bool isAbsolute);
 
     /*!
      * Splits the path into two components: head & tail.

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -78,6 +78,7 @@ public:
     */
     static std::string expandEnvironmentVariables(const std::string& path, bool checkIfExists = true);
     static std::string expandEnvironmentVariables(const std::string& path, Filesystem::FileType);
+    static std::vector<std::string> expandedEnvironmentVariables(const std::string& path); // mostly for unit-testing
 
     /*!
      * Joins two paths together, using the OS-specific delimiter.

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -122,7 +122,7 @@ public:
      *  them. This splits on both '/' and '\\'.
      */
     static std::vector<std::string> separate(const std::string& path);
-    static std::vector<std::string> separate(const std::string& path, bool& isRooted);
+    static std::vector<std::string> separate(const std::string& path, bool& isAbsolute);
 
     inline std::vector<std::string> separate() const
     {

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -128,11 +128,6 @@ public:
     }
 
     /*!
-     *  Reverses separate()
-     */
-    static std::string merge(const std::vector<std::string>&);
-
-    /*!
      * Splits the path into two components: head & tail.
      *
      * The tail part will never contain the delim; if path ends in the delim,

--- a/modules/c++/sys/include/sys/Path.h
+++ b/modules/c++/sys/include/sys/Path.h
@@ -121,11 +121,17 @@ public:
      *  them. This splits on both '/' and '\\'.
      */
     static std::vector<std::string> separate(const std::string& path);
+    static std::vector<std::string> separate(const std::string& path, bool& isRooted);
 
     inline std::vector<std::string> separate() const
     {
         return separate(mPathName);
     }
+
+    /*!
+     *  Reverses separate()
+     */
+    static std::string merge(const std::vector<std::string>&, bool isRooted);
 
     /*!
      * Splits the path into two components: head & tail.

--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -379,7 +379,11 @@ std::string Path::merge(const std::vector<std::string>& components, bool isAbsol
 
         if (i < components.size() - 1)
         {
-            retval += Path::delimiter(); // no trailing delimiter after last component
+            // various manipulations can result in empty components, espeically at the end
+            if (!components[i+1].empty())
+            {
+                retval += Path::delimiter();  // no trailing delimiter after last component
+            }
         }
     }
     return retval;

--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -455,6 +455,7 @@ static ExtractedEnvironmentVariable extractEnvironmentVariable_dollar(std::strin
     return retval;
 }
 
+#if _WIN32 // %FOO% only on Windows
 static ExtractedEnvironmentVariable extractEnvironmentVariable_percent(std::string component, size_t pos) // make a copy for manipulation
 {
     assert(pos != std::string::npos);
@@ -474,6 +475,7 @@ static ExtractedEnvironmentVariable extractEnvironmentVariable_percent(std::stri
     retval.end = component.substr(percent_pos+1);
     return retval;
 }
+#endif // _WIN32
 
 static ExtractedEnvironmentVariable extractEnvironmentVariable(const std::string& component)
 {
@@ -541,7 +543,10 @@ static path_components expandEnvironmentVariable(const std::string& component)
 static path_components join(const std::string& v1, const std::string& v2)
 {
     // put two strings into a new list
-    return path_components{ {v1, v2} };
+    path_components retval;
+    retval.push_back(v1);
+    retval.push_back(v2);
+    return retval;
 }
 static path_components join(path_components v1, const std::string& v2)
 {

--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -288,7 +288,7 @@ std::istream& operator>>(std::istream& is, Path& path)
     return is;
 }
 
-std::string Path::merge(const std::vector<std::string>& components)
+static std::string merge(const std::vector<std::string>& components)
 {
     std::string retval;
     for (const auto& component : components)
@@ -448,7 +448,7 @@ static std::string expandEnvironmentVariables(const std::vector<std::string>& co
     {
     
     }
-    return Path::merge(components);
+    return merge(components);
 }
 
 static std::string expandEnvironmentVariables_noCheckIfExists(const std::vector<std::string>& components)
@@ -462,7 +462,7 @@ static std::string expandEnvironmentVariables_noCheckIfExists(const std::vector<
         // not checking for existence, just grab the first one
         expandedComponents.push_back(result.front());    
     }
-    return Path::merge(expandedComponents);
+    return merge(expandedComponents);
 }
 
 static std::string expandEnvironmentVariables(const std::vector<std::string>& components, bool checkIfExists)
@@ -476,7 +476,7 @@ static std::string expandEnvironmentVariables(const std::vector<std::string>& co
     {
     
     }
-    return Path::merge(components);
+    return merge(components);
 }
 
 // a single "~" is a bit of a special case

--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -344,17 +344,14 @@ static std::string merge_(const std::vector<std::string>& components, bool isAbs
 
         if ((i == 0) && (isAbsolute))
         {
-            // don't want \C:\dir on Windows, but need \\server\dir
-            const auto colon_pos = component.find(':');
-            if (colon_pos == 1)  // yea, there are devices like PRN:
+            // don't want \C:\dir on Windows or //dir on *nix
+            if (component.find(':') == 1)  // yea, there are devices like PRN:
             {
                 retval.clear();  // get rid of delimiter from initialization
             }
-            else
+            else if (component.find('/') == 0)
             {
-                #if _WIN32
-                retval += Path::delimiter();  // \\server
-                #endif
+                retval.clear();  // get rid of delimiter from initialization
             }
         }
         

--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -149,26 +149,9 @@ std::vector<std::string> Path::separate(const std::string& path)
     std::reverse(pathList.begin(), pathList.end());
     return pathList;
 }
-static bool isPathRooted(const std::string& path)
+std::vector<std::string> Path::separate(const std::string& path, bool& isAbsolute)
 {
-    #if _WIN32
-    const auto backslash_pos = path.find('\\');
-    if (backslash_pos == 0)
-    {
-        return path.find("\\\\") ==  0;  // "\\server\folder" is rooted on Windows
-    }
-    else if ((path.find(':') == 1) && (backslash_pos == 2))
-    {
-        return  isalpha(path[0]) ? true : false;  // "C:\" is rooted on Windows
-    }
-    return false;
-    #else
-    return path.find('/') == 0; // "/foo" is rooted on *nix
-    #endif
-}
-std::vector<std::string> Path::separate(const std::string& path, bool& isRooted)
-{
-    isRooted = isPathRooted(path);
+    isAbsolute = isAbsolutePath(path);
     return separate(path);
 }
 
@@ -652,9 +635,9 @@ static std::string expandTilde()
 static std::vector<std::string> expandedEnvironmentVariables_(const std::string& path_, bool& specialPath)
 {
     // Avoid pathalogical cases where the first env-variable expands to escape or ~
-    #ifdef _WIN32
-    // https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
-    constexpr auto escape = R"(\\?\)";
+    #if _WIN32
+    //constexpr auto escape = R"(\\?\)"; // https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    constexpr auto escape = R"(\\)"; // none of the Path:: code supports UNC paths: \\server\dir\file.txt, only C:\dir\file.txt
     #else // assuming *nix
     constexpr auto escape = R"(//)";
     #endif

--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -287,4 +287,40 @@ std::istream& operator>>(std::istream& is, Path& path)
     path.reset(str);
     return is;
 }
+
+std::string Path::merge(const std::vector<std::string>& components)
+{
+    std::string retval;
+    for (const auto& component : components)
+    {
+        if (!retval.empty())
+        {
+            retval += Path::delimiter();
+        }
+        retval += component;
+    }
+    return retval;
+}
+
+std::string Path::expandEnvironmentVariables(const std::string& path)
+{
+    #ifdef _WIN32
+    // https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+    constexpr auto escape = R"(\\?\)";
+    #else
+    // assuming *nix
+    constexpr auto escape = R"(//)";
+    #endif
+    if (path.find_first_of(escape) == 0)
+    {
+        return path;
+    }
+
+    const auto components = Path::separate(path); // "This splits on both '/' and '\\'."
+    for (const auto& component : components)
+    {
+    
+    }
+    return merge(components);
+}
 }

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -323,6 +323,24 @@ TEST_CASE(testBacktrace)
     }
 }
 
+TEST_CASE(testPathMerge)
+{
+    const sys::OS os;
+
+    // PATH is usually set to multiple directories on both Windows and *nix
+    std::vector<std::string> paths;
+    bool result = os.splitEnv("PATH", paths);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_GREATER(paths.size(), 0);
+
+    const auto components = sys::Path::separate(paths[0]);
+    TEST_ASSERT_GREATER(components.size(), 0);
+    const auto path = sys::Path::merge(components);
+    TEST_ASSERT_FALSE(path.empty());
+    TEST_ASSERT_TRUE(sys::Filesystem::exists(path));
+    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(path));
+}
+
 }
 
 int main(int, char**)
@@ -334,6 +352,8 @@ int main(int, char**)
     TEST_CHECK(testFsExtension);
     TEST_CHECK(testFsOutput);
     TEST_CHECK(testBacktrace);
+    TEST_CHECK(testPathMerge);
+
     return 0;
 }
 

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -323,24 +323,6 @@ TEST_CASE(testBacktrace)
     }
 }
 
-TEST_CASE(testPathMerge)
-{
-    const sys::OS os;
-
-    // PATH is usually set to multiple directories on both Windows and *nix
-    std::vector<std::string> paths;
-    bool result = os.splitEnv("PATH", paths);
-    TEST_ASSERT_TRUE(result);
-    TEST_ASSERT_GREATER(paths.size(), 0);
-
-    const auto components = sys::Path::separate(paths[0]);
-    TEST_ASSERT_GREATER(components.size(), 0);
-    const auto path = sys::Path::merge(components);
-    TEST_ASSERT_FALSE(path.empty());
-    TEST_ASSERT_TRUE(sys::Filesystem::exists(path));
-    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(path));
-}
-
 }
 
 int main(int, char**)

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -154,6 +154,49 @@ TEST_CASE(testEnvVariables)
     TEST_ASSERT_FALSE(os.isEnvSet(testvar));
 }
 
+TEST_CASE(testSplitEnv)
+{
+    sys::OS os;
+
+    // PATH is usually set to multiple directories on both Windows and *nix
+    const std::string pathEnvVar = "PATH";
+    std::vector<std::string> paths;
+    bool result = os.splitEnv(pathEnvVar, paths);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_GREATER(paths.size(), 0);
+    for (const auto& path : paths)
+    {
+        TEST_ASSERT_TRUE(sys::Filesystem::exists(path));
+    }
+    
+    // create an environemnt variable with a known bogus path
+    const auto bogusValue =  paths[0] + sys::Path::separator() + "this does not exist";
+    paths.clear();
+    const std::string bogusEnvVar = "CODA_OSS_TEST_PATH";
+    std::string value;
+    TEST_ASSERT_FALSE(os.getEnvIfSet(bogusEnvVar, value));
+    os.setEnv(bogusEnvVar, bogusValue, false /*overwrite*/);
+    result = os.splitEnv(bogusEnvVar, paths);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQ(paths.size(), 1);
+
+    // PATHs are directories, not files
+    paths.clear();
+    result = os.splitEnv(pathEnvVar, paths, sys::Filesystem::FileType::Directory);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_GREATER(paths.size(), 0);
+    paths.clear();
+    result = os.splitEnv(pathEnvVar, paths, sys::Filesystem::FileType::Regular);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_TRUE(paths.empty());
+
+    const std::string notFoundEnvVar = "CODA_OSS_SOME_VAR_THAT_WE_KNOW_WONT_BE_SET";
+    paths.clear();
+    result = os.splitEnv(notFoundEnvVar, paths);
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_TRUE(paths.empty());
+}
+
 template <typename TPath>
 static void testFsExtension_(const std::string& testName)
 {
@@ -287,6 +330,7 @@ int main(int, char**)
     TEST_CHECK(testRecursiveRemove);
     TEST_CHECK(testForcefulMove);
     TEST_CHECK(testEnvVariables);
+    TEST_CHECK(testSplitEnv);
     TEST_CHECK(testFsExtension);
     TEST_CHECK(testFsOutput);
     TEST_CHECK(testBacktrace);

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -352,7 +352,6 @@ int main(int, char**)
     TEST_CHECK(testFsExtension);
     TEST_CHECK(testFsOutput);
     TEST_CHECK(testBacktrace);
-    TEST_CHECK(testPathMerge);
 
     return 0;
 }

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -49,6 +49,8 @@ TEST_CASE(testExpandEnvTilde)
 {
     const auto result = sys::Path::expandEnvironmentVariables("~");
     TEST_ASSERT_FALSE(result.empty());
+    TEST_ASSERT_TRUE(sys::Filesystem::exists(result));
+    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(result));
 }
 
 TEST_CASE(testExpandEnvPath)
@@ -100,10 +102,8 @@ TEST_CASE(testExpandEnvPath)
     pathpath = sys::Path::expandEnvironmentVariables("%PATH%%PATH%", false);
     TEST_ASSERT_EQ(pathpath, path + path);
     #endif
-    auto pathpathpath = sys::Path::expandEnvironmentVariables("$PATH$PATH$PATH", false);
-    TEST_ASSERT_EQ(pathpathpath, path + path + path);
-    pathpathpath = sys::Path::expandEnvironmentVariables("$PATH$(PATH)${PATH}", false);
-    TEST_ASSERT_EQ(pathpathpath, path + path + path);
+    auto pathpathpath = sys::Path::expandEnvironmentVariables("$PATH$(PATH)${PATH}", false);
+    TEST_ASSERT_EQ(pathpathpath, pathpath + path);
 
     const auto foopath_barpathbar_ = sys::Path::expandEnvironmentVariables("foo$PATH-bar$(PATH)BAR)", false);
     TEST_ASSERT_EQ(foopath_barpathbar_, "foo" + path + "-bar" + path + "BAR)");

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -56,28 +56,27 @@ TEST_CASE(testExpandEnvPath)
     const auto path = sys::Path::expandEnvironmentVariables("$PATH", false);
     TEST_ASSERT_FALSE(path.empty());
 
+    #if _WIN32  // %FOO% only on Windows
+    const auto win32_path = sys::Path::expandEnvironmentVariables("%PATH%", false);
+    TEST_ASSERT_EQ(win32_path, path);
+    #endif
+
     const auto path2 = sys::Path::expandEnvironmentVariables("$(PATH)", false);
-    TEST_ASSERT_FALSE(path2.empty());
     TEST_ASSERT_EQ(path2, path);
 
     const auto path3 = sys::Path::expandEnvironmentVariables("${PATH}", false);
-    TEST_ASSERT_FALSE(path3.empty());
     TEST_ASSERT_EQ(path3, path);
 
     const auto foopath = sys::Path::expandEnvironmentVariables("foo${PATH}", false);
-    TEST_ASSERT_FALSE(foopath.empty());
     TEST_ASSERT_EQ(foopath, "foo" + path);
 
     const auto pathfoo = sys::Path::expandEnvironmentVariables("${PATH}foo", false);
-    TEST_ASSERT_FALSE(pathfoo.empty());
     TEST_ASSERT_EQ(pathfoo, path + "foo");
 
     const auto foopathbar = sys::Path::expandEnvironmentVariables("foo${PATH}bar", false);
-    TEST_ASSERT_FALSE(foopathbar.empty());
     TEST_ASSERT_EQ(foopathbar, "foo" + path + "bar");
 
     const auto foopath_bar = sys::Path::expandEnvironmentVariables("foo$PATH-bar", false);
-    TEST_ASSERT_FALSE(foopath_bar.empty());
     TEST_ASSERT_EQ(foopath_bar, "foo" + path + "-bar");
 
     auto foopath_bar_ = sys::Path::expandEnvironmentVariables("foo$PATH(bar)", false);
@@ -85,12 +84,29 @@ TEST_CASE(testExpandEnvPath)
     TEST_ASSERT_EQ(foopath_bar_, "foo" + path + "(bar)");
 
     foopath_bar_ = sys::Path::expandEnvironmentVariables("foo$PATH)bar(", false);
-    TEST_ASSERT_FALSE(foopath_bar_.empty());
     TEST_ASSERT_EQ(foopath_bar_, "foo" + path + ")bar(");
 
     foopath_bar_ = sys::Path::expandEnvironmentVariables("foo$(PATH)BAR)", false);
-    TEST_ASSERT_FALSE(foopath_bar_.empty());
     TEST_ASSERT_EQ(foopath_bar_, "foo" + path + "BAR)");
+
+
+    auto pathpath = sys::Path::expandEnvironmentVariables("$PATH$PATH", false);
+    TEST_ASSERT_EQ(pathpath, path + path);
+    pathpath = sys::Path::expandEnvironmentVariables("$PATH$(PATH)", false);
+    TEST_ASSERT_EQ(pathpath, path + path);
+    pathpath = sys::Path::expandEnvironmentVariables("${PATH}$PATH", false);
+    TEST_ASSERT_EQ(pathpath, path + path);
+    #if _WIN32  // %FOO% only on Windows
+    pathpath = sys::Path::expandEnvironmentVariables("%PATH%%PATH%", false);
+    TEST_ASSERT_EQ(pathpath, path + path);
+    #endif
+    auto pathpathpath = sys::Path::expandEnvironmentVariables("$PATH$PATH$PATH", false);
+    TEST_ASSERT_EQ(pathpathpath, path + path + path);
+    pathpathpath = sys::Path::expandEnvironmentVariables("$PATH$(PATH)${PATH}", false);
+    TEST_ASSERT_EQ(pathpathpath, path + path + path);
+
+    const auto foopath_barpathbar_ = sys::Path::expandEnvironmentVariables("foo$PATH-bar$(PATH)BAR)", false);
+    TEST_ASSERT_EQ(foopath_barpathbar_, "foo" + path + "-bar" + path + "BAR)");
 }
 
 }

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -50,12 +50,56 @@ TEST_CASE(testExpandEnvTilde)
     const auto result = sys::Path::expandEnvironmentVariables("~");
     TEST_ASSERT_FALSE(result.empty());
 }
+
+TEST_CASE(testExpandEnvPath)
+{
+    const auto path = sys::Path::expandEnvironmentVariables("$PATH", false);
+    TEST_ASSERT_FALSE(path.empty());
+
+    const auto path2 = sys::Path::expandEnvironmentVariables("$(PATH)", false);
+    TEST_ASSERT_FALSE(path2.empty());
+    TEST_ASSERT_EQ(path2, path);
+
+    const auto path3 = sys::Path::expandEnvironmentVariables("${PATH}", false);
+    TEST_ASSERT_FALSE(path3.empty());
+    TEST_ASSERT_EQ(path3, path);
+
+    const auto foopath = sys::Path::expandEnvironmentVariables("foo${PATH}", false);
+    TEST_ASSERT_FALSE(foopath.empty());
+    TEST_ASSERT_EQ(foopath, "foo" + path);
+
+    const auto pathfoo = sys::Path::expandEnvironmentVariables("${PATH}foo", false);
+    TEST_ASSERT_FALSE(pathfoo.empty());
+    TEST_ASSERT_EQ(pathfoo, path + "foo");
+
+    const auto foopathbar = sys::Path::expandEnvironmentVariables("foo${PATH}bar", false);
+    TEST_ASSERT_FALSE(foopathbar.empty());
+    TEST_ASSERT_EQ(foopathbar, "foo" + path + "bar");
+
+    const auto foopath_bar = sys::Path::expandEnvironmentVariables("foo$PATH-bar", false);
+    TEST_ASSERT_FALSE(foopath_bar.empty());
+    TEST_ASSERT_EQ(foopath_bar, "foo" + path + "-bar");
+
+    auto foopath_bar_ = sys::Path::expandEnvironmentVariables("foo$PATH(bar)", false);
+    TEST_ASSERT_FALSE(foopath_bar_.empty());
+    TEST_ASSERT_EQ(foopath_bar_, "foo" + path + "(bar)");
+
+    foopath_bar_ = sys::Path::expandEnvironmentVariables("foo$PATH)bar(", false);
+    TEST_ASSERT_FALSE(foopath_bar_.empty());
+    TEST_ASSERT_EQ(foopath_bar_, "foo" + path + ")bar(");
+
+    foopath_bar_ = sys::Path::expandEnvironmentVariables("foo$(PATH)BAR)", false);
+    TEST_ASSERT_FALSE(foopath_bar_.empty());
+    TEST_ASSERT_EQ(foopath_bar_, "foo" + path + "BAR)");
+}
+
 }
 
 int main(int, char**)
 {
     TEST_CHECK(testPathMerge);
     TEST_CHECK(testExpandEnvTilde);
+    TEST_CHECK(testExpandEnvPath);
 
     return 0;
 }

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -68,8 +68,14 @@ TEST_CASE(testPathMerge)
 
 TEST_CASE(testExpandEnvTilde)
 {
-    const auto result = sys::Path::expandEnvironmentVariables("~");
-    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(result));
+    auto path = sys::Path::expandEnvironmentVariables("~");
+    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(path));
+
+    path = sys::Path::expandEnvironmentVariables("~", sys::Filesystem::FileType::Directory);
+    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(path));
+
+    path = sys::Path::expandEnvironmentVariables("~", sys::Filesystem::FileType::Regular);
+    TEST_ASSERT_TRUE(path.empty());
 }
 
 TEST_CASE(testExpandEnvPath)

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -170,9 +170,15 @@ TEST_CASE(testExpandEnvPathMultiple)
 
     const std::string path_to_expand = "/disk0/$(paths)/$(apps)/$(app)/$(libs)/$(exts)";
     const std::vector<std::string> expected{"disk0", paths[0], apps[0], app[0], libs[0], exts[0]};
-    const auto expected_path = sys::Path::merge(expected, true /*isAbsolute*/);
+    auto expected_path = sys::Path::merge(expected, true /*isAbsolute*/);
     auto expanded_path = sys::Path::expandEnvironmentVariables(path_to_expand, false /*checkIfExists*/);
     TEST_ASSERT_EQ(expanded_path, expected_path);
+
+    const auto expanded_paths = sys::Path::expandedEnvironmentVariables(path_to_expand);
+    TEST_ASSERT_EQ(expanded_paths.size(), paths.size() * apps.size() * app.size() * libs.size() * exts.size());
+    const std::vector<std::string> expected_back{"disk0", paths.back(), apps.back(), app.back(), libs.back(), exts.back()};
+    expected_path = sys::Path::merge(expected_back, true /*isAbsolute*/);
+    TEST_ASSERT_EQ(expanded_paths.back(), expected_path);
 }
 
 }

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -92,12 +92,8 @@ TEST_CASE(testExpandEnvPath)
     const auto foopath = sys::Path::expandEnvironmentVariables("foo${PATH}", false);
     TEST_ASSERT_EQ(foopath, "foo" + path);
 
-    getchar();
     const auto pathfoo = sys::Path::expandEnvironmentVariables("${PATH}foo", false);
-    std::clog << "pathfoo = '" << pathfoo << "'\n";
-    auto expected = path.substr(0, path.size()-1); // remove trailing '/'
-    expected += "foo";
-    TEST_ASSERT_EQ(pathfoo, expected);
+    TEST_ASSERT_EQ(pathfoo, path + "foo");
 
     const auto foopathbar = sys::Path::expandEnvironmentVariables("foo${PATH}bar", false);
     TEST_ASSERT_EQ(foopathbar, "foo" + path + "bar");

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -78,6 +78,17 @@ TEST_CASE(testExpandEnvTilde)
     TEST_ASSERT_TRUE(path.empty());
 }
 
+TEST_CASE(testExpandEnvTildePath)
+{
+    sys::OS os;
+    const std::vector<std::string> exts{"NTUSER.DAT", ".login", ".cshrc", ".bashrc"};
+    const auto result = os.prependEnv("exts", exts, true /*overwrite*/);
+    TEST_ASSERT_TRUE(result);
+
+    const auto path = sys::Path::expandEnvironmentVariables("~/$(exts)", sys::Filesystem::FileType::Regular);
+    TEST_ASSERT_TRUE(sys::Filesystem::is_regular_file(path));
+}
+
 TEST_CASE(testExpandEnvPath)
 {
     const auto path = sys::Path::expandEnvironmentVariables("$PATH", false);
@@ -171,7 +182,7 @@ TEST_CASE(testExpandEnvPathMultiple)
     result = os.prependEnv("libs", libs, false /*overwrite*/);
     TEST_ASSERT_TRUE(result);
     const std::vector<std::string> exts{"libfoo.a", "libfoo.so", "foo.dll"};
-    result = os.prependEnv("exts", exts, false /*overwrite*/);
+    result = os.prependEnv("exts", exts, true /*overwrite*/);
     TEST_ASSERT_TRUE(result);
 
     const std::string path_to_expand = "/disk0/$(paths)/$(apps)/$(app)/$(libs)/$(exts)";
@@ -194,6 +205,7 @@ int main(int, char**)
     TEST_CHECK(testPathMerge);
     TEST_CHECK(testExpandEnvTilde);
     TEST_CHECK(testExpandEnvPath);
+    TEST_CHECK(testExpandEnvTildePath);    
     TEST_CHECK(testExpandEnvPathExists);
     TEST_CHECK(testExpandEnvPathMultiple);
 

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -27,24 +27,6 @@
 
 namespace
 {
-TEST_CASE(testPathMerge)
-{
-    const sys::OS os;
-
-    // PATH is usually set to multiple directories on both Windows and *nix
-    std::vector<std::string> paths;
-    bool result = os.splitEnv("PATH", paths);
-    TEST_ASSERT_TRUE(result);
-    TEST_ASSERT_GREATER(paths.size(), 0);
-
-    const auto components = sys::Path::separate(paths[0]);
-    TEST_ASSERT_GREATER(components.size(), 0);
-    const auto path = sys::Path::merge(components);
-    TEST_ASSERT_FALSE(path.empty());
-    TEST_ASSERT_TRUE(sys::Filesystem::exists(path));
-    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(path));
-}
-
 TEST_CASE(testExpandEnvTilde)
 {
     const auto result = sys::Path::expandEnvironmentVariables("~");
@@ -113,7 +95,6 @@ TEST_CASE(testExpandEnvPath)
 
 int main(int, char**)
 {
-    TEST_CHECK(testPathMerge);
     TEST_CHECK(testExpandEnvTilde);
     TEST_CHECK(testExpandEnvPath);
 

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -172,6 +172,19 @@ TEST_CASE(testExpandEnvPathMultiple)
     const std::vector<std::string> paths{"home", "opt", "var"};
     bool result = os.prependEnv("paths", paths, false /*overwrite*/);
     TEST_ASSERT_TRUE(result);
+    auto expanded_path = sys::Path::expandEnvironmentVariables("$(paths)", false /*checkIfExists*/);
+    TEST_ASSERT_EQ(expanded_path, "home");
+    auto expanded_paths = sys::Path::expandedEnvironmentVariables("$(paths)");
+    TEST_ASSERT_EQ(expanded_paths.size(), 3);
+    expanded_path = sys::Path::expandEnvironmentVariables("/$(paths)", false /*checkIfExists*/);
+    TEST_ASSERT_EQ(expanded_path, "/home");
+    expanded_paths = sys::Path::expandedEnvironmentVariables("/$(paths)");
+    TEST_ASSERT_EQ(expanded_paths.size(), 3);
+    expanded_path = sys::Path::expandEnvironmentVariables("/disk0/$(paths)", false /*checkIfExists*/);
+    TEST_ASSERT_EQ(expanded_path, "/disk0/home");
+    expanded_paths = sys::Path::expandedEnvironmentVariables("/disk0/$(paths)");
+    TEST_ASSERT_EQ(expanded_paths.size(), 3);
+
     const std::vector<std::string> apps{"apps"};
     result = os.prependEnv("apps", apps, false /*overwrite*/);
     TEST_ASSERT_TRUE(result);
@@ -188,10 +201,10 @@ TEST_CASE(testExpandEnvPathMultiple)
     const std::string path_to_expand = "/disk0/$(paths)/$(apps)/$(app)/$(libs)/$(exts)";
     const std::vector<std::string> expected{"disk0", paths[0], apps[0], app[0], libs[0], exts[0]};
     auto expected_path = sys::Path::merge(expected, true /*isAbsolute*/);
-    auto expanded_path = sys::Path::expandEnvironmentVariables(path_to_expand, false /*checkIfExists*/);
+    expanded_path = sys::Path::expandEnvironmentVariables(path_to_expand, false /*checkIfExists*/);
     TEST_ASSERT_EQ(expanded_path, expected_path);
 
-    const auto expanded_paths = sys::Path::expandedEnvironmentVariables(path_to_expand);
+    expanded_paths = sys::Path::expandedEnvironmentVariables(path_to_expand);
     TEST_ASSERT_EQ(expanded_paths.size(), paths.size() * apps.size() * app.size() * libs.size() * exts.size());
     const std::vector<std::string> expected_back{"disk0", paths.back(), apps.back(), app.back(), libs.back(), exts.back()};
     expected_path = sys::Path::merge(expected_back, true /*isAbsolute*/);

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -52,8 +52,6 @@ TEST_CASE(testPathMerge)
     auto components = sys::Path::separate(path, isAbsolute);
     TEST_ASSERT_GREATER(components.size(), 0);
     auto result = sys::Path::merge(components, isAbsolute);
-    std::clog << "path = '" << path << "'\n";
-    std::clog << "result = '" << result << "'\n";
     TEST_ASSERT_EQ(result, path);
     TEST_ASSERT_TRUE(sys::Filesystem::is_directory(result));
 
@@ -94,8 +92,12 @@ TEST_CASE(testExpandEnvPath)
     const auto foopath = sys::Path::expandEnvironmentVariables("foo${PATH}", false);
     TEST_ASSERT_EQ(foopath, "foo" + path);
 
+    getchar();
     const auto pathfoo = sys::Path::expandEnvironmentVariables("${PATH}foo", false);
-    TEST_ASSERT_EQ(pathfoo, path + "foo");
+    std::clog << "pathfoo = '" << pathfoo << "'\n";
+    auto expected = path.substr(0, path.size()-1); // remove trailing '/'
+    expected += "foo";
+    TEST_ASSERT_EQ(pathfoo, expected);
 
     const auto foopathbar = sys::Path::expandEnvironmentVariables("foo${PATH}bar", false);
     TEST_ASSERT_EQ(foopathbar, "foo" + path + "bar");

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -1,0 +1,62 @@
+/* =========================================================================
+ * This file is part of sys-c++
+ * =========================================================================
+ * 
+ * (C) Copyright 2004 - 2016, MDA Information Systems LLC
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this program; If not, 
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <assert.h>
+
+#include <sys/Path.h>
+#include "TestCase.h"
+
+namespace
+{
+TEST_CASE(testPathMerge)
+{
+    const sys::OS os;
+
+    // PATH is usually set to multiple directories on both Windows and *nix
+    std::vector<std::string> paths;
+    bool result = os.splitEnv("PATH", paths);
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_GREATER(paths.size(), 0);
+
+    const auto components = sys::Path::separate(paths[0]);
+    TEST_ASSERT_GREATER(components.size(), 0);
+    const auto path = sys::Path::merge(components);
+    TEST_ASSERT_FALSE(path.empty());
+    TEST_ASSERT_TRUE(sys::Filesystem::exists(path));
+    TEST_ASSERT_TRUE(sys::Filesystem::is_directory(path));
+}
+
+TEST_CASE(testExpandEnvTilde)
+{
+    const auto result = sys::Path::expandEnvironmentVariables("~");
+    TEST_ASSERT_FALSE(result.empty());
+}
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(testPathMerge);
+    TEST_CHECK(testExpandEnvTilde);
+
+    return 0;
+}
+


### PR DESCRIPTION
This makes it easy to write C++ code that works like SHELL code. This can be especially convenient for various utilities or testing where an environment variable specifies a "root" directory.