### PR TITLE
tweak toString() to reduce specialization

### DIFF
--- a/UnitTest/TestCase.h
+++ b/UnitTest/TestCase.h
@@ -30,8 +30,8 @@ namespace test
         static void FailOnCondition(bool condition, const unsigned short* message, const Microsoft::VisualStudio::CppUnitTestFramework::__LineInfo* pLineInfo);    
         static std::wstring GetAssertMessage(bool equality, const std::string& expected, const std::string& actual, const wchar_t *message);
     };
-#define CODA_OSS_equals_message_(expected, actual, message) reinterpret_cast<const unsigned short*>(test::Assert::GetAssertMessage(true, str::toString(expected),  str::toString(actual), message).c_str())
-#define CODA_OSS_not_equals_message_(notExpected, actual, message) reinterpret_cast<const unsigned short*>(test::Assert::GetAssertMessage(false,  str::toString(notExpected),  str::toString(actual), message).c_str())
+#define CODA_OSS_equals_message_(expected, actual, message) reinterpret_cast<const unsigned short*>(test::Assert::GetAssertMessage(true, test::toString(expected),  test::toString(actual), message).c_str())
+#define CODA_OSS_not_equals_message_(notExpected, actual, message) reinterpret_cast<const unsigned short*>(test::Assert::GetAssertMessage(false,  test::toString(notExpected),  test::toString(actual), message).c_str())
 #define CODA_OSS_message_(message) reinterpret_cast<const unsigned short*>(test::Assert::GetAssertMessage(false,  "", "", message).c_str())
 
 // see Assert::AreEqual<>

--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -79,7 +79,7 @@ inline void diePrintf_(const char* format, const std::string& testName, const ch
 {
     diePrintf(format, testName, file, func, line, test::toString(X));
 }
-#define test_diePrintf1(format, X1) test::diePrintf_(format, testName, __FILE__, SYS_FUNC, __LINE__, (X1)) // might not want str::toString()
+#define test_diePrintf1(format, X1) test::diePrintf_(format, testName, __FILE__, SYS_FUNC, __LINE__, X1)
 
 template<typename TX1, typename TX2>
 inline void diePrintf_(const char* format, const std::string& testName, const char* file, const char* func, int line,
@@ -87,7 +87,7 @@ inline void diePrintf_(const char* format, const std::string& testName, const ch
 {
     diePrintf(format, testName, file, func, line, test::toString(X1), test::toString(X2));
 }
-#define test_diePrintf2(format, X1, X2) test::diePrintf_(format, testName, __FILE__, SYS_FUNC, __LINE__, (X1), (X2)) // might not want str::toString()
+#define test_diePrintf2(format, X1, X2) test::diePrintf_(format, testName, __FILE__, SYS_FUNC, __LINE__, X1, X2)
 
 template<typename TX1, typename TX2>
 inline void diePrintf_(const char* format, const std::string& testName, const char* file, int line, const std::string& msg,
@@ -95,12 +95,12 @@ inline void diePrintf_(const char* format, const std::string& testName, const ch
 {
     diePrintf(format, testName, file, line, msg, test::toString(X1), test::toString(X2));
 }
-#define test_diePrintf2_msg(format, msg, X1, X2) test::diePrintf_(format, testName, __FILE__, __LINE__, msg, (X1), (X2)) // might not want str::toString()
+#define test_diePrintf2_msg(format, msg, X1, X2) test::diePrintf_(format, testName, __FILE__, __LINE__, msg, X1, X2)
 
-#define CODA_OSS_test_diePrintf_eq_(X1, X2) test_diePrintf2("%s (%s,%s,%d): FAILED: Recv'd %s, Expected %s\n", (X1), (X2))
-#define CODA_OSS_test_diePrintf_eq_msg_(msg, X1, X2) test_diePrintf2_msg("%s (%s,%d): FAILED (%s): Recv'd %s, Expected %s\n", msg, (X1), (X2))
+#define CODA_OSS_test_diePrintf_eq_(X1, X2) test_diePrintf2("%s (%s,%s,%d): FAILED: Recv'd %s, Expected %s\n", X1, X2)
+#define CODA_OSS_test_diePrintf_eq_msg_(msg, X1, X2) test_diePrintf2_msg("%s (%s,%d): FAILED (%s): Recv'd %s, Expected %s\n", msg, X1, X2)
 #define CODA_OSS_test_diePrintf_not_eq_(X1, X2) test_diePrintf2("%s (%s,%s,%d): FAILED: Recv'd %s should not equal %s\n", X1, X2)
-#define CODA_OSS_test_diePrintf_not_eq_msg_(msg, X1, X2) test_diePrintf2_msg("%s (%s,%d): FAILED (%s): Recv'd %s should not equal %s\n", msg, (X1), (X2))
+#define CODA_OSS_test_diePrintf_not_eq_msg_(msg, X1, X2) test_diePrintf2_msg("%s (%s,%d): FAILED (%s): Recv'd %s should not equal %s\n", msg, X1, X2)
 #define CODA_OSS_test_diePrintf_greater_eq_(X1, X2) test_diePrintf0("%s (%s,%s,%d): FAILED: Value should be greater than or equal\n")
 #define CODA_OSS_test_diePrintf_greater_(X1, X2) test_diePrintf0("%s (%s,%s,%d): FAILED: Value should be greater than\n")
 #define CODA_OSS_test_diePrintf_lesser_eq_(X1, X2) test_diePrintf0("%s (%s,%s,%d): FAILED: Value should be less than or equal\n")
@@ -170,7 +170,7 @@ inline int main(TFunc f)
 }
 
 #define TEST_CHECK(X) try{ X(std::string(#X)); std::cerr << #X << ": PASSED\n"; } \
-  catch(const except::Throwable& ex) { test::diePrintf("%s: FAILED: Exception thrown: %s\n", #X, ex.toString().c_str()); } \
+  catch(const except::Throwable& ex) { test::diePrintf("%s: FAILED: Exception thrown: %s\n", #X, test::toString(ex).c_str()); } \
   catch(const except::Throwable11& ex) { test::diePrintf("%s: FAILED: Exception thrown: %s\n", #X, ex.what()); }
 
 #define TEST_ASSERT_NULL(X) if ((X) != nullptr) { test_diePrintf0("%s (%s,%s,%d): FAILED: Value should be NULL\n"); }

--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -65,29 +65,6 @@ inline void diePrintf(const char* format, const std::string& testName, const cha
 // older C++ compilers don't like __VA_ARGS__ :-(
 #define test_diePrintf0(format) test::diePrintf(format, testName, __FILE__, SYS_FUNC, __LINE__)
 
-// https://stackoverflow.com/questions/1005476/how-to-detect-whether-there-is-a-specific-member-variable-in-class/1007175#1007175
-namespace details
-{
-    // https://stackoverflow.com/a/9154394/8877
-    template<typename T>
-    inline auto toString_imp(const T& obj, int) -> decltype(toString(obj), std::string())
-    {
-        return toString(obj);
-    }
-
-    template<typename T>
-    inline auto toString_imp(const T& obj, long) -> decltype(str::toString(obj), std::string())
-    {
-        return str::toString(obj);
-    }
-
-    template<typename T>
-    inline auto toString(const T& obj) -> decltype(toString_imp(obj, 0), std::string())
-    {
-        return toString_imp(obj, 0);
-    }
-}
-
 // Route all toString() for unittests through here ... so that we can have more control
 // over the routine used.
 template <typename TX>

--- a/modules/c++/str/include/str/Convert.h
+++ b/modules/c++/str/include/str/Convert.h
@@ -55,12 +55,15 @@ namespace details
     // problems; avoid trying to work-around all that by just not doing it.
     // 
     // The preferred approach is to make a a toString() free function.
-    // 
-    // Note that std::to_string() doesn't necessarily generate the same output as writing
-    // to std::cout; see https://en.cppreference.com/w/cpp/string/basic_string/to_string
     template <typename T>
-    std::string default_toString(const T& value)
+    inline std::string default_toString(const T& value)
     {
+        // Use operator<<() to generate a string value; this may not be quite
+        // 100% kosher, but it's been long-standing practice in this codebase.
+        //
+        // Note that std::to_string() doesn't necessarily generate the same
+        // output as writing to std::cout; see
+        // https://en.cppreference.com/w/cpp/string/basic_string/to_string
         std::ostringstream buf;
         buf.precision(getPrecision(value));
         buf << std::boolalpha << value;
@@ -74,50 +77,93 @@ namespace details
     template<typename T>
     inline auto toString_imp(const T& obj, priority<2>) -> decltype(obj.toString(), std::string())
     {
-        return obj.toString();
+        return obj.toString(); // member-function
     }
 
     template<typename T>
     inline auto toString_imp(const T& obj, priority<1>) -> decltype(toString(obj), std::string())
     {
-        return toString(obj);
+        return toString(obj); // free function
     }
 
     template<typename T>
     inline auto toString_imp(const T& obj, priority<0>) -> decltype(default_toString(obj), std::string())
     {
-        return details::default_toString(obj);
+        return details::default_toString(obj); // our default utility which uses operator<<()
     }
-
+    
+    // In order, try to call 1) obj.toString() (highest priority), 2) toString(obj),
+    // and finally 3) toString_(obj) (lowest priority).
     template<typename T>
     inline auto toString_(const T& obj) -> decltype(toString_imp(obj, priority<2>{}), std::string())
     {
-        // In order, try to call 1) obj.toString() (highest priority), 2) toString(obj), and
-        // finally 3) toString_(obj) (lowest priority).
         return details::toString_imp(obj, priority<2>{});
     }
 }
 template <typename T>
-std::string toString(const T& value)
+inline std::string toString(const T& value) // no dectype() noise here, leave that in details::toString_()
 {
     return details::toString_(value);
 }
 
-// C++11 has a bunch of overloads, do the same
-CODA_OSS_API std::string toString(int value);
-CODA_OSS_API std::string toString(long value);
-CODA_OSS_API std::string toString(long long value);
-CODA_OSS_API std::string toString(unsigned value);
-CODA_OSS_API std::string toString(unsigned long value);
-CODA_OSS_API std::string toString(unsigned long long value);
-CODA_OSS_API std::string toString(float value);
-CODA_OSS_API std::string toString(double value);
-CODA_OSS_API std::string toString(long double value);
+// C++11 has a bunch of overloads, do the same.
+// https://en.cppreference.com/w/cpp/string/basic_string/to_string
+inline std::string toString(int value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(long value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(long long value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(unsigned value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(unsigned long value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(unsigned long long value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(float value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(double value)
+{
+    return details::default_toString(value);
+}
+inline std::string oString(long double value)
+{
+    return details::default_toString(value);
+}
 
-CODA_OSS_API std::string toString(bool value);
-CODA_OSS_API std::string toString(uint8_t value);
-CODA_OSS_API std::string toString(int8_t value);
-CODA_OSS_API std::string toString(coda_oss::byte value);
+// C++ doesn't have these ...
+// https://en.cppreference.com/w/cpp/string/basic_string/to_string
+inline std::string toString(bool value)
+{
+    return details::default_toString(value);
+}
+inline std::string toString(uint8_t value)
+{
+    return toString(static_cast<unsigned int>(value));
+}
+inline std::string toString(int8_t value)
+{
+    return toString(static_cast<int>(value));
+}
+inline std::string toString(coda_oss::byte value)
+{
+    return toString(static_cast<uint8_t>(value));
+}
+
 inline std::string toString(std::nullptr_t)
 {
     return "<nullptr>";
@@ -132,21 +178,26 @@ inline std::string toString(char value)
 {
     return std::string(1, value);
 }
+inline std::string toString(const char* pStr)
+{
+    return std::string(pStr);
+}
 
 template <typename T>
-std::string toString(const coda_oss::optional<T>& value)
+inline std::string toString(const coda_oss::optional<T>& value)
 {
+    // TODO: handle empty/NULL optional?
     return details::default_toString(value.value());
 }
 
 template <typename T>
-std::string toString(const T& real, const T& imag)
+inline std::string toString(const T& real, const T& imag)
 {
     return details::default_toString(std::complex<T>(real, imag));
 }
 
 template <typename T>
-std::string toString(const T* ptr)
+inline std::string toString(const T* ptr)
 {
     return details::default_toString(ptr);
 }

--- a/modules/c++/str/include/str/Convert.h
+++ b/modules/c++/str/include/str/Convert.h
@@ -71,34 +71,51 @@ std::string toString(const T& value)
     return details::toString(value);
 }
 
-template <>
-CODA_OSS_API std::string toString(const uint8_t& value);
+// C++11 has a bunch of overloads, do the same
+CODA_OSS_API std::string toString(int value);
+CODA_OSS_API std::string toString(long value);
+CODA_OSS_API std::string toString(long long value);
+CODA_OSS_API std::string toString(unsigned value);
+CODA_OSS_API std::string toString(unsigned long value);
+CODA_OSS_API std::string toString(unsigned long long value);
+CODA_OSS_API std::string toString(float value);
+CODA_OSS_API std::string toString(double value);
+CODA_OSS_API std::string toString(long double value);
 
-template <>
-CODA_OSS_API std::string toString(const int8_t& value);
-
-template <>
-CODA_OSS_API std::string toString(const coda_oss::byte& value);
-
-template <>
-inline std::string toString(const std::nullptr_t&)
+CODA_OSS_API std::string toString(uint8_t value);
+CODA_OSS_API std::string toString(int8_t value);
+CODA_OSS_API std::string toString(coda_oss::byte value);
+inline std::string toString(std::nullptr_t)
 {
     return "<nullptr>";
 }
 
-template <>
 CODA_OSS_API std::string toString(const coda_oss::u8string&);
+inline std::string toString(const std::string& value)
+{
+    return value;
+}
+inline std::string toString(char value)
+{
+    return std::string(1, value);
+}
 
 template <typename T>
 std::string toString(const coda_oss::optional<T>& value)
 {
-    return toString(value.value());
+    return details::toString(value.value());
 }
 
 template <typename T>
 std::string toString(const T& real, const T& imag)
 {
-    return toString(std::complex<T>(real, imag));
+    return details::toString(std::complex<T>(real, imag));
+}
+
+template <typename T>
+std::string toString(const T* ptr)
+{
+    return details::toString(ptr);
 }
 
 template <typename T>

--- a/modules/c++/str/include/str/Convert.h
+++ b/modules/c++/str/include/str/Convert.h
@@ -49,6 +49,11 @@ int getPrecision(const T& type);
 template <typename T>
 int getPrecision(const std::complex<T>& type);
 
+namespace details
+{
+// Templating (and the n specializing) toString() creates all kinds of weird name-look
+// problems; avoid trying to work-around all that by just not doing it.
+// 
 // Note that std::to_string() doesn't necessarily generate the same output as writing
 // to std::cout; see https://en.cppreference.com/w/cpp/string/basic_string/to_string
 template <typename T>
@@ -58,6 +63,12 @@ std::string toString(const T& value)
     buf.precision(getPrecision(value));
     buf << std::boolalpha << value;
     return buf.str();
+}
+}
+template <typename T>
+std::string toString(const T& value)
+{
+    return details::toString(value);
 }
 
 template <>

--- a/modules/c++/str/include/str/EncodedString.h
+++ b/modules/c++/str/include/str/EncodedString.h
@@ -156,9 +156,14 @@ inline bool operator!=(const EncodedString& lhs, const EncodedString& rhs)
     return !(lhs == rhs);
 }
 
+inline std::string toString(const EncodedString& es)
+{
+    return es.native();
+}
+
 inline std::ostream& operator<<(std::ostream& os, const EncodedString& es)
 {
-    os << es.native();
+    os << toString(es);
     return os;
 }
 

--- a/modules/c++/str/include/str/EncodedStringView.h
+++ b/modules/c++/str/include/str/EncodedStringView.h
@@ -193,9 +193,14 @@ inline bool operator!=(const coda_oss::u8string& lhs, const EncodedStringView& r
     return !(lhs == rhs);
 }
 
+inline std::string toString(const EncodedStringView& esv) 
+{
+    return esv.native();
+}
+
 inline std::ostream& operator<<(std::ostream& os, const EncodedStringView& esv)
 {
-    os << esv.native();
+    os << toString(esv);
     return os;
 }
 

--- a/modules/c++/str/include/str/Manip.h
+++ b/modules/c++/str/include/str/Manip.h
@@ -199,7 +199,7 @@ inline std::string join(const std::vector<T>& toks, const std::string& with)
     int i = 0;
     for (; i < len - 1; i++)
     {
-        oss << str::toString<T>(toks[i]) << with;
+        oss << str::toString(toks[i]) << with;
     }
     oss << str::toString(toks[i]);
     return oss.str();

--- a/modules/c++/str/source/Convert.cpp
+++ b/modules/c++/str/source/Convert.cpp
@@ -40,19 +40,54 @@ template<> std::string str::toType<std::string>(const std::string& s)
     return s;
 }
 
-template<> std::string str::toString(const uint8_t& value)
+std::string str::toString(int value)
 {
-    return str::toString(static_cast<unsigned int>(value));
+    return details::toString(value);
+}
+std::string str::toString(long value)
+{
+    return details::toString(value);
+}
+std::string str::toString(long long value)
+{
+    return details::toString(value);
+}
+std::string str::toString(unsigned value)
+{
+    return details::toString(value);
+}
+std::string str::toString(unsigned long value)
+{
+    return details::toString(value);
+}
+std::string str::toString(unsigned long long value)
+{
+    return details::toString(value);
+}
+std::string str::toString(float value)
+{
+    return details::toString(value);
+}
+std::string str::toString(double value)
+{
+    return details::toString(value);
+}
+std::string str::toString(long double value)
+{
+    return details::toString(value);
 }
 
-template<> std::string str::toString(const int8_t& value)
+std::string str::toString(uint8_t value)
 {
-    return str::toString(static_cast<int>(value));
+    return toString(static_cast<unsigned int>(value));
 }
-
-template<> std::string str::toString(const coda_oss::byte& value)
+std::string str::toString(int8_t value)
 {
-    return str::toString(static_cast<uint8_t>(value));
+    return toString(static_cast<int>(value));
+}
+std::string str::toString(coda_oss::byte value)
+{
+    return toString(static_cast<uint8_t>(value));
 }
 
 template<> bool str::toType<bool>(const std::string& s)

--- a/modules/c++/str/source/Convert.cpp
+++ b/modules/c++/str/source/Convert.cpp
@@ -40,61 +40,6 @@ template<> std::string str::toType<std::string>(const std::string& s)
     return s;
 }
 
-std::string str::toString(int value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(long value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(long long value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(unsigned value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(unsigned long value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(unsigned long long value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(float value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(double value)
-{
-    return details::default_toString(value);
-}
-std::string str::toString(long double value)
-{
-    return details::default_toString(value);
-}
-
-std::string str::toString(bool value)
-{
-    return details::default_toString(value);
-}
-
-std::string str::toString(uint8_t value)
-{
-    return toString(static_cast<unsigned int>(value));
-}
-std::string str::toString(int8_t value)
-{
-    return toString(static_cast<int>(value));
-}
-std::string str::toString(coda_oss::byte value)
-{
-    return toString(static_cast<uint8_t>(value));
-}
-
 template<> bool str::toType<bool>(const std::string& s)
 {
     std::string ss = s;

--- a/modules/c++/str/source/Convert.cpp
+++ b/modules/c++/str/source/Convert.cpp
@@ -42,39 +42,44 @@ template<> std::string str::toType<std::string>(const std::string& s)
 
 std::string str::toString(int value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(long value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(long long value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(unsigned value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(unsigned long value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(unsigned long long value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(float value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(double value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
 }
 std::string str::toString(long double value)
 {
-    return details::toString(value);
+    return details::default_toString(value);
+}
+
+std::string str::toString(bool value)
+{
+    return details::default_toString(value);
 }
 
 std::string str::toString(uint8_t value)

--- a/modules/c++/str/source/Encoding.cpp
+++ b/modules/c++/str/source/Encoding.cpp
@@ -382,7 +382,6 @@ coda_oss::u8string str::to_u8string(W1252string::const_pointer p, size_t sz)
     return retval;
 }
 
-template <>
 std::string str::toString(const coda_oss::u8string& utf8)
 {
     return str::EncodedStringView(utf8).native();

--- a/modules/c++/str/unittests/test_base_convert.cpp
+++ b/modules/c++/str/unittests/test_base_convert.cpp
@@ -63,15 +63,15 @@ TEST_CASE(testBadConvert)
 
 TEST_CASE(testEightBitIntToString)
 {
-    TEST_ASSERT_EQ(str::toString<uint8_t>(1), "1");
-    TEST_ASSERT_EQ(str::toString<int8_t>(2), "2");
-    TEST_ASSERT_EQ(str::toString<int8_t>(-2), "-2");
+    TEST_ASSERT_EQ(str::toString(static_cast<uint8_t>(1)), "1");
+    TEST_ASSERT_EQ(str::toString(static_cast<int8_t>(2)), "2");
+    TEST_ASSERT_EQ(str::toString(static_cast<int8_t>(-2)), "-2");
 }
 
 TEST_CASE(testCharToString)
 {
-    TEST_ASSERT_EQ(str::toString<char>('a'), "a");
-    TEST_ASSERT_EQ(str::toString<char>(65), "A");
+    TEST_ASSERT_EQ(str::toString('a'), "a");
+    TEST_ASSERT_EQ(str::toString(static_cast<char>(65)), "A");
 }
 
 static std::u8string fromWindows1252(const std::string& s)


### PR DESCRIPTION
Overloading is usually better than specialization; this PR tweaks `toString()` to make overloading work better.  It also uses some "template magic" to hopefully minimize the need for specialization (and ... 🤞🏻 ... not break too much existing code).