### PR TITLE
add types::complex_short

### DIFF
--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -321,6 +321,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\modules\c++\types\unittests\test_complex_short.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\modules\c++\types\unittests\test_page_row_col.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/UnitTest/UnitTest.vcxproj.filters
+++ b/UnitTest/UnitTest.vcxproj.filters
@@ -222,6 +222,9 @@
     <ClCompile Include="..\modules\c++\mt\unittests\test_mt_byte_swap.cpp">
       <Filter>mt</Filter>
     </ClCompile>
+    <ClCompile Include="..\modules\c++\types\unittests\test_complex_short.cpp">
+      <Filter>types</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/UnitTest/pch.h
+++ b/UnitTest/pch.h
@@ -53,6 +53,7 @@
 #include <types/PageRowCol.h>
 #include <types/RangeList.h>
 #include <types/Range.h>
+#include <types/complex_short.h>
 #include <sys/Conf.h>
 #include <sys/Path.h>
 #include <except/Exception.h>

--- a/UnitTest/types.cpp
+++ b/UnitTest/types.cpp
@@ -15,4 +15,8 @@ TEST_CLASS(test_range_list){ public:
 #include "types/unittests/test_range_list.cpp"
 };
 
+TEST_CLASS(test_complex_short){ public:
+#include "types/unittests/test_complex_short.cpp"
+};
+
 }

--- a/modules/c++/coda-oss-lite.vcxproj
+++ b/modules/c++/coda-oss-lite.vcxproj
@@ -257,6 +257,7 @@
     <ClInclude Include="tiff\include\tiff\KnownTags.h" />
     <ClInclude Include="tiff\include\tiff\TypeFactory.h" />
     <ClInclude Include="tiff\include\tiff\Utils.h" />
+    <ClInclude Include="types\include\types\complex_short.h" />
     <ClInclude Include="types\include\types\PageRowCol.h" />
     <ClInclude Include="types\include\types\Range.h" />
     <ClInclude Include="types\include\types\RangeList.h" />

--- a/modules/c++/coda-oss-lite.vcxproj.filters
+++ b/modules/c++/coda-oss-lite.vcxproj.filters
@@ -750,6 +750,9 @@
     <ClInclude Include="sys\include\sys\SysInt.h">
       <Filter>sys</Filter>
     </ClInclude>
+    <ClInclude Include="types\include\types\complex_short.h">
+      <Filter>types</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/modules/c++/std/include/import/cpp14.h
+++ b/modules/c++/std/include/import/cpp14.h
@@ -26,12 +26,26 @@
 #define CODA_OSS_import_cpp14_h_INCLUDED_
 #pragma once
 
+#include "coda_oss/CPlusPlus.h"
+#include "config/disable_compiler_warnings.h"
+
 // Common C++14 headers
 #include <limits>
 #include <memory>
 #include <new>
 
+CODA_OSS_disable_warning_push
+#ifdef _MSC_VER
+#pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
+#endif
+
 #include <complex>
+namespace
+{
+    std::complex<short> unused;
+}
+CODA_OSS_disable_warning_pop
+
 #include <utility>
 #include <tuple>
 #include <future>

--- a/modules/c++/std/include/import/cpp14.h
+++ b/modules/c++/std/include/import/cpp14.h
@@ -21,31 +21,16 @@
  *
  */
 
-
+#pragma once 
 #ifndef CODA_OSS_import_cpp14_h_INCLUDED_
 #define CODA_OSS_import_cpp14_h_INCLUDED_
-#pragma once
-
-#include "coda_oss/CPlusPlus.h"
-#include "config/disable_compiler_warnings.h"
 
 // Common C++14 headers
 #include <limits>
 #include <memory>
 #include <new>
 
-CODA_OSS_disable_warning_push
-#ifdef _MSC_VER
-#pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
-#endif
-
 #include <complex>
-namespace
-{
-    std::complex<short> unused;
-}
-CODA_OSS_disable_warning_pop
-
 #include <utility>
 #include <tuple>
 #include <future>

--- a/modules/c++/types/CMakeLists.txt
+++ b/modules/c++/types/CMakeLists.txt
@@ -2,7 +2,7 @@ set(MODULE_NAME types)
 
 coda_add_module(${MODULE_NAME}
     VERSION 1.0
-    DEPS std-c++ gsl-c++ coda_oss-c++)
+    DEPS coda_oss-c++ config-c++ gsl-c++ coda_oss-c++)
 
 coda_add_tests(
     MODULE_NAME ${MODULE_NAME}

--- a/modules/c++/types/CMakeLists.txt
+++ b/modules/c++/types/CMakeLists.txt
@@ -2,7 +2,7 @@ set(MODULE_NAME types)
 
 coda_add_module(${MODULE_NAME}
     VERSION 1.0
-    DEPS gsl-c++ coda_oss-c++)
+    DEPS std-c++ gsl-c++ coda_oss-c++)
 
 coda_add_tests(
     MODULE_NAME ${MODULE_NAME}

--- a/modules/c++/types/CMakeLists.txt
+++ b/modules/c++/types/CMakeLists.txt
@@ -2,7 +2,7 @@ set(MODULE_NAME types)
 
 coda_add_module(${MODULE_NAME}
     VERSION 1.0
-    DEPS gsl-c++)
+    DEPS gsl-c++ coda_oss-c++)
 
 coda_add_tests(
     MODULE_NAME ${MODULE_NAME}

--- a/modules/c++/types/include/types/complex_short.h
+++ b/modules/c++/types/include/types/complex_short.h
@@ -25,10 +25,10 @@
 #ifndef CODA_OSS_types_complex_short_h_INCLUDED_
 #define CODA_OSS_types_complex_short_h_INCLUDED_
 
-#include "import/std.h"
+#include <complex>
 
+#include "config/disable_compiler_warnings.h"
 #include "coda_oss/CPlusPlus.h"
-#include "gsl/gsl.h"
 
 namespace types
 {
@@ -75,15 +75,26 @@ private:
 };
 static_assert(sizeof(complex_short) == sizeof(float), "sizeof(complex_short) != sizeof(float)");
 
+CODA_OSS_disable_warning_push
+#ifdef _MSC_VER
+#pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
+#endif
+
+inline const std::complex<short>& cast(const complex_short& z)
+{
+    // Getting different results with GCC vs MSVC :-(  So just use
+    // std::complex<short> Assume by the time we're actually using C++23 with a
+    // compiler that enforces this restriction, "something" will be different.
+    const void* const pZ_ = &z;
+    return *static_cast<const std::complex<short>*>(pZ_);
+}
+
+CODA_OSS_disable_warning_pop
+
 // https://en.cppreference.com/w/cpp/numeric/complex/abs
 inline auto abs(const complex_short& z)
 {
-    // Getting different results with GCC vs MSVC :-(  So just use std::abs() with std::complex<short>
-    // Assume by the time we're actually using C++23 with a compiler that enforces
-    // this restriction, "things will be different."
-    const void* const pZ_ = &z;
-    auto const pZ = static_cast<const std::complex<short>*>(pZ_);
-    return std::abs(*pZ);
+    return abs(cast(z));
 }
 
 }
@@ -91,7 +102,8 @@ inline auto abs(const complex_short& z)
 #if CODA_OSS_cpp23
     using details::complex_short;
 #else
-    // no macro to turn this on/off, want to implement what we need in details::complex_short
+    // No macro to turn this on/off, want to implement what we need in details::complex_short.
+    // But keep in `details` in case somebody wants to uncomment.
     //using complex_short = std::complex<short>; // not valid in C++23
     using details::complex_short;
 

--- a/modules/c++/types/include/types/complex_short.h
+++ b/modules/c++/types/include/types/complex_short.h
@@ -1,0 +1,89 @@
+/* =========================================================================
+ * This file is part of types-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2023, Maxar Technologies, Inc.
+ *
+ * types-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+#ifndef CODA_OSS_types_complex_short_h_INCLUDED_
+#define CODA_OSS_types_complex_short_h_INCLUDED_
+
+#include <complex>
+
+#include "coda_oss/CPlusPlus.h"
+
+namespace types
+{
+namespace details
+{
+/*!
+ *  \class complex_short
+ *  \brief std::complex<short>
+ *
+ * `std::complex<short>` is no longer valid C++; provide a (partial) work-around.
+ * See https://en.cppreference.com/w/cpp/numeric/complex for detals.
+ */
+struct complex_short final
+{
+    using value_type = short;
+
+    complex_short(value_type re = 0, value_type im = 0) : z{re, im} {}
+    complex_short(const complex_short&) = default;
+    complex_short& operator=(const complex_short&) = default;
+    complex_short(complex_short&&) = default;
+    complex_short& operator=(complex_short&&) = default;
+    ~complex_short() = default;
+
+    value_type real() const
+    {
+        return z[0];
+    }
+    void real(value_type value)
+    {
+        z[0] = value;
+    }
+
+    value_type imag() const
+    {
+        return z[1];
+    }
+    void imag(value_type value)
+    {
+        z[1] = value;
+    }
+
+private:
+    value_type z[2]{0, 0};
+};
+static_assert(sizeof(complex_short) == sizeof(float), "sizeof(complex_short) != sizeof(float)");
+}
+
+#if CODA_OSS_cpp23
+    using complex_short = details::complex_short;
+#else
+    // no macro to turn this on/off, want to implement what we need in details::complex_short
+    //using complex_short = std::complex<short>; // not valid in C++23
+    using complex_short = details::complex_short;
+
+    static_assert(sizeof(std::complex<short>) == sizeof(complex_short), "sizeof(sizeof(std::complex<short>) != sizeof(complex_short)");
+#endif
+}
+
+#endif  // CODA_OSS_types_complex_short_h_INCLUDED_

--- a/modules/c++/types/include/types/complex_short.h
+++ b/modules/c++/types/include/types/complex_short.h
@@ -78,8 +78,8 @@ static_assert(sizeof(complex_short) == sizeof(float), "sizeof(complex_short) != 
 // https://en.cppreference.com/w/cpp/numeric/complex/abs
 inline auto abs(const complex_short& z)
 {
-    const std::complex<long double> z_(z.real(), z.imag());
-    const auto result = abs(z_);
+    const std::complex<float> z_(z.real(), z.imag());
+    const auto result = std::abs(z_);
     return gsl::narrow_cast<complex_short::value_type>(result);
 }
 

--- a/modules/c++/types/include/types/complex_short.h
+++ b/modules/c++/types/include/types/complex_short.h
@@ -25,7 +25,7 @@
 #ifndef CODA_OSS_types_complex_short_h_INCLUDED_
 #define CODA_OSS_types_complex_short_h_INCLUDED_
 
-#include <complex>
+#include "import/std.h"
 
 #include "coda_oss/CPlusPlus.h"
 #include "gsl/gsl.h"
@@ -78,9 +78,12 @@ static_assert(sizeof(complex_short) == sizeof(float), "sizeof(complex_short) != 
 // https://en.cppreference.com/w/cpp/numeric/complex/abs
 inline auto abs(const complex_short& z)
 {
-    const std::complex<float> z_(z.real(), z.imag());
-    const auto result = std::abs(z_);
-    return gsl::narrow_cast<complex_short::value_type>(result);
+    // Getting different results with GCC vs MSVC :-(  So just use std::abs() with std::complex<short>
+    // Assume by the time we're actually using C++23 with a compiler that enforces
+    // this restriction, "things will be different."
+    const void* const pZ_ = &z;
+    auto const pZ = static_cast<const std::complex<short>*>(pZ_);
+    return std::abs(*pZ);
 }
 
 }

--- a/modules/c++/types/include/types/complex_short.h
+++ b/modules/c++/types/include/types/complex_short.h
@@ -78,7 +78,7 @@ static_assert(sizeof(complex_short) == sizeof(float), "sizeof(complex_short) != 
 // https://en.cppreference.com/w/cpp/numeric/complex/abs
 inline auto abs(const complex_short& z)
 {
-    const std::complex<float> z_(z.real(), z.imag());
+    const std::complex<long double> z_(z.real(), z.imag());
     const auto result = abs(z_);
     return gsl::narrow_cast<complex_short::value_type>(result);
 }

--- a/modules/c++/types/include/types/complex_short.h
+++ b/modules/c++/types/include/types/complex_short.h
@@ -28,6 +28,7 @@
 #include <complex>
 
 #include "coda_oss/CPlusPlus.h"
+#include "gsl/gsl.h"
 
 namespace types
 {
@@ -73,14 +74,23 @@ private:
     value_type z[2]{0, 0};
 };
 static_assert(sizeof(complex_short) == sizeof(float), "sizeof(complex_short) != sizeof(float)");
+
+// https://en.cppreference.com/w/cpp/numeric/complex/abs
+inline auto abs(const complex_short& z)
+{
+    const std::complex<float> z_(z.real(), z.imag());
+    const auto result = abs(z_);
+    return gsl::narrow_cast<complex_short::value_type>(result);
+}
+
 }
 
 #if CODA_OSS_cpp23
-    using complex_short = details::complex_short;
+    using details::complex_short;
 #else
     // no macro to turn this on/off, want to implement what we need in details::complex_short
     //using complex_short = std::complex<short>; // not valid in C++23
-    using complex_short = details::complex_short;
+    using details::complex_short;
 
     static_assert(sizeof(std::complex<short>) == sizeof(complex_short), "sizeof(sizeof(std::complex<short>) != sizeof(complex_short)");
 #endif

--- a/modules/c++/types/unittests/test_complex_short.cpp
+++ b/modules/c++/types/unittests/test_complex_short.cpp
@@ -20,16 +20,6 @@
  *
  */
 
-// Told ya this wasn't valid C++ ... :-)
-#define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING
-#ifdef _MSC_VER
-#pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
-#endif
-
-#include <math.h>
-
-#include <complex>
-
 #include "TestCase.h"
 
 #include <types/complex_short.h>
@@ -41,16 +31,9 @@ TEST_CASE(TestCxShort_abs)
 
     const std::complex<short> cx_short(real, imag);
     const auto expected = abs(cx_short);
-    TEST_ASSERT_EQ(343, expected);
-
-    // Compute value "by hand", see
-    // https://en.cppreference.com/w/cpp/numeric/math/hypot
-    const auto result = hypotf(cx_short.real(), cx_short.imag());
-    auto actual = gsl::narrow_cast<short>(result);
-    TEST_ASSERT_EQ(actual, expected);
 
     const types::complex_short types_cx_short(real, imag);
-    actual = abs(types_cx_short);
+    const auto actual = abs(types_cx_short);
     TEST_ASSERT_EQ(actual, expected);
 }
 

--- a/modules/c++/types/unittests/test_complex_short.cpp
+++ b/modules/c++/types/unittests/test_complex_short.cpp
@@ -1,0 +1,44 @@
+/* =========================================================================
+ * This file is part of types-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * types-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include <complex>
+
+#include "TestCase.h"
+
+#include <types/complex_short.h>
+
+TEST_CASE(TestCxShort_abs)
+{
+    constexpr auto real = 123;
+    constexpr auto imag = -321;
+
+    const std::complex<short> cx_short(real, imag);
+    const auto expected = abs(cx_short);
+
+    const types::complex_short types_cx_short(real, imag);
+    const auto actual = abs(types_cx_short);
+
+    TEST_ASSERT_EQ(actual, expected);
+}
+
+TEST_MAIN(
+    TEST_CHECK(TestCxShort_abs);
+    )

--- a/modules/c++/types/unittests/test_complex_short.cpp
+++ b/modules/c++/types/unittests/test_complex_short.cpp
@@ -19,6 +19,13 @@
  * see <http://www.gnu.org/licenses/>.
  *
  */
+
+// Told ya this wasn't valid C++ ... :-)
+#define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING
+#ifdef _MSC_VER
+#pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
+#endif
+
 #include <complex>
 
 #include "TestCase.h"
@@ -33,8 +40,17 @@ TEST_CASE(TestCxShort_abs)
     const std::complex<short> cx_short(real, imag);
     const auto expected = abs(cx_short);
 
+    // Compute value "by hand", see https://en.cppreference.com/w/cpp/numeric/math/hypot
+    const auto r_ = gsl::narrow<int64_t>(cx_short.real());
+    const auto i_ = gsl::narrow<int64_t>(cx_short.imag());
+    const auto r_2 = r_ * r_;
+    const auto i_2 = i_ * i_;
+    const auto result = sqrt(r_2 + i_2);
+    auto actual = gsl::narrow_cast<short>(result);
+    TEST_ASSERT_EQ(actual, expected);
+
     const types::complex_short types_cx_short(real, imag);
-    const auto actual = abs(types_cx_short);
+    actual = abs(types_cx_short);
 
     TEST_ASSERT_EQ(actual, expected);
 }

--- a/modules/c++/types/unittests/test_complex_short.cpp
+++ b/modules/c++/types/unittests/test_complex_short.cpp
@@ -26,6 +26,8 @@
 #pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
 #endif
 
+#include <math.h>
+
 #include <complex>
 
 #include "TestCase.h"
@@ -39,19 +41,16 @@ TEST_CASE(TestCxShort_abs)
 
     const std::complex<short> cx_short(real, imag);
     const auto expected = abs(cx_short);
+    TEST_ASSERT_EQ(343, expected);
 
-    // Compute value "by hand", see https://en.cppreference.com/w/cpp/numeric/math/hypot
-    const auto r_ = gsl::narrow<int64_t>(cx_short.real());
-    const auto i_ = gsl::narrow<int64_t>(cx_short.imag());
-    const auto r_2 = gsl::narrow<short>(r_ * r_);
-    const auto i_2 = gsl::narrow<short>(i_ * i_);
-    const auto result = sqrt(r_2 + i_2);
+    // Compute value "by hand", see
+    // https://en.cppreference.com/w/cpp/numeric/math/hypot
+    const auto result = hypotf(cx_short.real(), cx_short.imag());
     auto actual = gsl::narrow_cast<short>(result);
     TEST_ASSERT_EQ(actual, expected);
 
     const types::complex_short types_cx_short(real, imag);
     actual = abs(types_cx_short);
-
     TEST_ASSERT_EQ(actual, expected);
 }
 

--- a/modules/c++/types/unittests/test_complex_short.cpp
+++ b/modules/c++/types/unittests/test_complex_short.cpp
@@ -43,8 +43,8 @@ TEST_CASE(TestCxShort_abs)
     // Compute value "by hand", see https://en.cppreference.com/w/cpp/numeric/math/hypot
     const auto r_ = gsl::narrow<int64_t>(cx_short.real());
     const auto i_ = gsl::narrow<int64_t>(cx_short.imag());
-    const auto r_2 = r_ * r_;
-    const auto i_2 = i_ * i_;
+    const auto r_2 = gsl::narrow<short>(r_ * r_);
+    const auto i_2 = gsl::narrow<short>(i_ * i_);
     const auto result = sqrt(r_2 + i_2);
     auto actual = gsl::narrow_cast<short>(result);
     TEST_ASSERT_EQ(actual, expected);

--- a/modules/c++/types/unittests/test_complex_short.cpp
+++ b/modules/c++/types/unittests/test_complex_short.cpp
@@ -29,7 +29,12 @@ TEST_CASE(TestCxShort_abs)
     constexpr auto real = 123;
     constexpr auto imag = -321;
 
+    CODA_OSS_disable_warning_push
+    #ifdef _MSC_VER
+    #pragma warning(disable: 4996) // '...': warning STL4037: The effect of instantiating the template std::complex for any type other than float, double, or long double is unspecified. You can define _SILENCE_NONFLOATING_COMPLEX_DEPRECATION_WARNING to suppress this warning.
+    #endif
     const std::complex<short> cx_short(real, imag);
+    CODA_OSS_disable_warning_pop
     const auto expected = abs(cx_short);
 
     const types::complex_short types_cx_short(real, imag);

--- a/modules/c++/types/unittests/test_range.cpp
+++ b/modules/c++/types/unittests/test_range.cpp
@@ -24,6 +24,7 @@
 #include "TestCase.h"
 
 #include <types/Range.h>
+#include <types/complex_short.h>
 
 TEST_CASE(TestGetNumSharedElements)
 {

--- a/modules/c++/types/unittests/test_range.cpp
+++ b/modules/c++/types/unittests/test_range.cpp
@@ -24,7 +24,6 @@
 #include "TestCase.h"
 
 #include <types/Range.h>
-#include <types/complex_short.h>
 
 TEST_CASE(TestGetNumSharedElements)
 {

--- a/modules/c++/types/wscript
+++ b/modules/c++/types/wscript
@@ -1,6 +1,6 @@
 NAME            = 'types'
 VERSION         = '1.0'
-MODULE_DEPS     = 'gsl coda_oss'
+MODULE_DEPS     = 'std gsl coda_oss'
 UNITTEST_DEPS   = 'sys'
 
 options = configure = distclean = lambda p: None

--- a/modules/c++/types/wscript
+++ b/modules/c++/types/wscript
@@ -1,6 +1,6 @@
 NAME            = 'types'
 VERSION         = '1.0'
-MODULE_DEPS     = 'gsl'
+MODULE_DEPS     = 'gsl coda_oss'
 UNITTEST_DEPS   = 'sys'
 
 options = configure = distclean = lambda p: None

--- a/modules/c++/types/wscript
+++ b/modules/c++/types/wscript
@@ -1,6 +1,6 @@
 NAME            = 'types'
 VERSION         = '1.0'
-MODULE_DEPS     = 'std gsl coda_oss'
+MODULE_DEPS     = 'coda_oss config gsl coda_oss'
 UNITTEST_DEPS   = 'sys'
 
 options = configure = distclean = lambda p: None


### PR DESCRIPTION
`std::complex<short>` (and similar) are no longer valid C++, some compilers are starting to issue warnings about this.  While `std::complex<short>` doesn't make a lot of sense, we have some existing code which uses it.  Rather than force that code to change, provide a smoother migration with our own `types::complex_short`.