### PR TITLE
Fix wscript to successfully build test_num_elements

### DIFF
--- a/modules/c++/numpyutils/wscript
+++ b/modules/c++/numpyutils/wscript
@@ -15,3 +15,4 @@ def build(bld):
     if 'PY_HAVE_NUMPY' in bld.env and bld.env['PY_HAVE_NUMPY']:
        bld.module(**globals())
        bld.recurse(['examples'])
+

--- a/modules/c++/numpyutils/wscript
+++ b/modules/c++/numpyutils/wscript
@@ -2,7 +2,7 @@ NAME            = 'numpyutils'
 MAINTAINER      = 'anuraag.pakanati@mdaus.com'
 VERSION         = '1.0'
 MODULE_DEPS     = 'types except sys'
-USELIB          = 'NUMPY PYEXT'
+USELIB          = 'NUMPY PYEXT PYEMBED'
 
 from waflib import Options
 


### PR DESCRIPTION
There was a missing required library in this wscript which caused some tests to fail to build. This fixes the issue.