### PR TITLE
Change xml lite function to virtual

### DIFF
--- a/modules/c++/xml.lite/include/xml/lite/Document.h
+++ b/modules/c++/xml.lite/include/xml/lite/Document.h
@@ -103,7 +103,7 @@ struct Document // SOAPDocument derives :-(
      * \param characterData The character data (if any)
      * \return A new element
      */
-    Element *createElement(const std::string & qname, const std::string & uri, std::string characterData = "");
+    virtual Element *createElement(const std::string & qname, const std::string & uri, std::string characterData = "");
     #ifndef SWIG // SWIG doesn't like std::unique_ptr
     std::unique_ptr<Element> createElement(const xml::lite::QName&, const std::string& characterData) const;
     std::unique_ptr<Element> createElement(const xml::lite::QName&, const coda_oss::u8string& characterData) const;

--- a/modules/c++/xml.lite/unittests/test_soapelements.cpp
+++ b/modules/c++/xml.lite/unittests/test_soapelements.cpp
@@ -19,11 +19,11 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+
 #include <TestCase.h>
 #include "xml/lite/Document.h"
 #include "xml/lite/Element.h"
 #include "xml/lite/QName.h"
-#include <iostream>
 static const std::string test_text = "SOAP Test";
 
 struct SOAPBody : public xml::lite::Element
@@ -52,15 +52,10 @@ struct SOAP : public xml::lite::Document
 
 TEST_CASE(test_overrideCreateElement)
 {
-    SOAP *soap_test = new SOAP();
-    xml::lite::Document * doc = new xml::lite::Document();
+    xml::lite::Document *soap_test = new SOAP();
     xml::lite::Element * a = soap_test->createElement("a","b","Not SOAP Test");
-    SOAPBody* b = dynamic_cast<SOAPBody*>(a);
-    xml::lite::Element *  c = doc->createElement("a","b","Not Soap Test");
+    SOAPBody* b = static_cast<SOAPBody*>(a);
     TEST_ASSERT_NOT_NULL(b);
-    std::cout << a->getCharacterData() << std::endl;
-    std::cout << b->getCharacterData() << std::endl;
-    std::cout << c->getCharacterData() << std::endl;
     std::cout << test_text << std::endl;
     TEST_ASSERT_EQ(a->getCharacterData(), test_text);
     TEST_ASSERT_EQ(b->getCharacterData(), test_text);

--- a/modules/c++/xml.lite/unittests/test_soapelements.cpp
+++ b/modules/c++/xml.lite/unittests/test_soapelements.cpp
@@ -19,7 +19,6 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
-
 #include <TestCase.h>
 #include "xml/lite/Document.h"
 #include "xml/lite/Element.h"
@@ -53,16 +52,22 @@ struct SOAP : public xml::lite::Document
 
 TEST_CASE(test_overrideCreateElement)
 {
-    SOAP soap_test;
-    auto a = soap_test.createElement("a","b","Not SOAP Test");
-    std::cout << test_text << std::endl;
+    SOAP *soap_test = new SOAP();
+    xml::lite::Document * doc = new xml::lite::Document();
+    xml::lite::Element * a = soap_test->createElement("a","b","Not SOAP Test");
+    SOAPBody* b = dynamic_cast<SOAPBody*>(a);
+    xml::lite::Element *  c = doc->createElement("a","b","Not Soap Test");
+    TEST_ASSERT_NOT_NULL(b);
     std::cout << a->getCharacterData() << std::endl;
+    std::cout << b->getCharacterData() << std::endl;
+    std::cout << c->getCharacterData() << std::endl;
+    std::cout << test_text << std::endl;
     TEST_ASSERT_EQ(a->getCharacterData(), test_text);
+    TEST_ASSERT_EQ(b->getCharacterData(), test_text);
 }
 
 int main(int, char**)
 {
     TEST_CHECK(test_overrideCreateElement);
 }
-
 

--- a/modules/c++/xml.lite/unittests/test_soapelements.cpp
+++ b/modules/c++/xml.lite/unittests/test_soapelements.cpp
@@ -54,9 +54,8 @@ TEST_CASE(test_overrideCreateElement)
 {
     xml::lite::Document *soap_test = new SOAP();
     xml::lite::Element * a = soap_test->createElement("a","b","Not SOAP Test");
-    SOAPBody* b = static_cast<SOAPBody*>(a);
+    SOAPBody* b = dynamic_cast<SOAPBody*>(a);
     TEST_ASSERT_NOT_NULL(b);
-    std::cout << test_text << std::endl;
     TEST_ASSERT_EQ(a->getCharacterData(), test_text);
     TEST_ASSERT_EQ(b->getCharacterData(), test_text);
 }

--- a/modules/c++/xml.lite/unittests/test_soapelements.cpp
+++ b/modules/c++/xml.lite/unittests/test_soapelements.cpp
@@ -1,0 +1,68 @@
+/* =========================================================================
+ * This file is part of io-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2019, MDA Information Systems LLC
+ *
+ * io-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <TestCase.h>
+#include "xml/lite/Document.h"
+#include "xml/lite/Element.h"
+#include "xml/lite/QName.h"
+#include <iostream>
+static const std::string test_text = "SOAP Test";
+
+struct SOAPBody : public xml::lite::Element
+{
+    SOAPBody ()
+    {}
+
+    SOAPBody (const xml::lite::QName& qname)
+    {
+      setQName(qname);
+    }
+};
+
+struct SOAP : public xml::lite::Document
+{
+    xml::lite::Element* createElement(const std::string & qname,
+                                      const std::string& uri,
+                                      std::string characterData = "") {
+        xml::lite::Element * elem;
+        xml::lite::QName asQName(uri, qname);
+        elem = new SOAPBody(asQName);
+        elem->setCharacterData(test_text);
+        return elem;
+    }
+};
+
+TEST_CASE(test_overrideCreateElement)
+{
+    SOAP soap_test;
+    auto a = soap_test.createElement("a","b","Not SOAP Test");
+    std::cout << test_text << std::endl;
+    std::cout << a->getCharacterData() << std::endl;
+    TEST_ASSERT_EQ(a->getCharacterData(), test_text);
+}
+
+int main(int, char**)
+{
+    TEST_CHECK(test_overrideCreateElement);
+}
+
+


### PR DESCRIPTION
Program dependent on coda-oss has class that inherits and overrides createElement function from document in the xml lite class. This pull request changes createElement back to virtual.