### PR TITLE
Release 2022-08-30

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-```
+﻿```
      _________________________
     |   ____  _||_  ___  __   |
     |  /___ \/_||_\| __\/  \  |
@@ -10,6 +10,12 @@
     |__________||_____________|
  ```
 # coda-oss Release Notes
+
+## [Release 2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30)
+* XML is now always written as UTF-8; the code will still try to read Windows-1252.
+* `Uri`s are no longer validated by default.
+* Minor tweaks from other projects.
+* Final C++11 release 🤞🏻; future releases will be C++14 from [main](https://github.com/mdaus/coda-oss/tree/main).
 
 ## [Release 2022-08-02](https://github.com/mdaus/coda-oss/releases/tag/2022-08-02)
 * remove *Expat* and *libXML* modules and support in **xml.lite**; only *Xerces* was actively used.

--- a/modules/c++/config/include/config/Version.h
+++ b/modules/c++/config/include/config/Version.h
@@ -42,12 +42,12 @@ static_assert(CODA_OSS_MAKE_VERSION_MMPB(9999, 9999, 9999, 9999) <= UINT64_MAX, 
 
 // Do this ala C++ ... we don't currently have major/minor/patch
 //#define CODA_OSS_VERSION_ 20210910L // c.f. __cplusplus
-#define CODA_OSS_VERSION_ 2022 ## 0008 ## 0002 ## 0000 ## L
+#define CODA_OSS_VERSION_ 2022 ## 0008 ## 0030 ## 0000 ## L
 
 // Use the same macros other projects might want to use; overkill for us.
 #define CODA_OSS_VERSION_MAJOR	2022
 #define CODA_OSS_VERSION_MINOR	8
-#define CODA_OSS_VERSION_PATCH	2
+#define CODA_OSS_VERSION_PATCH	30
 #define CODA_OSS_VERSION_BUILD	0
 #define CODA_OSS_VERSION CODA_OSS_MAKE_VERSION_MMPB(CODA_OSS_VERSION_MAJOR, CODA_OSS_VERSION_MINOR, CODA_OSS_VERSION_PATCH, CODA_OSS_VERSION_BUILD)
 


### PR DESCRIPTION
* XML is now always written as UTF-8; the code will still try to read Windows-1252.
* `Uri`s are no longer validated by default.
* Minor tweaks from other projects.
* Final C++11 release 🤞🏻; future releases will be C++14 from [main](https://github.com/mdaus/coda-oss/tree/main).
