### PR TITLE
added missing "virtual", support unique_ptr

### DIFF
--- a/modules/c++/logging/include/logging/Filter.h
+++ b/modules/c++/logging/include/logging/Filter.h
@@ -24,8 +24,9 @@
 //  Filter.h
 ///////////////////////////////////////////////////////////
 
-#ifndef __LOGGING_FILTER_H__
-#define __LOGGING_FILTER_H__
+#ifndef CODA_OSS_logging_Filter_h_INCLUDED_
+#define CODA_OSS_logging_Filter_h_INCLUDED_
+#pragma once
 
 #include <string>
 #include "logging/LogRecord.h"
@@ -38,18 +39,25 @@ namespace logging
  *
  * \brief Filter instances are used to perform arbitrary filtering of LogRecords.
  */
-class Filter
+struct Filter
 {
-public:
     Filter(std::string name = "") : mName(name){}
-    virtual ~Filter(){}
+    virtual ~Filter() = default;
 
-    bool filter(const LogRecord* record) const;
-    std::string getName() const { return mName; }
+    virtual bool filter(const LogRecord* record) const;
+    virtual bool filter(const LogRecord& record) const
+    {
+        return filter(&record);
+    }
+
+    std::string getName() const
+    {
+        return mName;
+    }
 
 protected:
     std::string mName;
 };
 
 }
-#endif
+#endif  // CODA_OSS_logging_Filter_h_INCLUDED_

--- a/modules/c++/logging/include/logging/Filterer.h
+++ b/modules/c++/logging/include/logging/Filterer.h
@@ -24,8 +24,9 @@
 //  Filterer.h
 ///////////////////////////////////////////////////////////
 
-#ifndef __LOGGING_FILTERER_H__
-#define __LOGGING_FILTERER_H__
+#ifndef CODA_OSS_logging_Filterer_h_INCLUDED_
+#define CODA_OSS_logging_Filterer_h_INCLUDED_
+#pragma once
 
 #include <string>
 #include <map>
@@ -51,19 +52,22 @@ struct Filterer
      * the pointer
      */
     void addFilter(Filter* filter);
+    void addFilter(Filter&);
 
-    bool filter(const LogRecord* record) const; // this is probably WRONG, use the virtual
-    virtual bool filter(const LogRecord&) const;
+    virtual bool filter(const LogRecord* record) const;
+    virtual bool filter(const LogRecord& record) const
+    {
+        return filter(&record);
+    }
 
     //! Removes the specified Filter
     void removeFilter(Filter* filter);
+    void removeFilter(Filter&);
 
 protected:
     std::map<std::string, Filter*> filters;
-
-private:
-    bool filter_(const LogRecord* record) const;
 };
 
 }
-#endif
+#endif // CODA_OSS_logging_Filterer_h_INCLUDED_
+

--- a/modules/c++/logging/include/logging/Filterer.h
+++ b/modules/c++/logging/include/logging/Filterer.h
@@ -41,11 +41,10 @@ namespace logging
  * A base class for loggers and handlers which allows them to share
  * common code.
  */
-class Filterer
+struct Filterer
 {
-public:
-    Filterer(){}
-    virtual ~Filterer(){}
+    Filterer() = default;
+    virtual ~Filterer() = default;
 
     /*!
      * Adds a Filter to the managed map of Filters. We do NOT take control of
@@ -53,7 +52,8 @@ public:
      */
     void addFilter(Filter* filter);
 
-    bool filter(const LogRecord* record) const;
+    bool filter(const LogRecord* record) const; // this is probably WRONG, use the virtual
+    virtual bool filter(const LogRecord&) const;
 
     //! Removes the specified Filter
     void removeFilter(Filter* filter);
@@ -61,6 +61,8 @@ public:
 protected:
     std::map<std::string, Filter*> filters;
 
+private:
+    bool filter_(const LogRecord* record) const;
 };
 
 }

--- a/modules/c++/logging/include/logging/Handler.h
+++ b/modules/c++/logging/include/logging/Handler.h
@@ -24,8 +24,8 @@
 //  Handler.h
 ///////////////////////////////////////////////////////////
 
-#ifndef __LOGGING_HANDLER_H__
-#define __LOGGING_HANDLER_H__
+#ifndef CODA_OSS_logging_Handler_h_INCLUDED_
+#define CODA_OSS_logging_Handler_h_INCLUDED_
 
 #include <string>
 #include "logging/LogRecord.h"
@@ -51,9 +51,7 @@ struct Handler : public Filterer
      * Construct a Handler at the specified LogLevel (LogLevel::LOG_NOTSET is default)
      */
     Handler(LogLevel level = LogLevel::LOG_NOTSET);
-    virtual ~Handler()
-    {
-    }
+    virtual ~Handler() = default;
     Handler& operator=(const Handler&) = delete;
 
     /*! 
@@ -74,6 +72,10 @@ struct Handler : public Filterer
      * and emitted.
      */
     virtual bool handle(const LogRecord* record);
+    virtual bool handle(const LogRecord& record)
+    {
+        return handle(&record);
+    }
 
     virtual void close();
 
@@ -85,7 +87,10 @@ protected:
     // for writing directly to stream, 
     // used for the bulk of the logging for speed
     virtual void emitRecord(const LogRecord* record) = 0;
-
+    virtual void emitRecord(const LogRecord& record)
+    {
+        return emitRecord(&record);
+    }
 
     LogLevel mLevel = LogLevel::LOG_NOTSET;
     sys::Mutex mHandlerLock;
@@ -94,4 +99,4 @@ protected:
 };
 
 }
-#endif
+#endif  // CODA_OSS_logging_Handler_h_INCLUDED_

--- a/modules/c++/logging/include/logging/Handler.h
+++ b/modules/c++/logging/include/logging/Handler.h
@@ -59,6 +59,7 @@ struct Handler : public Filterer
      * Not Threads Safe!
      */ 
     virtual void setFormatter(Formatter* formatter);
+    virtual void setFormatter(std::unique_ptr<Formatter>&&);
 
     //! Sets the minimum LogLevel required to emit LogRecords
     void setLevel(LogLevel level);

--- a/modules/c++/logging/include/logging/Logger.h
+++ b/modules/c++/logging/include/logging/Logger.h
@@ -24,12 +24,13 @@
 //  Logger.h
 ///////////////////////////////////////////////////////////
 
-#ifndef __LOGGING_LOGGER_H__
-#define __LOGGING_LOGGER_H__
+#ifndef CODA_OSS_logging_Logger_h_INCLUDED_
+#define CODA_OSS_logging_Logger_h_INCLUDED_
 
 #include <string>
 #include <vector>
 #include <memory>
+
 #include "logging/Filterer.h"
 #include "logging/LogRecord.h"
 #include "logging/Handler.h"
@@ -104,6 +105,7 @@ struct Logger : public Filterer
      * This Logger does not own the passed-in Handler.
      */
     void addHandler(Handler* handler, bool own = false);
+    void addHandler(std::unique_ptr<Handler>&&); // own = true
 
     /*!
      * Removes the specified Handler from the list of Handlers.
@@ -139,14 +141,17 @@ struct Logger : public Filterer
 
 protected:
     void handle(const LogRecord* record);
+    void handle(const LogRecord& record)
+    {
+        handle(&record);
+    }
 
     typedef std::pair<Handler*, bool> Handler_T;
     typedef std::vector<Handler_T> Handlers_T;
 
     std::string mName;
     Handlers_T mHandlers;
-
 };
 typedef std::shared_ptr<Logger> LoggerPtr;
 }
-#endif
+#endif  // CODA_OSS_logging_Logger_h_INCLUDED_

--- a/modules/c++/logging/include/logging/StreamHandler.h
+++ b/modules/c++/logging/include/logging/StreamHandler.h
@@ -57,6 +57,7 @@ struct StreamHandler : public Handler
     //! adds the need to write epilogue before deleting formatter
     //  and then writing the prologue with the new formatter
     virtual void setFormatter(Formatter* formatter);
+    virtual void setFormatter(std::unique_ptr<Formatter>&&);
 
     virtual void close();
 

--- a/modules/c++/logging/source/Filterer.cpp
+++ b/modules/c++/logging/source/Filterer.cpp
@@ -34,8 +34,12 @@ void logging::Filterer::addFilter(logging::Filter* filter)
         filters[filter->getName()] = filter;
     }
 }
+void logging::Filterer::addFilter(logging::Filter& filter)
+{
+    addFilter(&filter);
+}
 
-bool logging::Filterer::filter_(const logging::LogRecord* record) const
+bool logging::Filterer::filter(const logging::LogRecord* record) const
 {
     for (const auto& p : filters)
     {
@@ -44,18 +48,12 @@ bool logging::Filterer::filter_(const logging::LogRecord* record) const
     }
     return true;
 }
-bool logging::Filterer::filter(const logging::LogRecord* record) const
-{
-    return filter_(record);
-}
-bool logging::Filterer::filter(const logging::LogRecord& record) const
-{
-    return filter_(&record);
-}
 
 void logging::Filterer::removeFilter(logging::Filter* filter)
 {
     filters.erase(filter->getName());
-
 }
-
+void logging::Filterer::removeFilter(logging::Filter& filter)
+{
+    removeFilter(&filter);
+}

--- a/modules/c++/logging/source/Filterer.cpp
+++ b/modules/c++/logging/source/Filterer.cpp
@@ -35,15 +35,22 @@ void logging::Filterer::addFilter(logging::Filter* filter)
     }
 }
 
-bool logging::Filterer::filter(const logging::LogRecord* record) const
+bool logging::Filterer::filter_(const logging::LogRecord* record) const
 {
-    for (std::map<std::string, logging::Filter*>::const_iterator p = filters.begin();
-            p != filters.end(); ++p)
+    for (const auto& p : filters)
     {
-        if (!p->second->filter(record))
+        if (!p.second->filter(record))
             return false;
     }
     return true;
+}
+bool logging::Filterer::filter(const logging::LogRecord* record) const
+{
+    return filter_(record);
+}
+bool logging::Filterer::filter(const logging::LogRecord& record) const
+{
+    return filter_(&record);
 }
 
 void logging::Filterer::removeFilter(logging::Filter* filter)

--- a/modules/c++/logging/source/Handler.cpp
+++ b/modules/c++/logging/source/Handler.cpp
@@ -39,11 +39,10 @@ Handler::Handler(LogLevel level)
 void Handler::close()
 {
     // delete if necessary
-    if (mFormatter != &mDefaultFormatter &&
-        mFormatter != NULL)
+    if (mFormatter != &mDefaultFormatter) // "delete NULL" is ok
     {
         delete mFormatter;
-        mFormatter = NULL;
+        mFormatter = nullptr;
     }
 }
 
@@ -82,5 +81,9 @@ void Handler::setFormatter(Formatter* formatter)
 
         mFormatter = formatter;
     }
+}
+void Handler::setFormatter(std::unique_ptr<Formatter>&& formatter)
+{
+    setFormatter(formatter.release());
 }
 }

--- a/modules/c++/logging/source/StreamHandler.cpp
+++ b/modules/c++/logging/source/StreamHandler.cpp
@@ -71,6 +71,17 @@ void StreamHandler::setFormatter(Formatter* formatter)
     // start log with formatter injection
     write(mFormatter->getPrologue());
 }
+void StreamHandler::setFormatter(std::unique_ptr<Formatter>&& formatter)
+{
+    // end log with formatter injection
+    write(mFormatter->getEpilogue());
+
+    // delete old and reset to new
+    Handler::setFormatter(std::move(formatter));
+
+    // start log with formatter injection
+    write(mFormatter->getPrologue());
+}
 
 void StreamHandler::close()
 {

--- a/modules/c++/logging/unittests/test_exception_logger.cpp
+++ b/modules/c++/logging/unittests/test_exception_logger.cpp
@@ -61,9 +61,9 @@ sys::Mutex RunNothing::counterLock;
 
 TEST_CASE(testExceptionLogger)
 {
-    std::unique_ptr<logging::Logger> log(new logging::Logger("test"));
+    logging::Logger log("test");
 
-    mem::SharedPtr<logging::ExceptionLogger> exLog(new logging::ExceptionLogger(log.get()));
+    logging::ExceptionLogger exLog(&log);
 
     size_t counter(0);
     uint16_t numThreads(2);
@@ -73,11 +73,11 @@ TEST_CASE(testExceptionLogger)
     mt::GenerationThreadPool pool(numThreads);
     pool.start();
 
-    runs.push_back(new RunNothing(counter, exLog.get()));
+    runs.push_back(new RunNothing(counter, &exLog));
     pool.addAndWaitGroup(runs);
     runs.clear();
 
-    runs.push_back(new RunNothing(counter, exLog.get()));
+    runs.push_back(new RunNothing(counter, &exLog));
     pool.addAndWaitGroup(runs);
     runs.clear();
 

--- a/modules/c++/logging/unittests/test_rotating_log.cpp
+++ b/modules/c++/logging/unittests/test_rotating_log.cpp
@@ -51,19 +51,18 @@ TEST_CASE(testRotate)
 
     sys::OS os;
     {
-        auto log = mem::make::unique<logging::Logger>("test");
-        auto formatter = mem::make::unique<logging::StandardFormatter>("%m");
+        logging::Logger log("test");
+
         auto logHandler = mem::make::unique<logging::RotatingFileHandler>(outFile, 10, maxFiles);
-
         logHandler->setLevel(logging::LogLevel::LOG_DEBUG);
-        logHandler->setFormatter(formatter.release());
-        log->addHandler(logHandler.release(), true);
+        logHandler->setFormatter(mem::make::unique<logging::StandardFormatter>("%m"));
+        log.addHandler(std::move(logHandler));
 
-        log->debug("0123456789");
+        log.debug("0123456789");
         TEST_ASSERT(os.exists(outFile));
         TEST_ASSERT_FALSE(os.isFile(outFile + ".1"));
 
-        log->debug("1");
+        log.debug("1");
         TEST_ASSERT(os.isFile(outFile + ".1"));
     }
 
@@ -77,13 +76,12 @@ TEST_CASE(testNeverRotate)
 
     sys::OS os;
     {
-        auto log = mem::make::unique<logging::Logger>("test");
-        auto formatter = mem::make::unique<logging::StandardFormatter>("%m");
-        auto logHandler = mem::make::unique<logging::RotatingFileHandler>(outFile);
+        logging::Logger log("test");
+        logging::RotatingFileHandler logHandler(outFile);
 
         for(size_t i = 0; i < 1024; ++i)
         {
-            log->debug("test");
+            log.debug("test");
         }
         TEST_ASSERT(os.exists(outFile));
         TEST_ASSERT_FALSE(os.isFile(outFile + ".1"));
@@ -99,14 +97,13 @@ TEST_CASE(testRotateReset)
 
     sys::OS os;
     {
-        auto log = mem::make::unique<logging::Logger>("test");
-        auto formatter = mem::make::unique<logging::StandardFormatter>("%m");
-        auto logHandler = mem::make::unique<logging::RotatingFileHandler>(outFile, 10);
-        log->debug("01234567890");
+        logging::Logger log("test");
+        logging::RotatingFileHandler logHandler(outFile, 10);
+        log.debug("01234567890");
         TEST_ASSERT(os.exists(outFile));
         TEST_ASSERT_FALSE(os.isFile(outFile + ".1"));
 
-        log->debug("0");
+        log.debug("0");
         TEST_ASSERT(os.exists(outFile));
         TEST_ASSERT_FALSE(os.isFile(outFile + ".1"));
     }


### PR DESCRIPTION
There was a missing `virtual` on a `filter()` method; adding it has the potential to break existing code, but that code is broken anyway (and the use-case for an actual break is obscure).  Trying to repair the damage without even the remote possibility of breaking existing code creates a huge mess.  🤞🏻

While I was in the code, used the opportunity to improve support for `std::unique_ptr`.