### PR TITLE
restore C++14 workarounds for older compilers

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -912,10 +912,11 @@ def configureCompilerOptions(self):
             # The "fastest-possible" option is new; see comments above.
             config['cxx']['optz_fastest-possible']   =  [ config['cxx']['optz_fastest'], '-march=native' ]
 
+            self.env.append_value('CXXFLAGS', '-fPIC'.split())
             if not Options.options.enablecpp17:
-                gxxCompileFlags='-fPIC -std=c++14'
+                gxxCompileFlags='-std=c++14'
             else:
-                gxxCompileFlags='-fPIC -std=c++17'
+                gxxCompileFlags='-std=c++17'
             self.env.append_value('CXXFLAGS', gxxCompileFlags.split())
 
             # DEFINES and LINKFLAGS will apply to both gcc and g++
@@ -952,6 +953,8 @@ def configureCompilerOptions(self):
             config['cc']['optz_fastest-possible']   =  [ config['cc']['optz_fastest'], '-march=native' ]
 
             self.env.append_value('CFLAGS', '-fPIC'.split())
+            # "gnu99" enables POSIX and BSD
+            self.env.append_value('CFLAGS', '-std=gnu99'.split())
 
     elif re.match(winRegex, sys_platform):
         crtFlag = '/%s' % Options.options.crt

--- a/modules/c++/coda_oss/include/coda_oss/CPlusPlus.h
+++ b/modules/c++/coda_oss/include/coda_oss/CPlusPlus.h
@@ -48,14 +48,28 @@
 
     #if defined(__GNUC__)
     #endif // __GNUC__
+
+    #if defined(__INTEL_COMPILER)
+    #endif  // __INTEL_COMPILER
 #endif // CODA_OSS_cplusplus
+
+#if CODA_OSS_cplusplus < 201402L
+    // oops ... try to fix
+    #if defined(__INTEL_COMPILER) && (__INTEL_COMPILER_BUILD_DATE >= 20151021)
+        // __cplusplus is 201300, not 201402L
+        // Enough C++14, at least with our std/ work-arounds
+        #undef CODA_OSS_cplusplus
+        #define CODA_OSS_cplusplus 201402L
+     #endif
+#endif  // CODA_OSS_cplusplus
+
 #if CODA_OSS_cplusplus < 202002L
     // oops ... try to fix
-    #if defined(__GNUC__) && (__cplusplus >= 201709L) // note > C++ 17 of 201703L
+    #if defined(__GNUC__) && (__cplusplus >= 201709L)  // note > C++ 17 of 201703L
         // Enough C++20 for our needs
         #undef CODA_OSS_cplusplus
         #define CODA_OSS_cplusplus 202002L
-     #endif
+    #endif
 #endif  // CODA_OSS_cplusplus
 
 // Define a few macros as that's less verbose than testing against a version number

--- a/modules/c++/coda_oss/include/coda_oss/memory.h
+++ b/modules/c++/coda_oss/include/coda_oss/memory.h
@@ -26,5 +26,42 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "config/compiler_extensions.h"
+
+#include "coda_oss/namespace_.h"
+namespace coda_oss
+{
+// C++11 inadvertently ommitted make_unique; provide it here. (Swiped from <memory>.)
+template <typename T, typename... TArgs, typename std::enable_if<!std::is_array<T>::value, int>::type = 0>
+std::unique_ptr<T> make_unique(TArgs&&... args)
+{
+    CODA_OSS_disable_warning_push
+    #if _MSC_VER
+    #pragma warning(disable: 26409) // Avoid calling new and delete explicitly, use std::make_unique<T> instead (r .11).
+    #endif
+    return std::unique_ptr<T>(new T(std::forward<TArgs>(args)...));
+    CODA_OSS_disable_warning_pop
+}
+
+template <typename T, typename std::enable_if<std::is_array<T>::value &&  std::extent<T>::value == 0, int>::type = 0>
+std::unique_ptr<T> make_unique(size_t size)
+{
+    using element_t = typename std::remove_extent<T>::type;
+
+    CODA_OSS_disable_warning_push
+    #if _MSC_VER
+    #pragma warning(disable: 26409) // Avoid calling new and delete explicitly, use std::make_unique<T> instead (r .11).
+    #endif    
+    return std::unique_ptr<T>(new element_t[size]());
+    CODA_OSS_disable_warning_pop
+}
+
+template <typename T, typename... TArgs, typename std::enable_if<std::extent<T>::value != 0, int>::type = 0>
+void make_unique(TArgs&&...) = delete;
+
+} // namespace coda_oss
 
 #endif // CODA_OSS_coda_oss_memory_h_INCLUDED_

--- a/modules/c++/coda_oss/include/coda_oss/type_traits.h
+++ b/modules/c++/coda_oss/include/coda_oss/type_traits.h
@@ -24,4 +24,23 @@
 
 #include <type_traits>
 
+#include "CPlusPlus.h"
+
+#include "coda_oss/namespace_.h"
+namespace coda_oss
+{
+// workaround missing "is_trivially_copyable" in g++ < 5.0
+// https://stackoverflow.com/a/31798726/8877
+#if defined(__GNUC__) && (__GNUC__ < 5)
+template <typename T>
+struct is_trivially_copyable final
+{
+    static_assert(CODA_OSS_cplusplus < 201402L, "C++14 must have is_trivially_copyable.");
+    static constexpr bool value = __has_trivial_copy(T);
+};
+#else
+using std::is_trivially_copyable;
+#endif
+}
+
 #endif  // CODA_OSS_coda_oss_type_traits_h_INCLUDED_

--- a/modules/c++/io/include/io/PipeStream.h
+++ b/modules/c++/io/include/io/PipeStream.h
@@ -23,7 +23,7 @@
 #ifndef __IO_PIPE_STREAM_H__
 #define __IO_PIPE_STREAM_H__
 
-#include <memory>
+#include <std/memory>
 
 #include <import/except.h>
 #include <str/Convert.h>

--- a/modules/c++/logging/include/logging/FileHandler.h
+++ b/modules/c++/logging/include/logging/FileHandler.h
@@ -29,6 +29,8 @@
 
 #include <string>
 #include <iostream>
+#include <std/memory>
+
 #include "logging/LogRecord.h"
 #include "logging/StreamHandler.h"
 #include <import/io.h>

--- a/modules/c++/math.linear/include/math/linear/Matrix2D.h
+++ b/modules/c++/math.linear/include/math/linear/Matrix2D.h
@@ -25,7 +25,7 @@
 #include <cmath>
 #include <algorithm>
 #include <functional>
-#include <memory>
+#include <std/memory>
 #include <cstddef>
 
 #include <import/sys.h>

--- a/modules/c++/mem/CMakeLists.txt
+++ b/modules/c++/mem/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MODULE_NAME mem)
 coda_add_module(
     ${MODULE_NAME}
     VERSION 1.0
-    DEPS sys-c++ gsl-c++)
+    DEPS sys-c++ gsl-c++ std-c++)
 
 coda_add_tests(
     MODULE_NAME ${MODULE_NAME}

--- a/modules/c++/mem/include/mem/ScopedPtr.h
+++ b/modules/c++/mem/include/mem/ScopedPtr.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <cstddef>
-#include <memory>
+#include <std/memory>
 #include <type_traits>
 
 #include "sys/Conf.h"

--- a/modules/c++/mt/CMakeLists.txt
+++ b/modules/c++/mt/CMakeLists.txt
@@ -7,7 +7,7 @@ coda_generate_module_config_header(${MODULE_NAME})
 coda_add_module(
     ${MODULE_NAME}
     VERSION 1.1
-    DEPS sys-c++ except-c++ math-c++ mem-c++ types-c++)
+    DEPS sys-c++ except-c++ math-c++ mem-c++ types-c++ std-c++)
 
 coda_add_tests(
     MODULE_NAME ${MODULE_NAME}

--- a/modules/c++/mt/include/mt/BasicThreadPool.h
+++ b/modules/c++/mt/include/mt/BasicThreadPool.h
@@ -24,7 +24,7 @@
 #define __MT_BASIC_THREAD_POOL_H__
 
 #include <vector>
-#include <memory>
+#include <std/memory>
 
 #include "except/Exception.h"
 #include "sys/Mutex.h"

--- a/modules/c++/mt/include/mt/Singleton.h
+++ b/modules/c++/mt/include/mt/Singleton.h
@@ -25,6 +25,7 @@
 #define __MT_SINGLETON_H__
 
 #include <mutex>
+#include <std/memory>
 
 #include <import/sys.h>
 #include <config/compiler_extensions.h>

--- a/modules/c++/mt/wscript
+++ b/modules/c++/mt/wscript
@@ -1,7 +1,6 @@
 NAME            = 'mt'
-MAINTAINER      = 'jmrandol@users.sourceforge.net'
 VERSION         = '1.1'
-MODULE_DEPS     = 'sys except math mem types'
+MODULE_DEPS     = 'sys except math mem types std'
 TEST_DEPS       = 'cli'
 
 distclean = lambda p: None

--- a/modules/c++/std/include/std/bit
+++ b/modules/c++/std/include/std/bit
@@ -22,9 +22,11 @@
 #define CODA_OSS_std_bit_INCLUDED_
 #pragma once
 
+#include "coda_oss/bit.h"
+#include "coda_oss/CPlusPlus.h"
+
 // Make it (too?) easy for clients to get our various std:: implementations
 #ifndef CODA_OSS_NO_std_endian
-    #include "coda_oss/CPlusPlus.h"
     #if CODA_OSS_cpp20
         // Some implementations cliam to be C++20 w/o <bit>
         #if __has_include(<bit>) // __has_include is C++17
@@ -34,7 +36,6 @@
     #endif 
     // At this point, CODA_OSS_NO_std_endian will be set only if we were able to successfully use <bit> (above)
     #ifndef CODA_OSS_NO_std_endian
-        #include "coda_oss/bit.h"
         #define CODA_OSS_NO_std_endian 0  // <= C++17, use our own
     #endif
 #endif

--- a/modules/c++/std/include/std/cstddef
+++ b/modules/c++/std/include/std/cstddef
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <cstddef>
+#include "coda_oss/cstddef.h"
+#include "coda_oss/CPlusPlus.h"
 
 // Make it (too?) easy for clients to get our various std:: implementations
 #ifndef CODA_OSS_NO_std_byte
@@ -30,7 +32,6 @@
         #undef CODA_OSS_NO_std_byte
         #define CODA_OSS_NO_std_byte 1  // provided by implementation, probably C++20
     #else
-        #include "coda_oss/cstddef.h"
         #define CODA_OSS_NO_std_byte 0  // use our own
     #endif
 #endif

--- a/modules/c++/std/include/std/filesystem
+++ b/modules/c++/std/include/std/filesystem
@@ -22,9 +22,11 @@
 #define CODA_OSS_std_filesystem_INCLUDED_
 #pragma once
 
+#include "sys/filesystem.h"
+#include "coda_oss/CPlusPlus.h"
+
 // Make it (too?) easy for clients to get our various std:: implementations
 #ifndef CODA_OSS_NO_std_filesystem
-    #include "coda_oss/CPlusPlus.h"
     #if CODA_OSS_cpp17
         // Some versions of G++ say they're C++17 but don't have <filesystem>
         #if __has_include(<filesystem>)  // __has_include is C++17
@@ -32,7 +34,6 @@
             #define CODA_OSS_NO_std_filesystem 1  // part of C++17
         #endif
     #else
-        #include "sys/filesystem.h"
         #define CODA_OSS_NO_std_filesystem 0  // use our own
     #endif
 #endif

--- a/modules/c++/std/include/std/memory
+++ b/modules/c++/std/include/std/memory
@@ -22,7 +22,24 @@
 #define CODA_OSS_std_memory_INCLUDED_
 #pragma once
 
-#include "coda_oss/CPlusPlus.h"
+#include <memory>
 #include "coda_oss/memory.h"
+#include "coda_oss/CPlusPlus.h"
+
+// Make it (too?) easy for clients to get our various std:: implementations
+#ifndef CODA_OSS_NO_std_make_unique
+    #if CODA_OSS_cpp14
+        #define CODA_OSS_NO_std_make_unique 1  // part of C++14
+    #else
+        #define CODA_OSS_NO_std_make_unique 0  // use our own
+    #endif
+#endif
+
+#if !CODA_OSS_NO_std_make_unique
+namespace std // This is slightly uncouth: we're not supposed to augment "std".
+{
+    using coda_oss::make_unique;
+}
+#endif  // !CODA_OSS_NO_std_make_unique
 
 #endif  // CODA_OSS_std_memory_INCLUDED_

--- a/modules/c++/std/include/std/optional
+++ b/modules/c++/std/include/std/optional
@@ -22,14 +22,15 @@
 #define CODA_OSS_std_optional_INCLUDED_
 #pragma once
 
+#include "coda_oss/optional.h"
+#include "coda_oss/CPlusPlus.h"
+
 // Make it (too?) easy for clients to get our various std:: implementations
 #ifndef CODA_OSS_NO_std_optional
-    #include "coda_oss/CPlusPlus.h"
     #if CODA_OSS_cpp17
         #include <optional>
         #define CODA_OSS_NO_std_optional 1  // part of C++17
     #else
-        #include "coda_oss/optional.h"
         #define CODA_OSS_NO_std_optional 0  // use our own
     #endif
 #endif

--- a/modules/c++/std/include/std/span
+++ b/modules/c++/std/include/std/span
@@ -22,14 +22,15 @@
 #define CODA_OSS_std_span_INCLUDED_
 #pragma once
 
+#include "coda_oss/span.h"
+#include "coda_oss/CPlusPlus.h"
+
 // Make it (too?) easy for clients to get our various std:: implementations
 #ifndef CODA_OSS_NO_std_span
-    #include "coda_oss/CPlusPlus.h"
     #if CODA_OSS_cpp20
         #include <span>
         #define CODA_OSS_NO_std_span 1  // part of C++20
     #else
-        #include "coda_oss/span.h"
         #define CODA_OSS_NO_std_span 0  // use our own
     #endif
 #endif

--- a/modules/c++/std/include/std/string
+++ b/modules/c++/std/include/std/string
@@ -23,14 +23,14 @@
 #pragma once
 
 #include <string>
+#include "coda_oss/string.h"
+#include "coda_oss/CPlusPlus.h"
 
 // Make it (too?) easy for clients to get our various std:: implementations
 #ifndef CODA_OSS_NO_std_u8string
-    #include "coda_oss/CPlusPlus.h"
     #if CODA_OSS_cpp20
         #define CODA_OSS_NO_std_u8string 1  // part of C++20
     #else
-        #include "coda_oss/string.h"
         #define CODA_OSS_NO_std_u8string 0  // use our own
     #endif
 #endif

--- a/modules/c++/std/include/std/type_traits
+++ b/modules/c++/std/include/std/type_traits
@@ -22,8 +22,26 @@
 #define CODA_OSS_std_type_traits_INCLUDED_
 #pragma once
 
-#include "coda_oss/CPlusPlus.h"
+#include <type_traits>
 #include "coda_oss/type_traits.h"
+
+// Make it (too?) easy for clients to get our various std:: implementations
+#ifndef CODA_OSS_NO_is_trivially_copyable
+	// https://stackoverflow.com/a/31798726/8877
+	// workaround missing "is_trivially_copyable" in g++ < 5.0
+	#if defined(__GNUC__) && (__GNUC__ < 5)
+		#define CODA_OSS_NO_is_trivially_copyable 0  // *need* our own
+	#else
+		#define CODA_OSS_NO_is_trivially_copyable 1  // *disabled*, unless explicitly enabled
+	#endif
+#endif
+
+#if !CODA_OSS_NO_is_trivially_copyable
+namespace std // This is slightly uncouth: we're not supposed to augment "std".
+{
+	using coda_oss::is_trivially_copyable;
+}
+#endif // CODA_OSS_NO_is_trivially_copyable
 
 #endif  // CODA_OSS_std_type_traits_INCLUDED_
 

--- a/modules/c++/xml.lite/include/xml/lite/Document.h
+++ b/modules/c++/xml.lite/include/xml/lite/Document.h
@@ -39,6 +39,7 @@
 #include <assert.h>
 
 #include <utility>
+#include <std/memory>
 #include "coda_oss/string.h"
 #include "coda_oss/memory.h"
 

--- a/modules/c++/xml.lite/include/xml/lite/MinidomHandler.h
+++ b/modules/c++/xml.lite/include/xml/lite/MinidomHandler.h
@@ -46,7 +46,7 @@
  */
 
 #include <stack>
-#include <memory>
+#include <std/memory>
 #include "coda_oss/string.h"
 #include "coda_oss/memory.h"
 

--- a/modules/c++/xml.lite/source/ValidatorXerces.cpp
+++ b/modules/c++/xml.lite/source/ValidatorXerces.cpp
@@ -188,13 +188,8 @@ inline void reset(str::EncodedStringView xmlView, std::unique_ptr<std::wstring>&
     pWString = std::make_unique<std::wstring>(xmlView.wstring());
 }
 #else
-#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER_BUILD_DATE < 20190815)
-using XMLCh_t = uint16_t;
-static_assert(std::is_same<::XMLCh, XMLCh_t>::value, "XMLCh should be uint16_t");
-#else
 using XMLCh_t = char16_t;
 static_assert(std::is_same<::XMLCh, XMLCh_t>::value, "XMLCh should be char16_t");
-#endif
 #endif
 
 inline void reset(str::EncodedStringView xmlView, std::unique_ptr<std::u16string>& pWString)


### PR DESCRIPTION
We're still using an old version of the Intel compiler that only partially implements C++14.