### PR TITLE
Macros to narrowly target disabling warnings

### DIFF
--- a/modules/c++/config/include/config/compiler_extensions.h
+++ b/modules/c++/config/include/config/compiler_extensions.h
@@ -86,11 +86,40 @@
     #endif
 #endif  // _MM256_EXTRACTF
 
+
+#ifndef CODA_OSS_HAVE_DISABLE_WARNINGS
+    #define CODA_OSS_HAVE_DISABLE_WARNINGS 1
+
+    // Adapted from
+    // https://www.fluentcpp.com/2019/08/30/how-to-disable-a-warning-in-cpp/
+    #if defined(_MSC_VER)
+        #define CODA_OSS_disable_warning_push           __pragma(warning( push ))
+        #define CODA_OSS_disable_warning_pop            __pragma(warning( pop ))
+
+        #define CODA_OSS_disable_warning(warningNumber) __pragma(warning( disable : warningNumber ))
+    #elif defined(__GNUC__) || defined(__clang__)
+        #define CODA_OSS_do_pragma(X) _Pragma(#X)
+        #define CODA_OSS_disable_warning_push           CODA_OSS_do_pragma(GCC diagnostic push)
+        #define CODA_OSS_disable_warning_pop            CODA_OSS_do_pragma(gcc diagnostic pop)
+        #define CODA_OSS_disable_warning(warningName)   CODA_OSS_do_pragma(GCC diagnostic ignored #warningName)
+    #else
+        #define CODA_OSS_disable_warning_push
+        #define CODA_OSS_disable_warning_pop
+        #define CODA_OSS_disable_warning(warningName)
+    #endif
+#endif // CODA_OSS_HAVE_DISABLE_WARNINGS
+
 #ifndef CODA_OSS_mark_symbol_unused
     // Fix unused symbol warnings that crash Release build on -Werror
     // (won't work without C-style cast)
     // https://stackoverflow.com/a/777359/5401366
-    #define CODA_OSS_mark_symbol_unused(x) ((void)x)
+    // 4551 => 'function call missing argument list'
+    #define CODA_OSS_mark_symbol_unused(x) do { \
+        CODA_OSS_disable_warning_push \
+        CODA_OSS_disable_warning(4551) \
+        ((void)x); \
+        CODA_OSS_disable_warning_pop \
+    } while (0);
 #endif
 
 #endif  // CODA_OSS_config_compiler_extentions_h_INCLUDED_

--- a/modules/c++/config/include/config/compiler_extensions.h
+++ b/modules/c++/config/include/config/compiler_extensions.h
@@ -95,17 +95,23 @@
     #if defined(_MSC_VER)
         #define CODA_OSS_disable_warning_push           __pragma(warning( push ))
         #define CODA_OSS_disable_warning_pop            __pragma(warning( pop ))
-
         #define CODA_OSS_disable_warning(warningNumber) __pragma(warning( disable : warningNumber ))
+
+        // 4551 => 'function call missing argument list'
+        #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST CODA_OSS_disable_warning(4551)
     #elif defined(__GNUC__) || defined(__clang__)
         #define CODA_OSS_do_pragma(X) _Pragma(#X)
         #define CODA_OSS_disable_warning_push           CODA_OSS_do_pragma(GCC diagnostic push)
         #define CODA_OSS_disable_warning_pop            CODA_OSS_do_pragma(gcc diagnostic pop)
         #define CODA_OSS_disable_warning(warningName)   CODA_OSS_do_pragma(GCC diagnostic ignored #warningName)
+
+        // no such thing
+        #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST
     #else
         #define CODA_OSS_disable_warning_push
         #define CODA_OSS_disable_warning_pop
         #define CODA_OSS_disable_warning(warningName)
+        #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST
     #endif
 #endif // CODA_OSS_HAVE_DISABLE_WARNINGS
 
@@ -113,10 +119,9 @@
     // Fix unused symbol warnings that crash Release build on -Werror
     // (won't work without C-style cast)
     // https://stackoverflow.com/a/777359/5401366
-    // 4551 => 'function call missing argument list'
     #define CODA_OSS_mark_symbol_unused(x) do { \
         CODA_OSS_disable_warning_push \
-        CODA_OSS_disable_warning(4551) \
+        CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST \
         ((void)x); \
         CODA_OSS_disable_warning_pop \
     } while (0);


### PR DESCRIPTION
- [x] Macros for turning off warnings in a crossplatform way (https://www.fluentcpp.com/2019/08/30/how-to-disable-a-warning-in-cpp/)
- [x] Fix windows warning 4551 ('function call missing argument list') on one of the numpyutils tests (in the following code)
       ` CODA_OSS_mark_symbol_unused(_import_array);`
    - [x] Verified that no function call is actually emitted by MSVC when a function reference without an argument list appears in the code (like above) with the following demo program
```c++
// Compile with:
// cl.exe /EHsc foo.cpp
#include <iostream>

void
foo() {
   std::cout << "error if this shows up!" << std::endl;
}

int
main() {
    std::cout << "before" <<std::endl;
    foo;
    std::cout << "after" <<std::endl;
    return 0;
}
```
 
    