### PR TITLE
Fix for numerical precision issues surrounding horizontal lines

### DIFF
--- a/modules/c++/math.linear/source/Line2D.cpp
+++ b/modules/c++/math.linear/source/Line2D.cpp
@@ -149,6 +149,16 @@ bool Line2D::intersection(const Line2D& rhs, Point& P) const
         P.row = rhs.mXIntercept;
         P.col = y(P.row);
     }
+    else if (mType == Line2D::HORIZONTAL)
+    {
+        P.col = mYIntercept;
+        P.row = rhs.x(P.col);
+    }
+    else if (rhs.mType == Line2D::HORIZONTAL)
+    {
+        P.col = rhs.mYIntercept;
+        P.row = x(P.col);
+    }
     else
     {
         P.row = (rhs.mYIntercept - mYIntercept) / (mSlope - rhs.mSlope);


### PR DESCRIPTION
Migrating a subtree patch to oss that applies the same principle to horizontal calculations as is applied to vertical ones