### PR TITLE
use windows-2019 environment

### DIFF
--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -6,7 +6,7 @@ jobs:
   build-cmake-windows:
     strategy:
       matrix:
-        os: [windows-latest]
+        os: [windows-2019]
         python-version: ['3.7']
     name: ${{ matrix.os }}-${{ matrix.python-version }}-CMake
     runs-on: ${{ matrix.os }}
@@ -90,7 +90,7 @@ jobs:
   build-waf:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2019]
         python-version: ['3.7']
         debugging: ['--enable-debugging', '']
     name: ${{ matrix.os }}-${{ matrix.python-version }}-waf
@@ -108,7 +108,7 @@ jobs:
         mkdir install${{ matrix.os }}Waf-Github
         python waf configure --prefix="$PWD/install${{ matrix.os }}Waf-Github" --enable-swig ${{ matrix.debugging }}
     - name: configure_without_swig
-      if: ${{ matrix.os == 'windows-latest' }}
+      if: ${{ matrix.os == 'windows-2019' }}
       run: |
         pip install numpy
         mkdir install${{ matrix.os }}Waf-Github


### PR DESCRIPTION
`windows-latest` is now 2022 which breaks our ancient `waf` build; explicitly specify `windows-2019` which is still supported.