### PR TITLE
use overloads rather than varargs for std::format()

### DIFF
--- a/modules/c++/cli/include/cli/Value.h
+++ b/modules/c++/cli/include/cli/Value.h
@@ -106,10 +106,7 @@ public:
     {
         if (index >= mValues.size())
             throw except::IndexOutOfRangeException(
-                                                   Ctxt(
-                                                        FmtX(
-                                                             "Invalid index: %d",
-                                                             index)));
+                                                   Ctxt(FmtX("Invalid index: %d", index)));
         return str::toType<T>(mValues[index]);
     }
 

--- a/modules/c++/cli/source/ArgumentParser.cpp
+++ b/modules/c++/cli/source/ArgumentParser.cpp
@@ -317,8 +317,7 @@ std::unique_ptr<cli::Results> cli::ArgumentParser::parse(const std::string& prog
                 std::map<std::string, Argument*>& flagMap =
                         (subOption ? shortOptionsFlags : shortFlags);
                 if (flagMap.find(op) != flagMap.end())
-                    parseError(FmtX("Conflicting option: %c%s", mPrefixChar,
-                                    op.c_str()));
+                    parseError(FmtX("Conflicting option: %c%s", mPrefixChar, op));
                 flagMap[op] = arg;
             }
             for (std::vector<std::string>::const_iterator it =
@@ -328,8 +327,7 @@ std::unique_ptr<cli::Results> cli::ArgumentParser::parse(const std::string& prog
                 std::map<std::string, Argument*>& flagMap =
                         (subOption ? longOptionsFlags : longFlags);
                 if (flagMap.find(op) != flagMap.end())
-                    parseError(FmtX("Conflicting option: %c%c%s", mPrefixChar,
-                                    mPrefixChar, op.c_str()));
+                    parseError(FmtX("Conflicting option: %c%c%s", mPrefixChar, mPrefixChar, op));
                 flagMap[op] = arg;
             }
         }
@@ -458,8 +456,7 @@ std::unique_ptr<cli::Results> cli::ArgumentParser::parse(const std::string& prog
                     }
                     else
                     {
-                        throw except::Exception(Ctxt(
-                                FmtX("Invalid option: [%s]", argStr.c_str())));
+                        throw except::Exception(Ctxt(FmtX("Invalid option: [%s]", argStr)));
                     }
                 }
             }
@@ -500,8 +497,7 @@ std::unique_ptr<cli::Results> cli::ArgumentParser::parse(const std::string& prog
                     }
                     else
                     {
-                        throw except::Exception(Ctxt(
-                                FmtX("Invalid option: [%s]", argStr.c_str())));
+                        throw except::Exception(Ctxt(FmtX("Invalid option: [%s]", argStr)));
                     }
 
                 }
@@ -549,10 +545,7 @@ std::unique_ptr<cli::Results> cli::ArgumentParser::parse(const std::string& prog
                 }
 
                 if (!added)
-                    parseError(
-                               FmtX(
-                                    "option requires value or has exceeded its max: [%s]",
-                                    argVar.c_str()));
+                    parseError(FmtX("option requires value or has exceeded its max: [%s]", argVar));
 
                 currentResults->put(argVar, v);
                 break;
@@ -677,11 +670,9 @@ std::unique_ptr<cli::Results> cli::ArgumentParser::parse(const std::string& prog
         if (arg->isRequired() || numGiven > 0)
         {
             if (minArgs > 0 && numGiven < static_cast<size_t>(minArgs))
-                parseError(FmtX("not enough arguments, %d required: [%s]",
-                                minArgs, argId.c_str()));
+                parseError(FmtX("not enough arguments, %d required: [%s]", minArgs, argId));
             if (maxArgs >= 0 && numGiven > static_cast<size_t>(maxArgs))
-                parseError(FmtX("too many arguments, %d supported: [%s]",
-                                maxArgs, argId.c_str()));
+                parseError(FmtX("too many arguments, %d supported: [%s]", maxArgs, argId));
         }
 
 

--- a/modules/c++/pch.h
+++ b/modules/c++/pch.h
@@ -103,10 +103,10 @@ CODA_OSS_disable_warning_pop
 // change we want to rebuild everything anyway.
 #include "gsl/gsl.h"
 #include "config/Exports.h"
+#include "mem/SharedPtr.h"
+#include "sys/filesystem.h"
 #include "except/Throwable.h"
 #include "sys/Conf.h"
-#include "sys/filesystem.h"
-#include "mem/SharedPtr.h"
 
 #include "xml/lite/xerces_.h"
 #pragma comment(lib, "xerces-c")

--- a/modules/c++/plugin/include/plugin/BasicPluginManager.h
+++ b/modules/c++/plugin/include/plugin/BasicPluginManager.h
@@ -279,7 +279,7 @@ public:
                 for (unsigned int i = 0; ops[i] != nullptr; i++)
                     oss << ops[i] << ":";
                 eh->onPluginVersionUnsupported(
-                    FmtX("For plugin supporting ops %s version [%d.%d] not supported (%d.%d)",
+                    str::Format("For plugin supporting ops %s version [%d.%d] not supported (%d.%d)",
                          oss.str().c_str(), majorVersion, minorVersion,
                          mMajorVersion, mMinorVersion
                         )

--- a/modules/c++/str/include/str/Format.h
+++ b/modules/c++/str/include/str/Format.h
@@ -21,23 +21,20 @@
  */
 
 
-#ifndef __STR_FORMAT_H__
-#define __STR_FORMAT_H__
+#pragma once
+#ifndef CODA_OSS_str_Format_h_INCLUDED_
+#define CODA_OSS_str_Format_h_INCLUDED_
 
 #include <stdarg.h>
+#include<stdint.h>
+#include<stddef.h>
+
 #include <string>
 
 #include "config/Exports.h"
 
 namespace str
 {
-
-/*!
- *  \param format  The format
- *  \param ... Any printf like thing
- */
-CODA_OSS_API std::string format(const char* format, ...);
-
 struct CODA_OSS_API Format final
 {
     Format(const char* format, ...);
@@ -47,14 +44,99 @@ struct CODA_OSS_API Format final
         return mString;
     }
 
-    operator std::string& () noexcept
-    {
-        return mString;
-    }
-
-protected:
+private:
     std::string mString;
 };
 
+/*!
+ *  \param format  The format
+ *  \param ... Any printf like thing
+ */
+//CODA_OSS_API std::string format(const char* format, ...);
+
+inline std::string format(const char* format)
+{
+    return Format(format);
 }
-#endif
+
+inline std::string format(const char* format, const char* pStr)
+{
+    return Format(format, pStr);
+}
+inline std::string format(const char* format, const std::string& s)
+{
+    return Format(format, s.c_str());
+}
+inline std::string format(const char* format, int i)
+{
+    return Format(format, i);
+}
+inline std::string format(const char* format, uint32_t i)
+{
+    return Format(format, i);
+}
+inline std::string format(const char* format, ptrdiff_t l)
+{
+    return Format(format, l);
+}
+inline std::string format(const char* format, size_t ul)
+{
+    return Format(format, ul);
+}
+inline std::string format(const char* format, float f)
+{
+    return Format(format, f);
+}
+
+inline std::string format(const char* format, char ch, const char* pStr)
+{
+    return Format(format, ch, pStr);
+}
+inline std::string format(const char* format, char ch, const std::string& s)
+{
+    return Format(format, ch, s.c_str());
+}
+inline std::string format(const char* format, const std::string& s1, const std::string& s2)
+{
+    return Format(format, s1.c_str(), s2.c_str());
+}
+inline std::string format(const char* format, const std::string& s, size_t ul)
+{
+    return Format(format, s.c_str(), ul);
+}
+inline std::string format(const char* format, char ch1, char ch2)
+{
+    return Format(format, ch1, ch2);
+}
+inline std::string format(const char* format, size_t ul1, size_t ul2)
+{
+    return Format(format, ul1, ul2);
+}
+inline std::string format(const char* format, int i, const std::string& s)
+{
+    return Format(format, i, s.c_str());
+}
+inline std::string format(const char* format, int i, const char* pStr)
+{
+    return Format(format, i, pStr);
+}
+
+inline std::string format(const char* format, char ch1, char ch2, const std::string& s)
+{
+    return Format(format, ch1, ch2, s.c_str());
+}
+inline std::string format(const char* format, int i1, int i2, unsigned long ul)
+{
+    return Format(format, i1, i2, ul);
+}
+inline std::string format(const char* format, int i1, int i2, int i3)
+{
+    return Format(format, i1, i2, i3);
+}
+inline std::string format(const char* format, const std::string& s1, const std::string& s2, uint32_t ui)
+{
+    return Format(format, s1.c_str(), s2.c_str(), ui);
+}
+
+}
+#endif  // CODA_OSS_str_Format_h_INCLUDED_

--- a/modules/c++/str/source/Format.cpp
+++ b/modules/c++/str/source/Format.cpp
@@ -51,14 +51,14 @@ inline void va_end_(va_list& args)
     CODA_OSS_disable_warning_pop
 }
 
-std::string str::format(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    auto retval = vformat(format, args);
-    va_end_(args);
-    return retval;
-}
+//std::string str::format(const char *format, ...)
+//{
+//    va_list args;
+//    va_start(args, format);
+//    auto retval = vformat(format, args);
+//    va_end_(args);
+//    return retval;
+//}
 
 str::Format::Format(const char* format, ...)
 {

--- a/modules/c++/sys/source/OSUnix.cpp
+++ b/modules/c++/sys/source/OSUnix.cpp
@@ -143,7 +143,7 @@ std::string sys::OSUnix::getPlatformName() const
     if (uname(&name) == -1)
         throw sys::SystemException("Uname failed");
 
-    return FmtX("%s (%s): %s [build: %s]", name.sysname, name.machine,
+    return str::Format("%s (%s): %s [build: %s]", name.sysname, name.machine,
                 name.release, name.version);
 }
 

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -58,7 +58,7 @@ std::string sys::OSWin32::getPlatformName() const
     {
         platform = "Unknown Windows OS";
     }
-    return FmtX("%s: %d.%d [build: %d], %s", platform.c_str(),
+    return str::Format("%s: %d.%d [build: %d], %s", platform.c_str(),
                 info.dwMajorVersion, info.dwMinorVersion, info.dwBuildNumber,
                 info.szCSDVersion);
 }

--- a/modules/c++/xml.lite/source/Attributes.cpp
+++ b/modules/c++/xml.lite/source/Attributes.cpp
@@ -152,8 +152,7 @@ std::string xml::lite::Attributes::getValue(const QName& qname) const
     {
         const auto uri = qname.getUri().value;
         const auto localName = qname.getName();
-        throw except::NoSuchKeyException(Ctxt(FmtX("(uri: %s, localName: %s",
-                                                   uri.c_str(), localName.c_str())));
+        throw except::NoSuchKeyException(Ctxt(FmtX("(uri: %s, localName: %s", uri, localName)));
     }
     return retval;
 }


### PR DESCRIPTION
Use overloads rather than varargs for `std::format()`.