### PR TITLE
Poly2D::atY() bugfix

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,9 @@
  ```
 # coda-oss Release Notes
 
+## WIP: (Release 202?-??-??)
+* Fixed a bug in `Poly2D::atY()`; imporved `flipXY()` behavior.
+
 ## (Release 2022-02-22)
 * new `EnocdedString` and `EncodedStringView` to manage strings in different encodings
 * XML containing UTF-8 characters can now be validated

--- a/build/build.py
+++ b/build/build.py
@@ -676,7 +676,7 @@ def getPlatform(pwd=None, default=None):
                 out.close()
             except:{}
             try:
-                out = subprocess.Popen(loc, shell=True, stdout=subprocess.PIPE).stdout
+                out = subprocess.Popen(loc, shell=True, stdout=PIPE).stdout
                 platform = out.readline()
                 platform = platform.strip('\n')
                 out.close()

--- a/modules/c++/math.poly/include/math/poly/TwoD.hpp
+++ b/modules/c++/math.poly/include/math/poly/TwoD.hpp
@@ -107,7 +107,7 @@ OneD<_T>
 TwoD<_T>::atY(double y) const
 {
     OneD<_T> ret(0);
-    if (orderX() > 0)
+    if (!empty())
     {
         // We have no more X, but we have Y still
         ret = OneD<_T>(orderX());
@@ -153,6 +153,11 @@ template<typename _T>
 TwoD<_T>
 TwoD<_T>::flipXY() const
 {
+    if (empty())
+    {
+        return TwoD<_T>();
+    }
+
     size_t oY = orderX();
     size_t oX = orderY();
     TwoD<_T> prime(oX, oY);

--- a/modules/c++/math.poly/unittests/test_2d_poly.cpp
+++ b/modules/c++/math.poly/unittests/test_2d_poly.cpp
@@ -435,12 +435,56 @@ TEST_CASE(testIsScalar)
         }
     }
 
-    TEST_ASSERT(!p1.isScalar());
+    TEST_ASSERT_FALSE(p1.isScalar());
 
 
     math::poly::TwoD<double> p2(1, 3);
     p2[0][0] = 1;
     TEST_ASSERT(p2.isScalar());
+}
+
+TEST_CASE(testAtY)
+{
+    math::poly::TwoD<double> p1(2, 2);
+    // x^0*(1*y^0 2*y^1 3*y^2 )
+    // x^1*(3*y^0 4*y^1 5*y^2 )
+    // x^2*(5*y^0 6*y^1 7*y^2 )
+    for (size_t ii = 0; ii <= p1.orderX(); ++ii)
+    {
+        for (size_t jj = 0; jj <= p1.orderY(); ++jj)
+        {
+            p1[ii][jj] = static_cast<double>(ii * p1.orderY() + jj + 1);
+        }
+    }
+    TEST_ASSERT_EQ(p1(2, 3), p1.atY(3)(2));
+
+    // 2D polynomials with one dimension having 0 order
+    math::poly::TwoD<double> p2(2, 0);
+    for (size_t ii = 0; ii <= p2.orderX(); ++ii)
+    {
+        for (size_t jj = 0; jj <= p2.orderY(); ++jj)
+        {
+            p2[ii][jj] = static_cast<double>(ii * p2.orderY() + jj + 1);
+        }
+    }
+    TEST_ASSERT_EQ(p2.atY(3)(2), p2(2, 3));
+    TEST_ASSERT_EQ(p2.flipXY().atY(4)(5), p2(4, 5));
+
+    math::poly::TwoD<double> p3(0, 2);
+    for (size_t ii = 0; ii <= p3.orderX(); ++ii)
+    {
+        for (size_t jj = 0; jj <= p3.orderY(); ++jj)
+        {
+            p3[ii][jj] = static_cast<double>(ii * p3.orderY() + jj + 1);
+        }
+    }
+    TEST_ASSERT_EQ(p3.atY(3)(2), p3(2, 3));
+    TEST_ASSERT_EQ(p3.flipXY().atY(4)(5), p3(4, 5));
+
+    // Empty polynomial object
+    math::poly::TwoD<double> p4;
+    TEST_ASSERT_EQ(p4.atY(3)(2), p4(2, 3));
+    TEST_ASSERT_EQ(p4.flipXY().atY(4)(5), p4(4, 5));
 }
 }
 
@@ -453,5 +497,6 @@ int main(int, char**)
     TEST_CHECK(testTransformInput);
     TEST_CHECK(testOperators);
     TEST_CHECK(testIsScalar);
+    TEST_CHECK(testAtY);
 }
 


### PR DESCRIPTION
From E. Williams:
> We came across a bug inside the `Poly2D::atY()` function.  Attached is the fix (with unit tests).
>
> While updating the unit tests, I took the opportunity to improve the `flipXY()` behavior which is also tested by the same new unit tests.