### PR TITLE
add more projects to coda-oss-lite.vcxproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ project.sln
 *.vcxproj.user
 
 # Unit-tests
-TEST_*_TMP.*
+TEST_*_TMP*.*

--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -57,7 +57,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\hdf5.lite\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\hdf5.lite\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;$(SolutionDir)modules\c++\zip\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -85,7 +85,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\hdf5.lite\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\hdf5.lite\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;$(SolutionDir)modules\c++\zip\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -355,6 +355,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\modules\c++\zip\unittests\unittest_GZip.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="avx.cpp" />
     <ClCompile Include="cli.cpp" />
     <ClCompile Include="CppUnitTestAssert.cpp" />
@@ -376,6 +380,7 @@
     <ClCompile Include="sys.cpp" />
     <ClCompile Include="types.cpp" />
     <ClCompile Include="units.cpp" />
+    <ClCompile Include="zip.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -57,7 +57,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\hdf5.lite\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions);MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -75,7 +75,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\;$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -85,7 +85,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(ProjectDir);$(SolutionDir)modules\c++\;$(SolutionDir)modules\c++\avx\include\;$(SolutionDir)modules\c++\cli\include\;$(SolutionDir)modules\c++\config\include\;$(SolutionDir)modules\c++\coda_oss\include\;$(SolutionDir)modules\c++\gsl\include\;$(SolutionDir)modules\c++\hdf5.lite\include\;$(SolutionDir)modules\c++\io\include\;$(SolutionDir)modules\c++\std\include\;$(SolutionDir)modules\c++\str\include\;$(SolutionDir)modules\c++\sys\include\;$(SolutionDir)modules\c++\except\include\;$(SolutionDir)modules\c++\logging\include\;$(SolutionDir)modules\c++\math\include\;$(SolutionDir)modules\c++\math.linear\include\;$(SolutionDir)modules\c++\math.poly\include\;$(SolutionDir)modules\c++\mem\include\;$(SolutionDir)modules\c++\mt\include\;$(SolutionDir)modules\c++\polygon\include\;$(SolutionDir)modules\c++\re\include\;$(SolutionDir)modules\c++\types\include\;$(SolutionDir)modules\c++\units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions);MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -103,7 +103,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\;$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -112,6 +112,18 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\modules\c++\cli\unittests\test_cli.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5info.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5read.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5write.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -346,6 +358,7 @@
     <ClCompile Include="avx.cpp" />
     <ClCompile Include="cli.cpp" />
     <ClCompile Include="CppUnitTestAssert.cpp" />
+    <ClCompile Include="hdf5.lite.cpp" />
     <ClCompile Include="io.cpp" />
     <ClCompile Include="logging.cpp" />
     <ClCompile Include="math.linear.cpp" />

--- a/UnitTest/UnitTest.vcxproj.filters
+++ b/UnitTest/UnitTest.vcxproj.filters
@@ -237,6 +237,12 @@
     <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5write.cpp">
       <Filter>hdf5.lite</Filter>
     </ClCompile>
+    <ClCompile Include="zip.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\zip\unittests\unittest_GZip.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -290,6 +296,9 @@
     </Filter>
     <Filter Include="hdf5.lite">
       <UniqueIdentifier>{5997a3de-0dc5-4439-b068-b351c5f395e3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="zip">
+      <UniqueIdentifier>{223c163f-0321-4935-8e20-0e05f048adf0}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/UnitTest/UnitTest.vcxproj.filters
+++ b/UnitTest/UnitTest.vcxproj.filters
@@ -276,5 +276,8 @@
     <Filter Include="re">
       <UniqueIdentifier>{d205c017-7e98-456f-923f-2f78870a3d7d}</UniqueIdentifier>
     </Filter>
+    <Filter Include="hdf5.lite">
+      <UniqueIdentifier>{5997a3de-0dc5-4439-b068-b351c5f395e3}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
 </Project>

--- a/UnitTest/UnitTest.vcxproj.filters
+++ b/UnitTest/UnitTest.vcxproj.filters
@@ -225,6 +225,18 @@
     <ClCompile Include="..\modules\c++\types\unittests\test_complex.cpp">
       <Filter>types</Filter>
     </ClCompile>
+    <ClCompile Include="hdf5.lite.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5info.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5read.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="..\modules\c++\hdf5.lite\unittests\test_hdf5write.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/UnitTest/hdf5.lite.cpp
+++ b/UnitTest/hdf5.lite.cpp
@@ -2,6 +2,10 @@
 #include "CppUnitTest.h"
 
 #include <import/hdf5/lite.h>
+#include <hdf5/lite/HDF5Exception.h>
+#include <hdf5/lite/Info.h>
+#include <hdf5/lite/Read.h>
+#include <hdf5/lite/Write.h>
 
 namespace hdf5_lite
 {

--- a/UnitTest/hdf5.lite.cpp
+++ b/UnitTest/hdf5.lite.cpp
@@ -1,0 +1,21 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include <import/hdf5/lite.h>
+
+namespace hdf5_lite
+{
+
+TEST_CLASS(test_hdf5info){ public:
+#include "hdf5.lite/unittests/test_hdf5info.cpp"
+};
+
+TEST_CLASS(test_hdf5read){ public:
+#include "hdf5.lite/unittests/test_hdf5read.cpp"
+};
+
+TEST_CLASS(test_hdf5write){ public:
+#include "hdf5.lite/unittests/test_hdf5write.cpp"
+};
+
+}

--- a/UnitTest/pch.h
+++ b/UnitTest/pch.h
@@ -98,11 +98,7 @@
 #include <import/re.h>
 #include "io/StringStream.h"
 #include <sys/FileFinder.h>
-#include <import/hdf5/lite.h>
-#include <hdf5/lite/HDF5Exception.h>
-#include <hdf5/lite/Info.h>
-#include <hdf5/lite/Read.h>
-#include <hdf5/lite/Write.h>
+#include <io/ReadUtils.h>
 
 #include "TestCase.h"
 

--- a/UnitTest/pch.h
+++ b/UnitTest/pch.h
@@ -97,6 +97,12 @@
 #include <import/logging.h>
 #include <import/re.h>
 #include "io/StringStream.h"
+#include <sys/FileFinder.h>
+#include <import/hdf5/lite.h>
+#include <hdf5/lite/HDF5Exception.h>
+#include <hdf5/lite/Info.h>
+#include <hdf5/lite/Read.h>
+#include <hdf5/lite/Write.h>
 
 #include "TestCase.h"
 

--- a/UnitTest/zip.cpp
+++ b/UnitTest/zip.cpp
@@ -1,0 +1,12 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include <import/zip.h>
+
+namespace zip
+{
+TEST_CLASS(unittest_GZip){ public:
+#include "zip/unittests/unittest_GZip.cpp"
+};
+
+}

--- a/modules/c++/coda-oss-lite.vcxproj
+++ b/modules/c++/coda-oss-lite.vcxproj
@@ -274,6 +274,12 @@
     <ClInclude Include="units\include\units\Angles.h" />
     <ClInclude Include="units\include\units\Lengths.h" />
     <ClInclude Include="units\include\units\Unit.h" />
+    <ClInclude Include="zip\include\zip\GZipInputStream.h" />
+    <ClInclude Include="zip\include\zip\GZipOutputStream.h" />
+    <ClInclude Include="zip\include\zip\Types.h" />
+    <ClInclude Include="zip\include\zip\ZipEntry.h" />
+    <ClInclude Include="zip\include\zip\ZipFile.h" />
+    <ClInclude Include="zip\include\zip\ZipOutputStream.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="cli\source\Argument.cpp" />
@@ -405,6 +411,11 @@
     <ClCompile Include="tiff\source\Utils.cpp" />
     <ClCompile Include="types\source\Range.cpp" />
     <ClCompile Include="types\source\RangeList.cpp" />
+    <ClCompile Include="zip\source\GZipInputStream.cpp" />
+    <ClCompile Include="zip\source\GZipOutputStream.cpp" />
+    <ClCompile Include="zip\source\ZipEntry.cpp" />
+    <ClCompile Include="zip\source\ZipFile.cpp" />
+    <ClCompile Include="zip\source\ZipOutputStream.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="gsl\include\gsl\algorithm" />
@@ -474,7 +485,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);CODA_OSS_EXPORTS;CODA_OSS_DLL;MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
-      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;hdf5.lite\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;hdf5.lite\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\;zip\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -494,7 +505,7 @@
       </SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>hdf5-c++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>hdf5-c++.lib;z.lib;minizip.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -505,7 +516,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);CODA_OSS_EXPORTS;CODA_OSS_DLL;MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
-      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;hdf5.lite\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;hdf5.lite\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\;zip\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -525,7 +536,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\</AdditionalLibraryDirectories>
-      <AdditionalDependencies>hdf5-c++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>hdf5-c++.lib;z.lib;minizip.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/modules/c++/coda-oss-lite.vcxproj
+++ b/modules/c++/coda-oss-lite.vcxproj
@@ -43,6 +43,14 @@
     <ClInclude Include="gsl\include\gsl\Gsl_.h" />
     <ClInclude Include="gsl\include\gsl\Gsl_narrow.h" />
     <ClInclude Include="gsl\include\gsl\use_gsl.h" />
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\HDF5Exception.h" />
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\highfive.h" />
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\Info.h" />
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\Read.h" />
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\SpanRC.h" />
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\Write.h" />
+    <ClInclude Include="hdf5.lite\source\H5.h" />
+    <ClInclude Include="hdf5.lite\source\hdf5.lite.h" />
     <ClInclude Include="include\TestCase.h" />
     <ClInclude Include="io\include\io\BidirectionalStream.h" />
     <ClInclude Include="io\include\io\BufferViewStream.h" />
@@ -274,6 +282,11 @@
     <ClCompile Include="except\source\Context.cpp" />
     <ClCompile Include="except\source\Throwable.cpp" />
     <ClCompile Include="except\source\Trace.cpp" />
+    <ClCompile Include="hdf5.lite\source\H5.cpp" />
+    <ClCompile Include="hdf5.lite\source\hdf5.lite.cpp" />
+    <ClCompile Include="hdf5.lite\source\Info.cpp" />
+    <ClCompile Include="hdf5.lite\source\Read.cpp" />
+    <ClCompile Include="hdf5.lite\source\Write.cpp" />
     <ClCompile Include="io\source\ByteStream.cpp" />
     <ClCompile Include="io\source\FileInputStreamIOS.cpp" />
     <ClCompile Include="io\source\FileInputStreamOS.cpp" />
@@ -461,7 +474,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions);CODA_OSS_EXPORTS;CODA_OSS_DLL;MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
-      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;hdf5.lite\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -480,6 +493,7 @@
       <SubSystem>
       </SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -490,7 +504,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions);CODA_OSS_EXPORTS;CODA_OSS_DLL;MT_DEFAULT_PINNING=0;RE_ENABLE_STD_REGEX=1</PreprocessorDefinitions>
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
-      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>cli\include\;coda_oss\include;config\include\;except\include\;gsl\include\;hdf5.lite\include\;io\include\;logging\include\;math\include\;math.linear\include\;math.poly\include\;mem\include\;mt\include\;plugin\include\;polygon\include\;re\include\;sio.lite\include\;std\include\;str\include\;sys\include\;tiff\include;types\include\;units\include\;$(SolutionDir)out\install\$(Platform)-$(Configuration)\include\</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -509,6 +523,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/modules/c++/coda-oss-lite.vcxproj
+++ b/modules/c++/coda-oss-lite.vcxproj
@@ -494,6 +494,7 @@
       </SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>hdf5-c++.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -524,6 +525,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\out\install\$(Platform)-$(Configuration)\lib\</AdditionalLibraryDirectories>
+      <AdditionalDependencies>hdf5-c++.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/modules/c++/coda-oss-lite.vcxproj.filters
+++ b/modules/c++/coda-oss-lite.vcxproj.filters
@@ -777,6 +777,24 @@
     <ClInclude Include="hdf5.lite\include\hdf5\lite\Write.h">
       <Filter>hdf5.lite</Filter>
     </ClInclude>
+    <ClInclude Include="zip\include\zip\GZipInputStream.h">
+      <Filter>zip</Filter>
+    </ClInclude>
+    <ClInclude Include="zip\include\zip\GZipOutputStream.h">
+      <Filter>zip</Filter>
+    </ClInclude>
+    <ClInclude Include="zip\include\zip\Types.h">
+      <Filter>zip</Filter>
+    </ClInclude>
+    <ClInclude Include="zip\include\zip\ZipEntry.h">
+      <Filter>zip</Filter>
+    </ClInclude>
+    <ClInclude Include="zip\include\zip\ZipFile.h">
+      <Filter>zip</Filter>
+    </ClInclude>
+    <ClInclude Include="zip\include\zip\ZipOutputStream.h">
+      <Filter>zip</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1134,6 +1152,21 @@
     <ClCompile Include="hdf5.lite\source\Write.cpp">
       <Filter>hdf5.lite</Filter>
     </ClCompile>
+    <ClCompile Include="zip\source\GZipInputStream.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
+    <ClCompile Include="zip\source\GZipOutputStream.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
+    <ClCompile Include="zip\source\ZipEntry.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
+    <ClCompile Include="zip\source\ZipFile.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
+    <ClCompile Include="zip\source\ZipOutputStream.cpp">
+      <Filter>zip</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="config">
@@ -1210,6 +1243,9 @@
     </Filter>
     <Filter Include="hdf5.lite">
       <UniqueIdentifier>{e4db8b19-0870-4cb2-af64-14b928c68725}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="zip">
+      <UniqueIdentifier>{a2682912-3963-489a-9cf0-c5224b27eb84}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/modules/c++/coda-oss-lite.vcxproj.filters
+++ b/modules/c++/coda-oss-lite.vcxproj.filters
@@ -753,6 +753,30 @@
     <ClInclude Include="coda_oss\include\coda_oss\numbers.h">
       <Filter>coda_oss</Filter>
     </ClInclude>
+    <ClInclude Include="hdf5.lite\source\H5.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\source\hdf5.lite.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\HDF5Exception.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\highfive.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\Info.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\Read.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\SpanRC.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
+    <ClInclude Include="hdf5.lite\include\hdf5\lite\Write.h">
+      <Filter>hdf5.lite</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -1095,6 +1119,21 @@
     <ClCompile Include="sys\source\File.cpp">
       <Filter>sys</Filter>
     </ClCompile>
+    <ClCompile Include="hdf5.lite\source\H5.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="hdf5.lite\source\hdf5.lite.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="hdf5.lite\source\Info.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="hdf5.lite\source\Read.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
+    <ClCompile Include="hdf5.lite\source\Write.cpp">
+      <Filter>hdf5.lite</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="config">
@@ -1168,6 +1207,9 @@
     </Filter>
     <Filter Include="plugin">
       <UniqueIdentifier>{387bc6cb-323a-42b3-8502-4fac72586d12}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="hdf5.lite">
+      <UniqueIdentifier>{e4db8b19-0870-4cb2-af64-14b928c68725}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/modules/c++/hdf5.lite/include/hdf5/lite/HDF5Exception.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/HDF5Exception.h
@@ -52,4 +52,9 @@ CODA_OSS_DECLARE_EXTENDED_EXCEPTION(DataType, hdf5::lite::HDF5Exception);
 
 }
 }
+
+#if _MSC_VER
+#pragma comment(lib, "hdf5-c++.lib")
+#endif
+
 #endif  // CODA_OSS_hdf5_lite_HDF5Exception_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/HDF5Exception.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/HDF5Exception.h
@@ -20,6 +20,7 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_hdf5_lite_HDF5Exception_h_INCLUDED_
 #define CODA_OSS_hdf5_lite_HDF5Exception_h_INCLUDED_
 
@@ -52,9 +53,5 @@ CODA_OSS_DECLARE_EXTENDED_EXCEPTION(DataType, hdf5::lite::HDF5Exception);
 
 }
 }
-
-#if _MSC_VER
-#pragma comment(lib, "hdf5-c++.lib")
-#endif
 
 #endif  // CODA_OSS_hdf5_lite_HDF5Exception_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Info.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Info.h
@@ -106,4 +106,8 @@ CODA_OSS_API DataSetInfo dataSetInfo(const coda_oss::filesystem::path&, const st
 }
 }
 
+#if _MSC_VER
+#pragma comment(lib, "hdf5-c++.lib")
+#endif
+
 #endif // CODA_OSS_hdf5_lite_Info_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Info.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Info.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_hdf5_lite_Info_h_INCLUDED_
 #define CODA_OSS_hdf5_lite_Info_h_INCLUDED_
-#pragma once
 
 #include <string>
 #include <vector>
@@ -105,9 +105,5 @@ CODA_OSS_API DataSetInfo dataSetInfo(const coda_oss::filesystem::path&, const st
 
 }
 }
-
-#if _MSC_VER
-#pragma comment(lib, "hdf5-c++.lib")
-#endif
 
 #endif // CODA_OSS_hdf5_lite_Info_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Read.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Read.h
@@ -52,4 +52,8 @@ CODA_OSS_API SpanRC<float> readFile(const coda_oss::filesystem::path&, const std
 }
 }
 
+#if _MSC_VER
+#pragma comment(lib, "hdf5-c++.lib")
+#endif
+
 #endif // CODA_OSS_hdf5_lite_Read_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Read.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Read.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_hdf5_lite_Read_h_INCLUDED_
 #define CODA_OSS_hdf5_lite_Read_h_INCLUDED_
-#pragma once
 
 /*!
  * \file  Read.h
@@ -51,9 +51,5 @@ CODA_OSS_API SpanRC<float> readFile(const coda_oss::filesystem::path&, const std
 
 }
 }
-
-#if _MSC_VER
-#pragma comment(lib, "hdf5-c++.lib")
-#endif
 
 #endif // CODA_OSS_hdf5_lite_Read_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Write.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Write.h
@@ -77,4 +77,8 @@ inline void writeFile(const coda_oss::filesystem::path& path, const std::string&
 }
 }
 
+#if _MSC_VER
+#pragma comment(lib, "hdf5-c++.lib")
+#endif
+
 #endif // CODA_OSS_hdf5_lite_Write_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Write.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Write.h
@@ -48,6 +48,9 @@ namespace lite
 {
 template<typename TDataSet> // currently implemented for float and double
 CODA_OSS_API void createFile(const coda_oss::filesystem::path&, const std::string& ds, const types::RowCol<size_t>&);
+template<> CODA_OSS_API void createFile<float>(const coda_oss::filesystem::path&, const std::string& ds, const types::RowCol<size_t>&);
+template<> CODA_OSS_API void createFile<double>(const coda_oss::filesystem::path&, const std::string& ds, const types::RowCol<size_t>&);
+
 CODA_OSS_API void createFile(const coda_oss::filesystem::path&, const std::string& ds, SpanRC<const double>);
 inline void createFile(const coda_oss::filesystem::path& path, const std::string& ds, SpanRC<double> data_)
 {

--- a/modules/c++/hdf5.lite/include/hdf5/lite/Write.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/Write.h
@@ -20,11 +20,11 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_hdf5_lite_Write_h_INCLUDED_
 #define CODA_OSS_hdf5_lite_Write_h_INCLUDED_
-#pragma once
 
-/*!
+ /*!
  * \file  Write.h
  * \brief HDF File-writing API
  *
@@ -79,9 +79,5 @@ inline void writeFile(const coda_oss::filesystem::path& path, const std::string&
 
 }
 }
-
-#if _MSC_VER
-#pragma comment(lib, "hdf5-c++.lib")
-#endif
 
 #endif // CODA_OSS_hdf5_lite_Write_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/highfive.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/highfive.h
@@ -141,4 +141,8 @@ inline std::string read(const HighFive::Attribute& a)
 }
 }
 
+#if _MSC_VER
+#pragma comment(lib, "hdf5-c++.lib")
+#endif
+
 #endif // CODA_OSS_hdf5_lite_highfive_h_INCLUDED_

--- a/modules/c++/hdf5.lite/include/hdf5/lite/highfive.h
+++ b/modules/c++/hdf5.lite/include/hdf5/lite/highfive.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_hdf5_lite_highfive_h_INCLUDED_
 #define CODA_OSS_hdf5_lite_highfive_h_INCLUDED_
-#pragma once
 
 /*!
  * \file  highfive.h
@@ -140,9 +140,5 @@ inline std::string read(const HighFive::Attribute& a)
 
 }
 }
-
-#if _MSC_VER
-#pragma comment(lib, "hdf5-c++.lib")
-#endif
 
 #endif // CODA_OSS_hdf5_lite_highfive_h_INCLUDED_

--- a/modules/c++/io/include/io/FileOutputStreamOS.h
+++ b/modules/c++/io/include/io/FileOutputStreamOS.h
@@ -26,6 +26,8 @@
 
 #include <string>
 
+#include "config/Exports.h"
+
 #if !defined(USE_IO_STREAMS)
 
 #include "io/SeekableStreams.h"
@@ -55,8 +57,7 @@ namespace io
  *  This class corresponds closely to its java namesake.
  *  It uses native file handles to make writes.
  */
-class FileOutputStreamOS : public SeekableOutputStream
-
+class CODA_OSS_API FileOutputStreamOS : public SeekableOutputStream
 {
 protected:
     sys::File mFile;

--- a/modules/c++/io/include/io/ReadUtils.h
+++ b/modules/c++/io/include/io/ReadUtils.h
@@ -20,12 +20,14 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_io_ReadUtils_h_INCLUDED_
 #define CODA_OSS_io_ReadUtils_h_INCLUDED_
 
 #include <string>
 #include <vector>
 
+#include <config/Exports.h>
 #include <sys/Conf.h>
 #include <coda_oss/cstddef.h> // byte
 #include <sys/filesystem.h>
@@ -40,9 +42,8 @@ namespace io
  * \param pathname Pathname of the file to read in
  * \param buffer Raw bytes of the file
  */
-void readFileContents(const std::string& pathname,
-                      std::vector<sys::byte>& buffer);
-void readFileContents(const coda_oss::filesystem::path& pathname, std::vector<coda_oss::byte>& buffer);
+CODA_OSS_API void readFileContents(const std::string& pathname, std::vector<sys::byte>& buffer);
+CODA_OSS_API void readFileContents(const coda_oss::filesystem::path& pathname, std::vector<coda_oss::byte>& buffer);
 
 /*!
  * Reads the contents of a file into a string.  The file is assumed to be a
@@ -51,7 +52,7 @@ void readFileContents(const coda_oss::filesystem::path& pathname, std::vector<co
  * \param pathname Pathname of the file to read in
  * \param[out] str Contents of the file
  */
-void readFileContents(const std::string& pathname, std::string& str);
+CODA_OSS_API void readFileContents(const std::string& pathname, std::string& str);
 
 /*!
  * Reads the contents of a file into a string.  The file is assumed to be a

--- a/modules/c++/io/source/ReadUtils.cpp
+++ b/modules/c++/io/source/ReadUtils.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#include <io/ReadUtils.h>
+
 #include <io/FileInputStream.h>
 #include <coda_oss/span.h>
 

--- a/modules/c++/sys/include/sys/FileFinder.h
+++ b/modules/c++/sys/include/sys/FileFinder.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <utility>
 
+#include "config/Exports.h"
 #include "sys/filesystem.h"
 
 namespace sys
@@ -191,9 +192,10 @@ namespace test // i.e., sys::test
     // e.g., root / "externals" / [name] / path / file
     //
     // Once modulePath is found, the result is cached to avoid searching again.
-    coda_oss::filesystem::path findModuleFile(const coda_oss::filesystem::path& root,
+    coda_oss::filesystem::path findModuleFile(
+            const coda_oss::filesystem::path& root,
             const std::string& externalsName, const coda_oss::filesystem::path& modulePath, const coda_oss::filesystem::path& moduleFile);
-    coda_oss::filesystem::path findGITModuleFile( // use current_directory() to find_dotGITDirectory()
+    CODA_OSS_API coda_oss::filesystem::path findGITModuleFile(  // use current_directory() to find_dotGITDirectory()
             const std::string& externalsName, const coda_oss::filesystem::path& modulePath, const coda_oss::filesystem::path& moduleFile);
 }
 }

--- a/modules/c++/sys/source/AbstractOS.cpp
+++ b/modules/c++/sys/source/AbstractOS.cpp
@@ -364,6 +364,10 @@ static std::string getSpecialEnv_Platform(const AbstractOS&, const std::string& 
 static std::string getSpecialEnv_PlatformToolset(const AbstractOS&, const std::string& envVar)
 {
     assert(envVar == "PlatformToolset");
+    #if _MSC_VER
+    UNREFERENCED_PARAMETER(envVar);
+    #endif
+
 #ifdef _WIN32
 	// https://docs.microsoft.com/en-us/cpp/build/how-to-modify-the-target-framework-and-platform-toolset?view=msvc-160
 	// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170

--- a/modules/c++/zip/include/zip/GZipInputStream.h
+++ b/modules/c++/zip/include/zip/GZipInputStream.h
@@ -20,8 +20,11 @@
  *
  */
 
-#ifndef __ZIP_GZIP_INPUT_STREAM_H__
-#define __ZIP_GZIP_INPUT_STREAM_H__
+#pragma once
+#ifndef CODA_OSS_zip_GZipInputStream_h_INCLUDED_
+#define CODA_OSS_zip_GZipInputStream_h_INCLUDED_
+
+#include "config/Exports.h"
 
 #include "zip/Types.h"
 
@@ -38,7 +41,7 @@ namespace zip
  *  argument is given, and in a loop.  On the last run, the buffer
  *  size should will probably smaller than the amount requested.
  */
-class GZipInputStream: public io::InputStream
+class CODA_OSS_API GZipInputStream : public io::InputStream
 {
     gzFile mFile;
 public:
@@ -63,5 +66,4 @@ protected:
 };
 }
 
-#endif
-
+#endif  // CODA_OSS_zip_GZipInputStream_h_INCLUDED_

--- a/modules/c++/zip/include/zip/GZipOutputStream.h
+++ b/modules/c++/zip/include/zip/GZipOutputStream.h
@@ -20,8 +20,11 @@
  *
  */
 
-#ifndef __ZIP_GZIP_OUTPUT_STREAM_H__
-#define __ZIP_GZIP_OUTPUT_STREAM_H__
+#pragma once
+#ifndef CODA_OSS_zip_GZipOutputStream_h_INCLUDED_
+#define CODA_OSS_zip_GZipOutputStream_h_INCLUDED_
+
+#include "config/Exports.h"
 
 #include "zip/Types.h"
 
@@ -32,7 +35,7 @@ namespace zip
  *  \brief IO wrapper for zlib API
  *
  */
-class GZipOutputStream: public io::OutputStream
+class CODA_OSS_API GZipOutputStream : public io::OutputStream
 {
     gzFile mFile;
 public:
@@ -56,4 +59,4 @@ public:
 };
 }
 
-#endif
+#endif  // CODA_OSS_zip_GZipOutputStream_h_INCLUDED_

--- a/modules/c++/zip/unittests/unittest_GZip.cpp
+++ b/modules/c++/zip/unittests/unittest_GZip.cpp
@@ -54,7 +54,8 @@ TEST_CASE(gzip)
     const std::filesystem::path outputName_(txt_to_gz(inputPath));
     const auto outputName = "TEST_" + outputName_.stem().string() + "_TMP" + outputName_.extension().string(); // see .gitignore
     const auto outputDir = inputPath.parent_path();
-    auto outputPath = outputDir / outputName;
+    const auto origOutputPath = outputDir / outputName;
+    auto outputPath = origOutputPath;
 
     {
         io::FileInputStream input(inputPath.string());
@@ -80,6 +81,9 @@ TEST_CASE(gzip)
         const auto str = io::readFileContents(outputPath.string());
         TEST_ASSERT_EQ("Hello World!", str);
     }
+
+    remove(origOutputPath);
+    remove(outputPath);
 }
 
 TEST_CASE(gunzip)
@@ -99,6 +103,8 @@ TEST_CASE(gunzip)
 
     const auto str = io::readFileContents(outputPath.string());
     TEST_ASSERT_EQ("Hello World!", str);
+    
+    remove(outputPath);
 }
 
 TEST_MAIN(

--- a/modules/c++/zip/unittests/unittest_GZip.cpp
+++ b/modules/c++/zip/unittests/unittest_GZip.cpp
@@ -49,10 +49,13 @@ static std::string gz_to_txt(const std::filesystem::path& gz_path)
 
 TEST_CASE(gzip)
 {
-    const auto inputPath = find_unittest_file("text.txt");
+    static const auto inputPath = find_unittest_file("text.txt");
 
-    const std::filesystem::path argv0 = sys::OS().getSpecialEnv("0");
-    auto outputPath = argv0.parent_path() / txt_to_gz(inputPath);
+    const std::filesystem::path outputName_(txt_to_gz(inputPath));
+    const auto outputName = "TEST_" + outputName_.stem().string() + "_TMP" + outputName_.extension().string(); // see .gitignore
+    const auto outputDir = inputPath.parent_path();
+    auto outputPath = outputDir / outputName;
+
     {
         io::FileInputStream input(inputPath.string());
         zip::GZipOutputStream output(outputPath.string());
@@ -67,7 +70,7 @@ TEST_CASE(gzip)
     TEST_ASSERT_EQ(32, buffer.size());
     {
         zip::GZipInputStream input(outputPath.string());
-        outputPath = argv0.parent_path() / gz_to_txt(outputPath);
+        outputPath = outputDir / gz_to_txt(outputPath);
         io::FileOutputStream output(outputPath.string());
         while (input.streamTo(output, 8192)) ;
 
@@ -81,11 +84,12 @@ TEST_CASE(gzip)
 
 TEST_CASE(gunzip)
 {
-    const auto inputPath = find_unittest_file("test.gz");
+    static const auto inputPath = find_unittest_file("test.gz");
 
-    const std::filesystem::path argv0 = sys::OS().getSpecialEnv("0");
-    const auto outputPath = argv0.parent_path() / gz_to_txt(inputPath);
-        
+    const std::filesystem::path outputName_(gz_to_txt(inputPath));
+    const auto outputName = "TEST_" + outputName_.stem().string() + "_TMP" + outputName_.extension().string(); // see .gitignore
+    const auto outputPath = inputPath.parent_path() / outputName;
+                
     zip::GZipInputStream input(inputPath.string());
     io::FileOutputStream output(outputPath.string());
     while ( input.streamTo(output, 8192) );


### PR DESCRIPTION
Treat **modules/drivers** and "externals" and assume a pre-built **install**; this allows additional modules to be part of the project.