### PR TITLE
Bugfix/python3.9 related

### DIFF
--- a/modules/c++/config/include/config/compiler_extensions.h
+++ b/modules/c++/config/include/config/compiler_extensions.h
@@ -112,7 +112,8 @@
 
         #define CODA_OSS_disable_warning_system_header_push \
             CODA_OSS_disable_warning_push \
-            CODA_OSS_disable_warning(-w)
+            CODA_OSS_disable_warning(-Wall) \
+            CODA_OSS_disable_warning(-Wextra)
 
         // no such thing
         #define CODA_OSS_DISABLE_UNREACHABLE_CODE

--- a/modules/c++/config/include/config/compiler_extensions.h
+++ b/modules/c++/config/include/config/compiler_extensions.h
@@ -97,9 +97,11 @@
         #define CODA_OSS_disable_warning_pop            __pragma(warning( pop ))
         #define CODA_OSS_disable_warning(warningNumber) __pragma(warning( disable : warningNumber ))
 
+        #define CODA_OSS_disable_warning_system_header_push  __pragma(warning(push, 0))
+
         // 4551 => 'function call missing argument list'
         #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST CODA_OSS_disable_warning(4551)
-		
+
         // 4702 Unreachable Code Warning
         #define CODA_OSS_DISABLE_UNREACHABLE_CODE CODA_OSS_disable_warning(4702)
     #elif defined(__GNUC__) || defined(__clang__)
@@ -108,6 +110,9 @@
         #define CODA_OSS_disable_warning_pop            CODA_OSS_do_pragma(gcc diagnostic pop)
         #define CODA_OSS_disable_warning(warningName)   CODA_OSS_do_pragma(GCC diagnostic ignored #warningName)
 
+        #define CODA_OSS_disable_warning_system_header_push \
+            CODA_OSS_disable_warning_push \
+            CODA_OSS_disable_warning(-w)
 
         // no such thing
         #define CODA_OSS_DISABLE_UNREACHABLE_CODE
@@ -116,6 +121,8 @@
         #define CODA_OSS_disable_warning_push
         #define CODA_OSS_disable_warning_pop
         #define CODA_OSS_disable_warning(warningName)
+        #define CODA_OSS_disable_warning_system_header_push
+        #define CODA_OSS_DISABLE_UNREACHABLE_CODE
         #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST
     #endif
 #endif // CODA_OSS_HAVE_DISABLE_WARNINGS

--- a/modules/c++/config/include/config/compiler_extensions.h
+++ b/modules/c++/config/include/config/compiler_extensions.h
@@ -107,7 +107,7 @@
     #elif defined(__GNUC__) || defined(__clang__)
         #define CODA_OSS_do_pragma(X) _Pragma(#X)
         #define CODA_OSS_disable_warning_push           CODA_OSS_do_pragma(GCC diagnostic push)
-        #define CODA_OSS_disable_warning_pop            CODA_OSS_do_pragma(gcc diagnostic pop)
+        #define CODA_OSS_disable_warning_pop            CODA_OSS_do_pragma(GCC diagnostic pop)
         #define CODA_OSS_disable_warning(warningName)   CODA_OSS_do_pragma(GCC diagnostic ignored #warningName)
 
         #define CODA_OSS_disable_warning_system_header_push \
@@ -116,15 +116,15 @@
             CODA_OSS_disable_warning(-Wextra)
 
         // no such thing
-        #define CODA_OSS_DISABLE_UNREACHABLE_CODE
         #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST
+        #define CODA_OSS_DISABLE_UNREACHABLE_CODE
     #else
         #define CODA_OSS_disable_warning_push
         #define CODA_OSS_disable_warning_pop
         #define CODA_OSS_disable_warning(warningName)
         #define CODA_OSS_disable_warning_system_header_push
-        #define CODA_OSS_DISABLE_UNREACHABLE_CODE
         #define CODA_OSS_FUNCTION_CALL_MISSING_ARG_LIST
+        #define CODA_OSS_DISABLE_UNREACHABLE_CODE
     #endif
 #endif // CODA_OSS_HAVE_DISABLE_WARNINGS
 

--- a/modules/c++/numpyutils/include/numpyutils/numpyutils.h
+++ b/modules/c++/numpyutils/include/numpyutils/numpyutils.h
@@ -24,8 +24,13 @@
 #define __NUMPYUTILS_NUMPYUTILS_H__
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <config/compiler_extensions.h>
 #include <Python.h>
+CODA_OSS_disable_warning_system_header_push
 #include <numpy/arrayobject.h>
+CODA_OSS_disable_warning_pop
+
 #include <types/RowCol.h>
 #include <vector>
 

--- a/modules/c++/numpyutils/source/numpyutils.cpp
+++ b/modules/c++/numpyutils/source/numpyutils.cpp
@@ -118,7 +118,6 @@ const npy_intp* const getDimensions(PyObject* pyArrayObject)
     {
         throw except::Exception(Ctxt(
                     "Numpy array has dimensions different than 2"));
-        return 0;
     }
     return PyArray_DIMS(reinterpret_cast<PyArrayObject*>(pyArrayObject));
 }


### PR DESCRIPTION
- numpy's includes cause no end of trouble with the  `modules/c++/numpyutils/unittests/test_num_elements.cpp` test
    - I built locally against a 3.9.x version of python with MSVC, which manifested the error (not present in our default build against python 3.7)
    - I added some macros to allow turning off warnings when `#include`-ing a header or set of headers
      - Inspiration for the change came from this MS blogpost: https://devblogs.microsoft.com/cppblog/broken-warnings-theory/#warning-level-for-external-headers
