### PR TITLE
enable AVX2 and AVX512F CMake builds

### DIFF
--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -58,7 +58,8 @@ jobs:
         os: [windows-latest]
         platform: [x64]
         configuration: [Debug] # Debug turns on more compiler warnings
-    name: ${{ matrix.os }}-msbuild
+        avx: [AVX2, AVX512F]
+    name: ${{ matrix.os }}-${{ matrix.avx }}-msbuild
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -68,7 +69,7 @@ jobs:
         ls env:
         mkdir out
         cd out
-        cmake .. -DCMAKE_INSTALL_PREFIX=install\${{ matrix.platform }}-${{ matrix.configuration }} -DENABLE_PYTHON=OFF
+        cmake .. -DCMAKE_INSTALL_PREFIX=install\${{ matrix.platform }}-${{ matrix.configuration }} -DENABLE_PYTHON=OFF -DENABLE_${{ matrix.avx }}=ON
     - name: build
       run: |
         cd out
@@ -131,14 +132,15 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         configuration: [Debug, Release]
-    name: ${{ matrix.os }}-${{ matrix.configuration }}-CMake
+        avx: [AVX2, AVX512F]
+    name: ${{ matrix.os }}-${{ matrix.configuration }}-${{ matrix.avx }}-CMake
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
     - name: configure
       run: |
         mkdir out && cd out
-        cmake .. -DENABLE_PYTHON=OFF -DENABLE_ASAN=ON
+        cmake .. -DENABLE_PYTHON=OFF -DENABLE_ASAN=ON -DENABLE_${{ matrix.avx }}=ON
     - name: build
       run: |
         cd out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,19 +24,8 @@ if (${CMAKE_PROJECT_NAME} STREQUAL coda-oss)
     if (MSVC)
        add_compile_options(/WX) # warnings as errors
        add_compile_options(/MP) # multi-processor compile
-
-       if (ENABLE_ASAN)
-            # https://docs.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-160
-            add_compile_options(/fsanitize=address)
-       endif()
     elseif (UNIX)
        add_compile_options(-Werror) # warnings as errors
-
-       if (ENABLE_ASAN)
-            # https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
-            add_compile_options(-fsanitize=address)
-            add_link_options(-fsanitize=address)
-       endif()
     endif()
 
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/cmake/CodaBuild.cmake
+++ b/cmake/CodaBuild.cmake
@@ -170,6 +170,17 @@ macro(coda_initialize_build)
             # https://docs.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-160
             add_compile_options(/fsanitize=address)
        endif()
+
+       # Note SSE2 is implicitly enabled for x64 builds.
+       if (ENABLE_AVX2 AND (NOT ENABLE_AVX512F))
+            # https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-170
+            add_compile_options(/arch:AVX2)
+       endif()
+       if (ENABLE_AVX512F)
+            # https://learn.microsoft.com/en-us/cpp/build/reference/arch-x86?view=msvc-170
+           add_compile_options(/arch:AVX512)
+       endif()
+
     endif()
 
     # Unix/Linux specific options
@@ -184,6 +195,21 @@ macro(coda_initialize_build)
             add_compile_options(-fsanitize=address)
             add_link_options(-fsanitize=address)
        endif()
+
+       # Note SSE2 is implicitly enabled for x64 builds.
+       if (ENABLE_AVX2 AND (NOT ENABLE_AVX512F))
+            # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+            # It doesn't look like GCC has a specific option for AVX2;
+            # other projects use "haswell"
+            add_compile_options(-march=haswell)
+       endif()
+       if (ENABLE_AVX512F)
+            # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+            # It doesn't look like GCC has a specific option for AVX512F;
+            # other projects use "native" which isn't quite correct.'
+            add_compile_options(-march=native)
+       endif()
+
     endif()
 
     # all targets should be installed using this export set

--- a/cmake/CodaBuild.cmake
+++ b/cmake/CodaBuild.cmake
@@ -165,6 +165,11 @@ macro(coda_initialize_build)
         # This should probably be replaced by GenerateExportHeader
         #set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
         set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD TRUE)
+
+       if (ENABLE_ASAN)
+            # https://docs.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-160
+            add_compile_options(/fsanitize=address)
+       endif()
     endif()
 
     # Unix/Linux specific options
@@ -173,6 +178,12 @@ macro(coda_initialize_build)
             -D_LARGEFILE_SOURCE
             -D_FILE_OFFSET_BITS=64
         )
+
+       if (ENABLE_ASAN)
+            # https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html
+            add_compile_options(-fsanitize=address)
+            add_link_options(-fsanitize=address)
+       endif()
     endif()
 
     # all targets should be installed using this export set


### PR DESCRIPTION
Add `ENABLE_AVX2` and `ENABLE_AVX512F` Cmake options.