### PR TITLE
be sure our Path::isAbolute() matches std::filesystem::path::absolute()

### DIFF
--- a/modules/c++/sys/source/Path.cpp
+++ b/modules/c++/sys/source/Path.cpp
@@ -178,7 +178,17 @@ std::string Path::absolutePath(const std::string& path)
 bool Path::isAbsolutePath(const std::string& path)
 {
 #ifdef _WIN32
-    return !Path::splitDrive(path).first.empty();
+    const auto split = Path::splitDrive(path);
+    const auto drive = split.first;
+
+    // a URL such as "http://example.com" should NOT be an absolute path
+    // according to std::filesystem::path::is_absolute().
+    if (drive.length() > 2) // "C:"
+    {
+        return false; // drive letters are single characters, e.g., "C:\Windows"
+    }
+
+    return !drive.empty();
 #else
     return (!path.empty() && path[0] == Path::delimiter()[0]);
 #endif

--- a/modules/c++/sys/unittests/test_path.cpp
+++ b/modules/c++/sys/unittests/test_path.cpp
@@ -112,7 +112,7 @@ TEST_CASE(test_std_filesystem_is_absolute)
     TEST_ASSERT_TRUE(slash.is_absolute());
 #endif
 
-    const std::filesystem::path url("https://example.com");
+    const std::filesystem::path url("http://example.com");
     TEST_ASSERT_FALSE(url.is_absolute());
     TEST_ASSERT_TRUE(url.is_relative());  // Should this be false?
 }


### PR DESCRIPTION
Be sure our `Path::isAbolute()` matches `std::filesystem::path::absolute()` since we use that in pre-C++17.