### PR TITLE
Disable encryption support in minizip build and remove crypt.h header

### DIFF
--- a/modules/drivers/zlib/CMakeLists.txt
+++ b/modules/drivers/zlib/CMakeLists.txt
@@ -85,6 +85,8 @@ elseif(ENABLE_ZIP)
     endif()
 
     set(SOURCE_DIR "${${CMAKE_PROJECT_NAME}_${TARGET_NAME}_SOURCE_DIR}")
+    # remove crypt.h due to name clash with glibc
+    file(REMOVE "${SOURCE_DIR}/contrib/minizip/crypt.h")
     foreach(src "adler32.c" "crc32.c" "deflate.c" "infback.c" "inffast.c"
                 "inflate.c" "inftrees.c" "trees.c" "zutil.c" "compress.c"
                 "uncompr.c" "gzclose.c" "gzlib.c" "gzread.c" "gzwrite.c")
@@ -112,6 +114,9 @@ elseif(ENABLE_ZIP)
             DESTINATION "${CODA_STD_PROJECT_INCLUDE_DIR}"
             ${CODA_INSTALL_OPTION})
 endif()
+
+# disable include of crypt.h in minizip to fix name clash issue with glibc
+target_compile_definitions(minizip PUBLIC -DNOCRYPT -DNOUNCRYPT)
 
 install(TARGETS z minizip
         EXPORT ${CODA_EXPORT_SET_NAME}

--- a/modules/drivers/zlib/wscript
+++ b/modules/drivers/zlib/wscript
@@ -53,6 +53,15 @@ def configure(conf):
 
             untarFile(path=conf.path, fname=ZLIB_VERSION + '.tar')
 
+            # remove minizip's crypt.h and define NOCRYPT and NOUNCRYPT macros
+            # minizip crypt.h clashes with glibc crypt.h
+            crypt_h_path = os.path.join(
+                conf.path.abspath(),
+                ZLIB_VERSION,
+                'contrib', 'minizip', 'crypt.h')
+            if os.path.exists(crypt_h_path):
+                os.remove(crypt_h_path)
+
         else:
             if conf.check(lib='z', uselib_store='ZIP',
                        header_name='zlib.h', function_name='inflate',
@@ -65,6 +74,8 @@ def configure(conf):
                        header_name='zip.h', function_name='zipOpen',
                        msg='Checking for library minizip',
                        mandatory=False)
+        conf.define('NOCRYPT', 1)
+        conf.define('NOUNCRYPT', 1)
 
 
 def writeDefsFile(pathname, *exports):


### PR DESCRIPTION
This header clashes with glibc's crypt.h header.

The minizip crypt.h header is deleted after unpacking the zlib tarfile, and preprocessor options are configured to disable its inclusion.