### PR TITLE
mem::AutoPtr for C++17

### DIFF
--- a/UnitTest/TestCase.h
+++ b/UnitTest/TestCase.h
@@ -10,15 +10,17 @@
 #undef TEST_CHECK
 #undef TEST_ASSERT
 #undef TEST_ASSERT_NULL 
+#undef TEST_ASSERT_NOT_NULL 
 #undef TEST_ASSERT_TRUE
 #undef TEST_ASSERT_FALSE
 #undef TEST_MAIN
 #undef TEST_CASE
 #define TEST_CHECK(X) 
 #define TEST_MAIN(X)
-#define TEST_ASSERT_NULL(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsNull((X))
-#define TEST_ASSERT_TRUE(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsTrue((X))
-#define TEST_ASSERT_FALSE(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsFalse((X))
+#define TEST_ASSERT_NULL(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsNull(X)
+#define TEST_ASSERT_NOT_NULL(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsNotNull(X)
+#define TEST_ASSERT_TRUE(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsTrue(X)
+#define TEST_ASSERT_FALSE(X) testName, Microsoft::VisualStudio::CppUnitTestFramework::Assert::IsFalse(X)
 #define TEST_ASSERT(X) TEST_ASSERT_TRUE(X)
 #define CODA_OSS_testMethod_(X)  testMethod ## _ ## X
 #define TEST_CASE(X) TEST_METHOD(X) { CODA_OSS_testMethod_(X)(#X); } void CODA_OSS_testMethod_(X)(std::string testName)

--- a/UnitTest/pch.h
+++ b/UnitTest/pch.h
@@ -57,6 +57,7 @@
 #include "import/except.h"
 #include "import/mem.h"
 #include <mem/SharedPtr.h>
+#include <mem/AutoPtr.h>
 #include "import/cli.h"
 #include "polygon/DrawPolygon.h"
 #include "polygon/PolygonMask.h"

--- a/modules/c++/coda-oss-lite.vcxproj
+++ b/modules/c++/coda-oss-lite.vcxproj
@@ -114,6 +114,7 @@
     <ClInclude Include="math\include\math\Round.h" />
     <ClInclude Include="math\include\math\Utilities.h" />
     <ClInclude Include="mem\include\mem\Align.h" />
+    <ClInclude Include="mem\include\mem\AutoPtr.h" />
     <ClInclude Include="mem\include\mem\BufferView.h" />
     <ClInclude Include="mem\include\mem\ScopedAlignedArray.h" />
     <ClInclude Include="mem\include\mem\ScopedArray.h" />

--- a/modules/c++/coda-oss-lite.vcxproj.filters
+++ b/modules/c++/coda-oss-lite.vcxproj.filters
@@ -717,6 +717,9 @@
     <ClInclude Include="sys\include\sys\MutexCpp11.h">
       <Filter>sys</Filter>
     </ClInclude>
+    <ClInclude Include="mem\include\mem\AutoPtr.h">
+      <Filter>mem</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/modules/c++/mem/include/mem/AutoPtr.h
+++ b/modules/c++/mem/include/mem/AutoPtr.h
@@ -73,6 +73,7 @@ public:
     AutoPtr& operator=(std::unique_ptr<U>&& p) noexcept
     {
         ptr_ = std::move(p);
+        return *this;
     }
     template <typename U>
     AutoPtr(std::unique_ptr<U>&& p) noexcept

--- a/modules/c++/mem/include/mem/AutoPtr.h
+++ b/modules/c++/mem/include/mem/AutoPtr.h
@@ -1,0 +1,112 @@
+/* =========================================================================
+ * This file is part of mem-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2018, MDA Information Systems LLC
+ * (C) Copyright 2022, Maxar Technologies, Inc.
+ *
+ * mem-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CODA_OSS_mem_AutoPtr_h_INCLUDED_
+#define CODA_OSS_mem_AutoPtr_h_INCLUDED_
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "coda_oss/memory.h"
+
+namespace mem
+{
+// std::auto_ptr (deprecated in C++17) is copyable while
+// std::unique_ptr (new in C++11) isn't.  While unique_ptr
+// is right, making the change doesn't always work well with
+// legacy code.  Using shared_ptr instead of unique_ptr is
+// copyable, but that changes semantics: the "old" copied-from
+// object is still valid.
+//
+// Thus, this class to help make the transition easier.
+// Using (very) sparingly!
+
+template<typename T>
+class AutoPtr final
+{
+    std::unique_ptr<T> ptr_;
+
+public:
+    // https://en.cppreference.com/w/cpp/memory/auto_ptr/auto_ptr
+    explicit AutoPtr(T* p = nullptr) noexcept : ptr_(p)
+    {
+    }
+
+    AutoPtr& operator=(AutoPtr& r) noexcept
+    {
+        reset(r.release());
+        return *this;
+    }
+    AutoPtr(AutoPtr& r) noexcept
+    {
+        *this = r;
+    }
+    AutoPtr& operator=(const AutoPtr&) = delete; // can't change a "const" object
+    AutoPtr(const AutoPtr&) = delete;
+
+    ~AutoPtr() = default;
+    AutoPtr(AutoPtr&&) = default;
+    AutoPtr& operator=(AutoPtr&&) = default;
+
+    template<typename U>
+    AutoPtr& operator=(std::unique_ptr<U>&& p) noexcept
+    {
+        ptr_ = std::move(p);
+    }
+    template <typename U>
+    AutoPtr(std::unique_ptr<U>&& p) noexcept
+    {
+        *this = std::move(p);
+    }
+
+
+    T* get() const noexcept
+    {
+        return ptr_.get();
+    }
+
+    T* release() noexcept
+    {
+        return ptr_.release();
+    }
+
+    template<typename U>
+    void reset(U* p = nullptr) noexcept
+    {
+        ptr_.reset(p);
+    }
+
+    T& operator*() const noexcept
+    {
+        return *get();
+    }
+    T* operator->() const noexcept
+    {
+        return get();
+    }
+};
+
+} // namespace mem
+
+#endif // CODA_OSS_mem_AutoPtr_h_INCLUDED_

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -88,6 +88,12 @@ TEST_CASE(test_make_unique)
     }
 }
 
+static void f(const std::string& testName, mem::AutoPtr<Foo> p)
+{
+    TEST_ASSERT_NOT_NULL(p.get());
+    TEST_ASSERT_EQ(123, p->mVal);
+}
+
 TEST_CASE(memAutoPtr)
 {
     {
@@ -95,19 +101,24 @@ TEST_CASE(memAutoPtr)
         TEST_ASSERT_NULL(fooCtor.get());
 
         fooCtor.reset(new Foo(123));
-        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_NOT_NULL(fooCtor.get());
         TEST_ASSERT_EQ(123, fooCtor->mVal);
     }
     {
         mem::AutoPtr<Foo> fooCtor(new Foo(123));
-        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_NOT_NULL(fooCtor.get());
         TEST_ASSERT_EQ(123, fooCtor->mVal);
     }
     {
         mem::AutoPtr<Foo> fooCtor(new Foo(123));
         mem::AutoPtr<Foo> other(fooCtor);
-        TEST_ASSERT_NOT_EQ(nullptr, other.get());
+        TEST_ASSERT_NOT_NULL(other.get());
         TEST_ASSERT_EQ(123, other->mVal);
+    }
+    {
+        mem::AutoPtr<Foo> fooCtor(new Foo(123));
+        f(testName, fooCtor);
+        TEST_ASSERT_NULL(fooCtor.get());
     }
 }
 

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -93,7 +93,6 @@ static void f(const std::string& testName, mem::AutoPtr<Foo> p)
     TEST_ASSERT_NOT_NULL(p.get());
     TEST_ASSERT_EQ(123, p->mVal);
 }
-
 TEST_CASE(memAutoPtr)
 {
     {
@@ -118,6 +117,11 @@ TEST_CASE(memAutoPtr)
     {
         mem::AutoPtr<Foo> fooCtor(new Foo(123));
         f(testName, fooCtor);
+        TEST_ASSERT_NULL(fooCtor.get());
+    }
+    {
+        std::unique_ptr<Foo> fooCtor(new Foo(123));
+        f(testName, std::move(fooCtor));
         TEST_ASSERT_NULL(fooCtor.get());
     }
 }

--- a/modules/c++/mem/unittests/test_unique_ptr.cpp
+++ b/modules/c++/mem/unittests/test_unique_ptr.cpp
@@ -23,6 +23,7 @@
 #include <std/memory>
 
 #include <mem/SharedPtr.h>
+#include <mem/AutoPtr.h>
 
 #include "TestCase.h"
 
@@ -87,7 +88,32 @@ TEST_CASE(test_make_unique)
     }
 }
 
+TEST_CASE(memAutoPtr)
+{
+    {
+        mem::AutoPtr<Foo> fooCtor;
+        TEST_ASSERT_NULL(fooCtor.get());
+
+        fooCtor.reset(new Foo(123));
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        mem::AutoPtr<Foo> fooCtor(new Foo(123));
+        TEST_ASSERT_NOT_EQ(nullptr, fooCtor.get());
+        TEST_ASSERT_EQ(123, fooCtor->mVal);
+    }
+    {
+        mem::AutoPtr<Foo> fooCtor(new Foo(123));
+        mem::AutoPtr<Foo> other(fooCtor);
+        TEST_ASSERT_NOT_EQ(nullptr, other.get());
+        TEST_ASSERT_EQ(123, other->mVal);
+    }
+}
+
+
 TEST_MAIN(
    TEST_CHECK(testStdUniquePtr);
    TEST_CHECK(test_make_unique);
+   TEST_CHECK(memAutoPtr);
    )

--- a/modules/c++/pch.h
+++ b/modules/c++/pch.h
@@ -18,6 +18,7 @@
 #pragma warning(disable: 4355) // '...': used in base member initializer list
 #pragma warning(disable: 5220) // '...': a non-static data member with a volatile qualified type no longer implies that compiler generated copy/move constructors and copy/move assignment operators are not trivial
 #pragma warning(disable: 5204) // '...': class has virtual functions, but its trivial destructor is not virtual; instances of objects derived from this class may not be destructed correctly
+#pragma warning(disable : 5264)  // '...': '...' variable is not used
 
 // add headers that you want to pre-compile here
 #include "framework.h"
@@ -51,6 +52,7 @@
 #include <ostream>
 #include <sstream>
 #include <future>
+#include <functional>
 #include <std/span>
 #include <std/string>
 #include <std/filesystem>


### PR DESCRIPTION
Changing classes that use `std::unique_ptr` to not be copyable can require some cascading changes; something that may not be desirable at a particular moment.  This effectively brings back `std::auto_ptr` as `mem::AutoPtr` and using `std::unique_ptr` internally.