### PR TITLE
move debug -g flags to be turned on only if debugging

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -897,12 +897,6 @@ def configureCompilerOptions(self):
         #       If you want the plugins to not depend on Intel libraries,
         #       configure with:
         #       --with-cflags=-static-intel --with-cxxflags=-static-intel --with-linkflags=-static-intel
-        if cxxCompiler == 'gcc':
-            config['cxx']['debug']          = '-ggdb3'
-            config['cxx']['optz_debug']     = '-Og'
-        elif cxxCompiler == 'icpc':
-            config['cxx']['debug']          = '-g'
-            config['cxx']['optz_debug']     = ''
         if cxxCompiler == 'g++' or cxxCompiler == 'icpc':
             config['cxx']['warn']           = warningFlags.split()
             config['cxx']['verbose']        = '-v'
@@ -930,12 +924,21 @@ def configureCompilerOptions(self):
 
             self.env.append_value('LINKFLAGS', linkFlags.split())
 
-        if ccCompiler == 'gcc':
-            config['cc']['debug']          = '-ggdb3'
-            config['cc']['optz_debug']     = '-Og'
-        elif ccCompiler == 'icc':
-            config['cc']['debug']          = '-g'
-            config['cc']['optz_debug']     = ''
+        if Options.options.debugging:
+            if cxxCompiler == 'g++':
+                config['cxx']['debug'] = '-ggdb3'
+                config['cxx']['optz_debug'] = '-Og'
+            elif cxxCompiler == 'icpc':
+                config['cxx']['debug'] = '-g'
+                config['cxx']['optz_debug'] = ''
+
+            if ccCompiler == 'gcc':
+                config['cc']['debug'] = '-ggdb3'
+                config['cc']['optz_debug'] = '-Og'
+            elif ccCompiler == 'icc':
+                config['cc']['debug'] = '-g'
+                config['cc']['optz_debug'] = ''
+
         if ccCompiler == 'gcc' or ccCompiler == 'icc':
             config['cc']['warn']           = warningFlags.split()
             config['cc']['verbose']        = '-v'


### PR DESCRIPTION
# Description
Fix bug where `-g` debug flags were not being handled correctly for `waf` builds.  On master calling:
* `python waf configure --prefix=install --enable-debugging`
* `python waf install`  

Adds debug flags for `gcc` calls **but not** `g++`.  See below:
## gcc example on master
Obtained these dumps from running `python waf install --verbose`
```
'/usr/bin/gcc', '-fPIC', '-Wall', '-Wno-deprecated-declarations', '-ggdb3', '-Og', '-m64',
```
## g++ example on master
**note missing -g flags**
```
'/usr/bin/g++', '-fPIC', '-std=c++11', '-Wall', '-Wno-deprecated-declarations', '-m64',
```

# Steps to review
* Run: `python waf configure --prefix=install --enable-debugging`
* Run: `python waf install`
* Verify ability to debug executables with `gdb`
    - Set a breakpoint in an executable and print some stuff
    - Here's an example I used to verify this: `gdb install/unittests/math.linear/test_VectorN` 
