### PR TITLE
utilities to find files from a build

### DIFF
--- a/modules/c++/sys/include/sys/FileFinder.h
+++ b/modules/c++/sys/include/sys/FileFinder.h
@@ -168,6 +168,12 @@ namespace test // i.e., sys::test
     // Used by unittest to find sample files.
     coda_oss::filesystem::path findRootDirectory(const coda_oss::filesystem::path& p, const std::string& rootName,
         std::function<bool(const coda_oss::filesystem::path&)> isRoot);
+
+    coda_oss::filesystem::path findCMakeBuildRoot(const coda_oss::filesystem::path& p);
+    bool isCMakeBuild(const coda_oss::filesystem::path& p);
+
+    coda_oss::filesystem::path findCMakeInstallRoot(const coda_oss::filesystem::path& p);
+    bool isCMakeInstall(const coda_oss::filesystem::path& p);
 }
 }
 #endif

--- a/modules/c++/sys/source/FileFinder.cpp
+++ b/modules/c++/sys/source/FileFinder.cpp
@@ -259,7 +259,7 @@ static inline std::string Platform()
 
 static coda_oss::filesystem::path findCMakeRoot(const coda_oss::filesystem::path& path, const coda_oss::filesystem::path& dir)
 {
-	static const auto platform_and_configuration = ::Platform() + "-" + ::Configuration(); // "x64-Debug"
+   	static const auto platform_and_configuration = ::Platform() + "-" + ::Configuration(); // "x64-Debug"
     const auto pred = [&](const coda_oss::filesystem::path& p)
     {
         if (p.filename() == platform_and_configuration)
@@ -273,8 +273,10 @@ static coda_oss::filesystem::path findCMakeRoot(const coda_oss::filesystem::path
         const auto CMakeFiles = p / "CMakeFiles";
         if (is_regular_file(CMakeCache_txt) && is_directory(CMakeFiles))
         {
-            // looks promising ... if ../.git exists, this is probably it
-            return is_directory(p.parent_path() / ".git");
+            // looks promising ... _deps and modules directories are there, call it good.
+            const auto deps = p / "_deps";
+            const auto modules = p / "modules";
+            return is_directory(deps) && is_directory(modules);
         }
 
         return false;
@@ -298,11 +300,13 @@ coda_oss::filesystem::path findCMake_Root(const coda_oss::filesystem::path& path
     }
 
     // Might be given a path to something in "install" ...
+    std::clog << "path: " << path << '\n';
     const auto configAndPlatformDir = findCMakeRoot(path, install);  // should be, e.g., "x64-Debug"
     const auto installDir = configAndPlatformDir.parent_path();
     if (installDir.filename() == install)
     {
         auto retval = installDir.parent_path() / build;
+        std::clog << "root: " << retval << '\n';
         if (is_directory(retval))
         {
             return retval;
@@ -312,11 +316,15 @@ coda_oss::filesystem::path findCMake_Root(const coda_oss::filesystem::path& path
 }
 coda_oss::filesystem::path sys::test::findCMakeBuildRoot(const coda_oss::filesystem::path& path)
 {
-    return findCMake_Root(path, "build", "install");
+    auto retval = findCMake_Root(path, "build", "install");
+    std::clog << "findCMakeBuildRoot(): " << retval << "\n";
+    return retval;
 }
 coda_oss::filesystem::path sys::test::findCMakeInstallRoot(const coda_oss::filesystem::path& path)
 {
-    return findCMake_Root(path, "install", "build");
+    auto retval = findCMake_Root(path, "install", "build");
+    std::clog << "findCMakeInstallRoot(): " << retval << "\n";
+    return retval;
 }
 
 bool sys::test::isCMakeBuild(const coda_oss::filesystem::path& path)


### PR DESCRIPTION
Add some utility routines to find files from a build/install directory.  Complications include: both CMake and waf builds, and a project could be **externals** in another project.