### PR TITLE
OS::getSIMDInstructionSet() utility

### DIFF
--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -71,6 +71,7 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -96,6 +97,7 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/build/build.py
+++ b/build/build.py
@@ -852,7 +852,7 @@ def configureCompilerOptions(self):
         config['cxx']['optz_fast']      = '-O2'
         config['cxx']['optz_faster']   = '-O3'
         config['cxx']['optz_fastest']   = config['cxx']['optz_faster']
-        config['cxx']['optz_fastest-possible']   = config['cxx']['optz_fastest'] # TODO: -march=native ?
+        config['cxx']['optz_fastest-possible']   = config['cxx']['optz_fastest']
 
         #self.env.append_value('LINKFLAGS', '-fPIC -dynamiclib'.split())
         self.env.append_value('LINKFLAGS', '-fPIC'.split())
@@ -907,10 +907,11 @@ def configureCompilerOptions(self):
             # https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/x86-Options.html#x86-Options
             # "Using -march=native enables all instruction subsets supported by the local machine ..."
             config['cxx']['optz_faster']      = '-O3' # no -march=native
-            config['cxx']['optz_fastest']   =  config['cxx']['optz_faster'] # TODO: add -march=native ?
+            # Haswell is from 2013 ... 10 years ago: https://en.wikipedia.org/wiki/Haswell_%28microarchitecture%29
+            config['cxx']['optz_fastest']   =  [ config['cxx']['optz_faster'], '-march=haswell' ]
             # This "should" be part of fastest, but that could cause unexpected floating point differences.
             # The "fastest-possible" option is new; see comments above.
-            config['cxx']['optz_fastest-possible']   =  [ config['cxx']['optz_fastest'], '-march=native' ]
+            config['cxx']['optz_fastest-possible']   =  [ config['cxx']['optz_faster'], '-march=native' ]  # -march=native instead of haswell
 
             self.env.append_value('CXXFLAGS', '-fPIC'.split())
             if not Options.options.enablecpp17:
@@ -956,10 +957,11 @@ def configureCompilerOptions(self):
             # https://gcc.gnu.org/onlinedocs/gcc-12.2.0/gcc/x86-Options.html#x86-Options
             # "Using -march=native enables all instruction subsets supported by the local machine ..."
             config['cc']['optz_faster']      = '-O3' # no -march=native
-            config['cc']['optz_fastest']   =  config['cc']['optz_faster'] # TODO: add -march=native ?
+            # Haswell is from 2013 ... 10 years ago: https://en.wikipedia.org/wiki/Haswell_%28microarchitecture%29
+            config['cc']['optz_fastest']   =  [ config['cc']['optz_faster'], '-march=haswell' ]
             # This "should" be part of fastest, but that could cause unexpected floating point differences.
             # The "fastest-possible" option is new; see comments above.
-            config['cc']['optz_fastest-possible']   =  [ config['cc']['optz_fastest'], '-march=native' ]
+            config['cc']['optz_fastest-possible']   =  [ config['cc']['optz_faster'], '-march=native' ] # -march=native instead of haswell
 
             self.env.append_value('CFLAGS', '-fPIC'.split())
             # "gnu99" enables POSIX and BSD

--- a/modules/c++/coda-oss-lite.vcxproj
+++ b/modules/c++/coda-oss-lite.vcxproj
@@ -474,6 +474,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
       <EnablePREfast>true</EnablePREfast>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -500,6 +501,7 @@
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <EnableEnhancedInstructionSet>AdvancedVectorExtensions2</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -53,7 +53,8 @@ enum class SIMDInstructionSet
 {
     SSE2, //  https://en.wikipedia.org/wiki/SSE2
     AVX, // https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
-    AVX512, // https://en.wikipedia.org/wiki/AVX-512
+    AVX2,
+    AVX512F, // https://en.wikipedia.org/wiki/AVX-512
 };
 
 /*!

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -46,6 +46,16 @@
  */
 namespace sys
 {
+
+// List of available SIMD instruction sets; we require at least SSE2
+// which is from 2000 ... 23 years ago.
+enum class SIMDInstructionSet
+{
+    SSE2, //  https://en.wikipedia.org/wiki/SSE2
+    AVX, // https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
+    AVX512, // https://en.wikipedia.org/wiki/AVX-512
+};
+
 /*!
  *  \class AbstractOS
  *  \brief Interface for system independent function calls
@@ -282,6 +292,13 @@ struct CODA_OSS_API AbstractOS
      */
     virtual void getAvailableCPUs(std::vector<int>& physicalCPUs,
                                   std::vector<int>& htCPUs) const = 0;
+
+
+    /*!
+     * Figure out what SIMD instrunctions are available.  Keep in mind these
+     * are RUN-TIME, not compile-time, checks.
+     */
+    virtual SIMDInstructionSet getSIMDInstructionSet() const = 0;
 
     /*!
      *  Create a symlink, pathnames can be either absolute or relative

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -52,8 +52,7 @@ namespace sys
 enum class SIMDInstructionSet
 {
     SSE2, //  https://en.wikipedia.org/wiki/SSE2
-    AVX, // https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
-    AVX2,
+    AVX2,  // https://en.wikipedia.org/wiki/Advanced_Vector_Extensions
     AVX512F, // https://en.wikipedia.org/wiki/AVX-512
 };
 

--- a/modules/c++/sys/include/sys/AbstractOS.h
+++ b/modules/c++/sys/include/sys/AbstractOS.h
@@ -47,8 +47,15 @@
 namespace sys
 {
 
-// List of available SIMD instruction sets; we require at least SSE2
-// which is from 2000 ... 23 years ago.
+/*!
+ *  \class SIMDInstructionSet
+ *  \brief  List of available SIMD instruction sets.
+ *
+ *  We require at least SSE2 which is from 2000 ... 23 years ago.
+ *  Also see https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+ *  "... For the x86-64 compiler, these extensions [ -msse2 ] are enabled by default."
+*   We're 64-bit only.
+ */
 enum class SIMDInstructionSet
 {
     SSE2, //  https://en.wikipedia.org/wiki/SSE2

--- a/modules/c++/sys/include/sys/OSUnix.h
+++ b/modules/c++/sys/include/sys/OSUnix.h
@@ -202,6 +202,12 @@ struct OSUnix final : public AbstractOS
                                   std::vector<int>& htCPUs) const override;
 
     /*!
+     * Figure out what SIMD instrunctions are available.  Keep in mind these
+     * are RUN-TIME, not compile-time, checks.
+     */
+    SIMDInstructionSet getSIMDInstructionSet() const override;
+
+    /*!
      *  Create a symlink, pathnames can be either absolute or relative
      */
     virtual void createSymlink(const std::string& origPathname,

--- a/modules/c++/sys/include/sys/OSWin32.h
+++ b/modules/c++/sys/include/sys/OSWin32.h
@@ -227,6 +227,12 @@ struct CODA_OSS_API OSWin32 final : public AbstractOS
                                   std::vector<int>& htCPUs) const;
 
     /*!
+     * Figure out what SIMD instrunctions are available.  Keep in mind these
+     * are RUN-TIME, not compile-time, checks.
+     */
+    SIMDInstructionSet getSIMDInstructionSet() const override;
+
+    /*!
      *  Create a symlink, pathnames can be either absolute or relative
      */
     virtual void createSymlink(const std::string& origPathname,

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -426,17 +426,19 @@ sys::SIMDInstructionSet sys::OSUnix::getSIMDInstructionSet() const
     // https://gcc.gnu.org/onlinedocs/gcc-4.8.2/gcc/X86-Built-in-Functions.html
     __builtin_cpu_init();
 
+    /*
     if (__builtin_cpu_supports("avx512"))
     {
-        return SimdInstructionSet::AVX512;
+        return SIMDInstructionSet::AVX512;
     }
+    */
     if (__builtin_cpu_supports("avx"))
     {
-        return SimdInstructionSet::AVX;
+        return SIMDInstructionSet::AVX;
     }
     if (__builtin_cpu_supports("sse2"))
     {
-        return SimdInstructionSet::SSE2;
+        return SIMDInstructionSet::SSE2;
     }
 
     throw std::runtime_error("SSE2 support is required.");

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -434,10 +434,6 @@ sys::SIMDInstructionSet sys::OSUnix::getSIMDInstructionSet() const
     {
         return SIMDInstructionSet::AVX2;
     }
-    if (__builtin_cpu_supports("avx"))
-    {
-        return SIMDInstructionSet::AVX;
-    }
     if (__builtin_cpu_supports("sse2"))
     {
         return SIMDInstructionSet::SSE2;

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -29,6 +29,7 @@
 #include <vector>
 #include <set>
 #include <fstream>
+#include <stdexcept>
 
 #include "sys/Conf.h"
 
@@ -418,6 +419,27 @@ void sys::OSUnix::getAvailableCPUs(std::vector<int>& physicalCPUs,
             }
         }
     }
+}
+
+sys::SIMDInstructionSet sys::OSUnix::getSIMDInstructionSet() const
+{
+    // https://gcc.gnu.org/onlinedocs/gcc-4.8.2/gcc/X86-Built-in-Functions.html
+    __builtin_cpu_init();
+
+    if (__builtin_cpu_supports("avx512"))
+    {
+        return SimdInstructionSet::AVX512;
+    }
+    if (__builtin_cpu_supports("avx"))
+    {
+        return SimdInstructionSet::AVX;
+    }
+    if (__builtin_cpu_supports("sse2"))
+    {
+        return SimdInstructionSet::SSE2;
+    }
+
+    throw std::runtime_error("SSE2 support is required.");
 }
 
 void sys::OSUnix::createSymlink(const std::string& origPathname,

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -426,12 +426,14 @@ sys::SIMDInstructionSet sys::OSUnix::getSIMDInstructionSet() const
     // https://gcc.gnu.org/onlinedocs/gcc-4.8.2/gcc/X86-Built-in-Functions.html
     __builtin_cpu_init();
 
-    /*
-    if (__builtin_cpu_supports("avx512"))
+    if (__builtin_cpu_supports("avx512f"))
     {
-        return SIMDInstructionSet::AVX512;
+        return SIMDInstructionSet::AVX512F;
     }
-    */
+    if (__builtin_cpu_supports("avx2"))
+    {
+        return SIMDInstructionSet::AVX2;
+    }
     if (__builtin_cpu_supports("avx"))
     {
         return SIMDInstructionSet::AVX;

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -342,6 +342,25 @@ void sys::OSWin32::getAvailableCPUs(std::vector<int>& /*physicalCPUs*/,
         Ctxt("Windows getAvailableCPUs not yet implemented."));
 }
 
+sys::SIMDInstructionSet sys::OSWin32::getSIMDInstructionSet() const
+{
+    // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent
+    if (IsProcessorFeaturePresent(PF_AVX512F_INSTRUCTIONS_AVAILABLE))
+    {
+        return sys::SIMDInstructionSet::AVX512;
+    }
+    if (IsProcessorFeaturePresent(PF_AVX_INSTRUCTIONS_AVAILABLE))
+    {
+        return sys::SIMDInstructionSet::AVX;
+    }
+    if (IsProcessorFeaturePresent(PF_XMMI64_INSTRUCTIONS_AVAILABLE))
+    {
+        return sys::SIMDInstructionSet::SSE2;
+    }
+
+    throw std::runtime_error("SSE2 support is required.");
+}
+
 void sys::OSWin32::createSymlink(const std::string& origPathname,
                                  const std::string& symlinkPathname) const
 {

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -347,7 +347,11 @@ sys::SIMDInstructionSet sys::OSWin32::getSIMDInstructionSet() const
     // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent
     if (IsProcessorFeaturePresent(PF_AVX512F_INSTRUCTIONS_AVAILABLE))
     {
-        return sys::SIMDInstructionSet::AVX512;
+        return sys::SIMDInstructionSet::AVX512F;
+    }
+    if (IsProcessorFeaturePresent(PF_AVX2_INSTRUCTIONS_AVAILABLE))
+    {
+        return sys::SIMDInstructionSet::AVX2;
     }
     if (IsProcessorFeaturePresent(PF_AVX_INSTRUCTIONS_AVAILABLE))
     {

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -347,19 +347,19 @@ sys::SIMDInstructionSet sys::OSWin32::getSIMDInstructionSet() const
     // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent
     if (IsProcessorFeaturePresent(PF_AVX512F_INSTRUCTIONS_AVAILABLE))
     {
-        return sys::SIMDInstructionSet::AVX512F;
+        return SIMDInstructionSet::AVX512F;
     }
     if (IsProcessorFeaturePresent(PF_AVX2_INSTRUCTIONS_AVAILABLE))
     {
-        return sys::SIMDInstructionSet::AVX2;
+        return SIMDInstructionSet::AVX2;
     }
     if (IsProcessorFeaturePresent(PF_AVX_INSTRUCTIONS_AVAILABLE))
     {
-        return sys::SIMDInstructionSet::AVX;
+        return SIMDInstructionSet::AVX;
     }
     if (IsProcessorFeaturePresent(PF_XMMI64_INSTRUCTIONS_AVAILABLE))
     {
-        return sys::SIMDInstructionSet::SSE2;
+        return SIMDInstructionSet::SSE2;
     }
 
     throw std::runtime_error("SSE2 support is required.");

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -353,10 +353,6 @@ sys::SIMDInstructionSet sys::OSWin32::getSIMDInstructionSet() const
     {
         return SIMDInstructionSet::AVX2;
     }
-    if (IsProcessorFeaturePresent(PF_AVX_INSTRUCTIONS_AVAILABLE))
-    {
-        return SIMDInstructionSet::AVX;
-    }
     if (IsProcessorFeaturePresent(PF_XMMI64_INSTRUCTIONS_AVAILABLE))
     {
         return SIMDInstructionSet::SSE2;

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -517,10 +517,9 @@ TEST_CASE(test_SIMD_Instructions)
     const auto simdInstructionSet = os.getSIMDInstructionSet();
 
     const auto isSSE2 = simdInstructionSet == sys::SIMDInstructionSet::SSE2;
-    const auto isAVX = simdInstructionSet == sys::SIMDInstructionSet::AVX;
     const auto isAVX2 = simdInstructionSet == sys::SIMDInstructionSet::AVX2;
     const auto isAVX512F = simdInstructionSet == sys::SIMDInstructionSet::AVX512F;
-    TEST_ASSERT(isSSE2 || isAVX || isAVX2 || isAVX512F);
+    TEST_ASSERT(isSSE2 || isAVX2 || isAVX512F);
 }
 
 TEST_MAIN(

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -511,6 +511,17 @@ TEST_CASE(test_make_ifstream)
     TEST_ASSERT_TRUE(ifs.is_open());
 }
 
+TEST_CASE(test_SIMD_Instructions)
+{
+    const sys::OS os;
+    const auto simdInstructionSet = os.getSIMDInstructionSet();
+
+    const auto isSSE2 = simdInstructionSet == sys::SIMDInstructionSet::SSE2;
+    const auto isAVX = simdInstructionSet == sys::SIMDInstructionSet::AVX;
+    const auto isAVX512 = simdInstructionSet == sys::SIMDInstructionSet::AVX512;
+    TEST_ASSERT(isSSE2 || isAVX || isAVX512);
+}
+
 TEST_MAIN(
     //sys::AbstractOS::setArgvPathname(argv[0]);
     TEST_CHECK(testRecursiveRemove);
@@ -527,4 +538,5 @@ TEST_MAIN(
     TEST_CHECK(test_sys_fopen_failure);
     TEST_CHECK(test_sys_open);
     TEST_CHECK(test_make_ifstream);
+    TEST_CHECK(test_SIMD_Instructions);
     )

--- a/modules/c++/sys/unittests/test_os.cpp
+++ b/modules/c++/sys/unittests/test_os.cpp
@@ -518,8 +518,9 @@ TEST_CASE(test_SIMD_Instructions)
 
     const auto isSSE2 = simdInstructionSet == sys::SIMDInstructionSet::SSE2;
     const auto isAVX = simdInstructionSet == sys::SIMDInstructionSet::AVX;
-    const auto isAVX512 = simdInstructionSet == sys::SIMDInstructionSet::AVX512;
-    TEST_ASSERT(isSSE2 || isAVX || isAVX512);
+    const auto isAVX2 = simdInstructionSet == sys::SIMDInstructionSet::AVX2;
+    const auto isAVX512F = simdInstructionSet == sys::SIMDInstructionSet::AVX512F;
+    TEST_ASSERT(isSSE2 || isAVX || isAVX2 || isAVX512F);
 }
 
 TEST_MAIN(


### PR DESCRIPTION
Add a new `sys::OS::getSIMDInstructionSet()` to return the **runtime** SIMD instruction set that's available.  One of three values is supported:
* [SSE2](https://en.wikipedia.org/wiki/SSE2) (required)
* [AVX2](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions)
* [AVX512](https://en.wikipedia.org/wiki/AVX-512)

Also enable [haswell](https://en.wikipedia.org/wiki/Haswell_%28microarchitecture%29) (from 2013) at higher optimization levels (*waf* builds only).
