### PR TITLE
C++11/master release

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,15 +11,24 @@
  ```
 # coda-oss Release Notes
 
+## [Release 2023-03-10](https://github.com/mdaus/coda-oss/releases/tag/2023-01-10)
+* Final 🤞🏻 **C++11 release  from [master](https://github.com/mdaus/coda-oss/tree/master)
+  not [main](https://github.com/mdaus/coda-oss/tree/main)/C++14** (as releases since
+  [2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30) have been).
+* [HDF5](https://www.hdfgroup.org/) [source code](https://github.com/HDFGroup/hdf5) added (not built).
+* *waf* self-extractor rebuilt to fix FIPS warning because of insecure *md5* hashing.
+* Better debug/release configurations for *waf* builds.
+* Minor tweaks from other projects.
+
 ## [Release 2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30)
 * XML is now always written as UTF-8; the code will still try to read Windows-1252.
 * `Uri`s are no longer validated by default.
 * Minor tweaks from other projects.
-* Final C++11 release 🤞🏻; future releases will be C++14 from [main](https://github.com/mdaus/coda-oss/tree/main).
+* ~~Final C++11 release 🤞🏻; future releases will be C++14 from [main](https://github.com/mdaus/coda-oss/tree/main).~~
 
 ## [Release 2022-08-02](https://github.com/mdaus/coda-oss/releases/tag/2022-08-02)
 * remove *Expat* and *libXML* modules and support in **xml.lite**; only *Xerces* was actively used.
-* fix `waf` to work-around FIPS warning because of insecure *md5* hashing.
+* ~~fix `waf` to work-around FIPS warning because of insecure *md5* hashing.~~
 * tweak `str::EncodedStringView` and `str::EncodedString` for
   [future XML changes](https://github.com/mdaus/coda-oss/tree/feature/always-write-xml-as-utf8).
 

--- a/modules/c++/config/include/config/Version.h
+++ b/modules/c++/config/include/config/Version.h
@@ -41,13 +41,13 @@ static_assert(CODA_OSS_MAKE_VERSION_MMPB(9999, 9999, 9999, 9999) <= UINT64_MAX, 
 #define CODA_OSS_GET_VERSION_BUILD(version) CODA_OSS_GET_VERSION_(version, 1 /*factor*/)
 
 // Do this ala C++ ... we don't currently have major/minor/patch
-//#define CODA_OSS_VERSION_ 20210910L // c.f. __cplusplus
-#define CODA_OSS_VERSION_ 2022 ## 0008 ## 0030 ## 0000 ## L
+//#define CODA_OSS_VERSION_ 20230310L // c.f. __cplusplus
+#define CODA_OSS_VERSION_ 2023 ## 0003 ## 0010 ## 0000 ## L
 
 // Use the same macros other projects might want to use; overkill for us.
-#define CODA_OSS_VERSION_MAJOR	2022
-#define CODA_OSS_VERSION_MINOR	8
-#define CODA_OSS_VERSION_PATCH	30
+#define CODA_OSS_VERSION_MAJOR	2023
+#define CODA_OSS_VERSION_MINOR	3
+#define CODA_OSS_VERSION_PATCH	10
 #define CODA_OSS_VERSION_BUILD	0
 #define CODA_OSS_VERSION CODA_OSS_MAKE_VERSION_MMPB(CODA_OSS_VERSION_MAJOR, CODA_OSS_VERSION_MINOR, CODA_OSS_VERSION_PATCH, CODA_OSS_VERSION_BUILD)
 


### PR DESCRIPTION
* Final 🤞🏻 **C++11 release  from [master](https://github.com/mdaus/coda-oss/tree/master)
  not [main](https://github.com/mdaus/coda-oss/tree/main)/C++14** as releases since
  [2022-08-30](https://github.com/mdaus/coda-oss/releases/tag/2022-08-30) have been.
* [HDF5](https://www.hdfgroup.org/) [source code](https://github.com/HDFGroup/hdf5) added (not built).
* *waf* self-extractor rebuilt to fix FIPS error.
* Better debug/release configurations for *waf* builds.
* Minor tweaks from other projects.