### PR TITLE
Throwable always inherits from std::exception

### DIFF
--- a/modules/c++/except/include/except/Error.h
+++ b/modules/c++/except/include/except/Error.h
@@ -44,16 +44,12 @@
       _Name##Error_(const except::Context& c) : _Base(c){} \
       _Name##Error_(const std::string& msg) : _Base(msg){} \
       _Name##Error_(const except::Throwable& t, const except::Context& c) : _Base(t, c){} \
-      _Name##Error_(const except::ThrowableEx& t, const except::Context& c) : _Base(t, c){} \
       std::string getType() const noexcept override { return #_Name; } \
   }
 #define DECLARE_EXTENDED_ERROR(_Name, _Base) DECLARE_EXTENDED_ERROR_(_Name, Error, _Base)
-#define DECLARE_EXTENDED_ERROREX(_Name, _Base) DECLARE_EXTENDED_ERROR_(_Name, ErrorEx, _Base)
 
 // Need to keep this around for existing code
-#define DECLARE_ERROR(_Name) \
-    DECLARE_EXTENDED_ERROR(_Name, except::Error);		\
-    DECLARE_EXTENDED_ERROREX(_Name, except::ErrorEx)
+#define DECLARE_ERROR(_Name) DECLARE_EXTENDED_ERROR(_Name, except::Error)
 
 namespace except
 {
@@ -98,9 +94,6 @@ struct Error : public Throwable
         Throwable(t, c)
     {
     }
-    Error(const ThrowableEx& t, const Context& c) : Throwable(t, c)
-    {
-    }
 
     std::string getType() const override 
     {
@@ -110,46 +103,9 @@ struct Error : public Throwable
 
 // Use this in new code: name is FooErrror (not FooErrorEx), base is except::ErrorEx (not except::Error).
 #define CODA_OSS_DECLARE_EXTENDED_ERROR(name_, base_) DECLARE_EXTENDED_ERROR_(name_, Error, base_)
-#define CODA_OSS_DECLARE_ERROR(name_) CODA_OSS_DECLARE_EXTENDED_ERROR(name_, except::ErrorEx)
+#define CODA_OSS_DECLARE_ERROR(name_) CODA_OSS_DECLARE_EXTENDED_ERROR(name_, except::Error)
 
-struct ErrorEx : public ThrowableEx
-{
-    ErrorEx() = default;
-    virtual ~ErrorEx() = default;
-
-    /*!
-     * Constructor. Takes a Context
-     * \param c The Context
-     */
-    ErrorEx(const Context& c) : ThrowableEx(c)
-    {
-    }
-
-    /*!
-     * Constructor.  Takes a message
-     * \param message The message
-     */
-    ErrorEx(const std::string& message) : ThrowableEx(message)
-    {
-    }
-
-    /*!
-     * Constructor. Takes an Throwable and a Context
-     * \param t The Throwable
-     * \param c The Context
-     */
-    ErrorEx(const ThrowableEx& t, const Context& c) : ThrowableEx(t, c)
-    {
-    }
-    ErrorEx(const Throwable& t, const Context& c) : ThrowableEx(t, c)
-    {
-    }
-
-    std::string getType() const noexcept override
-    {
-        return "ErrorEx";
-    }
-};
+using ErrorEx = Error;
 using Error11 = ErrorEx; // keep old name around for other projects
 
 /*!

--- a/modules/c++/except/include/except/Exception.h
+++ b/modules/c++/except/include/except/Exception.h
@@ -60,17 +60,13 @@
       _Name##Exception_(const except::Context& c) : _Base(c){} \
       _Name##Exception_(const std::string& msg) : _Base(msg){} \
       _Name##Exception_(const except::Throwable& t, const except::Context& c) : _Base(t, c){} \
-      _Name##Exception_(const except::ThrowableEx& t, const except::Context& c) : _Base(t, c){} \
       CODA_OSS_except_Exception_suppress_26447_BEGIN_ \
       std::string getType() const noexcept override { return #_Name #Exception_; } \
       CODA_OSS_except_Exception_suppress_26447_END_ }
 #define DECLARE_EXTENDED_EXCEPTION(_Name, _Base) DECLARE_EXTENDED_EXCEPTION_(_Name, Exception, _Base)
-#define DECLARE_EXTENDED_EXCEPTIONEX(_Name, _Base) DECLARE_EXTENDED_EXCEPTION_(_Name, ExceptionEx, _Base)
 
 // Need to keep this around for existing code
-#define DECLARE_EXCEPTION(_Name) \
-    DECLARE_EXTENDED_EXCEPTION(_Name, except::Exception); \
-    DECLARE_EXTENDED_EXCEPTIONEX(_Name, except::ExceptionEx)
+#define DECLARE_EXCEPTION(_Name) DECLARE_EXTENDED_EXCEPTION(_Name, except::Exception)
 
 namespace except
 {
@@ -104,9 +100,6 @@ struct Exception : public Throwable
         Throwable(t, c)
     {
     }
-    Exception(const ThrowableEx& t, const Context& c) : Throwable(t, c)
-    {
-    }
 
     /*!
      * Constructor.  Takes a message
@@ -126,46 +119,9 @@ struct Exception : public Throwable
 
 // Use this in new code: name is FooException (not FooExceptionEx), base is except::ExceptionEx (not except::Exception).
 #define CODA_OSS_DECLARE_EXTENDED_EXCEPTION(name_, base_) DECLARE_EXTENDED_EXCEPTION_(name_, Exception, base_)
-#define CODA_OSS_DECLARE_EXCEPTION(name_) CODA_OSS_DECLARE_EXTENDED_EXCEPTION(name_, except::ExceptionEx)
+#define CODA_OSS_DECLARE_EXCEPTION(name_) CODA_OSS_DECLARE_EXTENDED_EXCEPTION(name_, except::Exception)
 
-struct ExceptionEx : public ThrowableEx
-{
-    ExceptionEx() = default;
-    virtual ~ExceptionEx() = default;
-
-    /*!
-     * Constructor. Takes a Context
-     * \param c The Context
-     */
-    ExceptionEx(const Context& c) : ThrowableEx(c)
-    {
-    }
-
-    /*!
-     * Constructor. Takes an Throwable and a Context
-     * \param t The Throwable
-     * \param c The Context
-     */
-    ExceptionEx(const ThrowableEx& t, const Context& c) : ThrowableEx(t, c)
-    {
-    }
-    ExceptionEx(const Throwable& t, const Context& c) : ThrowableEx(t, c)
-    {
-    }
-
-    /*!
-     * Constructor.  Takes a message
-     * \param message The message
-     */
-    ExceptionEx(const std::string& message) : ThrowableEx(message)
-    {
-    }
-
-    std::string getType() const noexcept override
-    {
-        return "ExceptionEx";
-    }
-};
+using ExceptionEx = Exception;
 using Exception11 = ExceptionEx; // keep old name around for other projects
 
 /*!

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -47,14 +47,11 @@
  * A lot of existing code has "catch (std::exception)" BEFORE "catch (except::Throwable)" 
  * making it difficult to change without the risk of breaking something. :-(
  */
-#ifdef CODA_OSS_THROWABLE_ISA_STD_EXCEPTION  // -DCODA_OSS_THROWABLE_ISA_STD_EXCEPTION
+#ifdef CODA_OSS_THROWABLE_ISA_STD_EXCEPTION 
+#error "No longer supported, please update your code."
+#endif
 #ifdef CODA_OSS_except_Throwable_ISA_std_exception
-#error "CODA_OSS_except_Throwable_ISA_std_exception is already #define'd."
-#endif
-#define CODA_OSS_except_Throwable_ISA_std_exception 1
-#endif
-#ifndef CODA_OSS_except_Throwable_ISA_std_exception // or, -DCODA_OSS_except_Throwable_ISA_std_exception=1
-#define CODA_OSS_except_Throwable_ISA_std_exception 0
+#error "No longer supported, please update your code."
 #endif
 
 /*!
@@ -74,18 +71,18 @@ namespace except
  * This class provides the base interface for exceptions and errors.
  */
 
-class ThrowableEx;
-class CODA_OSS_API Throwable
-#if CODA_OSS_except_Throwable_ISA_std_exception    
-    : public std::exception
+
+CODA_OSS_disable_warning_push
+#if _MSC_VER
+#pragma warning(disable: 4275) // non dll-interface class '...' used as base for dll-interface class '...'
 #endif
+class CODA_OSS_API Throwable : public std::exception
+CODA_OSS_disable_warning_pop
 {
     void doGetBacktrace();
-    template<typename TThrowable>
-    Throwable(const Context*, const TThrowable* pT, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t);
+    Throwable(const Context*, const Throwable* pT, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t);
 protected:
     Throwable(const Context*, const Throwable* pT = nullptr, const std::string* pMessage = nullptr, bool callGetBacktrace = false);
-    Throwable(const Context*, const ThrowableEx* pT, const std::string* pMessage = nullptr, bool callGetBacktrace = false);
 
 public:
     Throwable() = default;
@@ -94,7 +91,6 @@ public:
     Throwable(Throwable&&) = default;
     Throwable& operator=(Throwable&&) = default;
 
-    Throwable(const ThrowableEx&);
 
     /*!
      * Constructor.  Takes a message
@@ -114,7 +110,6 @@ public:
      * \param c The Context
      */
     Throwable(const Throwable&, Context);
-    Throwable(const ThrowableEx&, Context);
 
     /*!
      * Destructor
@@ -184,7 +179,7 @@ public:
 
     virtual std::string toString(bool includeBacktrace) const
     {
-        // Adding the backtrace to existing toString() output could substantally alter existing strings.
+        // Adding the backtrace to existing toString() output could substantially alter existing strings.
         std::string backtrace;
         if (includeBacktrace)
         {
@@ -194,11 +189,7 @@ public:
         return toString() + backtrace;
     }
 
-    const char* what() const noexcept
-    #if CODA_OSS_except_Throwable_ISA_std_exception    
-    // can't use "final" unless what() is virtual
-    final  // derived classes override toString()
-    #endif
+    const char* what() const noexcept final  // derived classes override toString()
     {
         // adding this to toString() output could (significantly) alter existing display
         mWhat = toString(true /*includeBacktrace*/); // call any derived toString()
@@ -222,57 +213,8 @@ private:
  *
  * This class provides the base interface for exceptions and errors.
  */
+using ThrowableEx = Throwable;
 
-/*
- * It can be quite convenient to derive from std::exception as often one less
- * "catch" will be needed and we'll have standard what().  But doing so could
- * break existing code as "catch (const std::exception&)" will catch
- * except::Throwable when it didn't before.
- */
-// Use multiple-inheritance :-( to reduce duplicated boilerplate code.
-class ThrowableEx : public Throwable // "ThrowableEx" = "Throwable exception"
-#if !CODA_OSS_except_Throwable_ISA_std_exception
-    , public std::exception
-#endif
-{
-public:
-    ThrowableEx() = default;
-    virtual ~ThrowableEx() = default;
-    ThrowableEx(const ThrowableEx&) = default;
-    ThrowableEx& operator=(const ThrowableEx&) = default;
-    ThrowableEx(ThrowableEx&&) = default;
-    ThrowableEx& operator=(ThrowableEx&&) = default;
-
-    ThrowableEx(const Throwable& t) : Throwable(t){}
-
-    /*!
-     * Constructor.  Takes a message
-     * \param message The message
-     */
-    ThrowableEx(const std::string& message) : Throwable(message) {}
-
-    /*!
-     * Constructor.  Takes a Context.
-     * \param c The Context
-     */
-    ThrowableEx(const Context& ctx) : Throwable(ctx) {}
-
-    /*!
-     * Constructor. Takes a Throwable and a Context
-     * \param t The throwable
-     * \param c The Context
-     */
-    ThrowableEx(const ThrowableEx& t, const Context& ctx) : Throwable(t, ctx) {}
-    ThrowableEx(const Throwable& t, const Context& ctx) : Throwable(t, ctx) {}
-
-    #if !CODA_OSS_except_Throwable_ISA_std_exception
-    const char* what() const noexcept override final  // derived classes override toString()
-    {
-        const Throwable* pThrowable = this;
-        return pThrowable->what();
-    }
-    #endif
-};
 using Throwable11 = ThrowableEx; // keep old name around for other projects
 }
 

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -47,14 +47,11 @@
  * A lot of existing code has "catch (std::exception)" BEFORE "catch (except::Throwable)" 
  * making it difficult to change without the risk of breaking something. :-(
  */
-#ifdef CODA_OSS_THROWABLE_ISA_STD_EXCEPTION  // -DCODA_OSS_THROWABLE_ISA_STD_EXCEPTION
+#ifdef CODA_OSS_THROWABLE_ISA_STD_EXCEPTION 
+#error "No longer supported, please update your code."
+#endif
 #ifdef CODA_OSS_except_Throwable_ISA_std_exception
-#error "CODA_OSS_except_Throwable_ISA_std_exception is already #define'd."
-#endif
-#define CODA_OSS_except_Throwable_ISA_std_exception 1
-#endif
-#ifndef CODA_OSS_except_Throwable_ISA_std_exception // or, -DCODA_OSS_except_Throwable_ISA_std_exception=1
-#define CODA_OSS_except_Throwable_ISA_std_exception 0
+#error "No longer supported, please update your code."
 #endif
 
 /*!
@@ -89,7 +86,6 @@ class Throwable {
     Throwable(const Context*, const Throwable* pT, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t);
 protected:
     Throwable(const Context*, const Throwable* pT = nullptr, const std::string* pMessage = nullptr, bool callGetBacktrace = false);
-    Throwable(const Context*, const ThrowableEx* pT, const std::string* pMessage = nullptr, bool callGetBacktrace = false);
 
 public:
     Throwable() = default;
@@ -98,7 +94,6 @@ public:
     Throwable(Throwable&&) = default;
     Throwable& operator=(Throwable&&) = default;
 
-    Throwable(const ThrowableEx&);
 
     /*!
      * Constructor.  Takes a message
@@ -118,7 +113,6 @@ public:
      * \param c The Context
      */
     Throwable(const Throwable&, Context);
-    Throwable(const ThrowableEx&, Context);
 
     /*!
      * Destructor
@@ -188,7 +182,7 @@ public:
 
     virtual std::string toString(bool includeBacktrace) const
     {
-        // Adding the backtrace to existing toString() output could substantally alter existing strings.
+        // Adding the backtrace to existing toString() output could substantially alter existing strings.
         std::string backtrace;
         if (includeBacktrace)
         {
@@ -223,57 +217,8 @@ private:
  *
  * This class provides the base interface for exceptions and errors.
  */
+using ThrowableEx = Throwable;
 
-/*
- * It can be quite convenient to derive from std::exception as often one less
- * "catch" will be needed and we'll have standard what().  But doing so could
- * break existing code as "catch (const std::exception&)" will catch
- * except::Throwable when it didn't before.
- */
-// Use multiple-inheritance :-( to reduce duplicated boilerplate code.
-class ThrowableEx : public Throwable // "ThrowableEx" = "Throwable exception"
-#if !CODA_OSS_except_Throwable_ISA_std_exception
-    , public std::exception
-#endif
-{
-public:
-    ThrowableEx() = default;
-    virtual ~ThrowableEx() = default;
-    ThrowableEx(const ThrowableEx&) = default;
-    ThrowableEx& operator=(const ThrowableEx&) = default;
-    ThrowableEx(ThrowableEx&&) = default;
-    ThrowableEx& operator=(ThrowableEx&&) = default;
-
-    ThrowableEx(const Throwable& t) : Throwable(t){}
-
-    /*!
-     * Constructor.  Takes a message
-     * \param message The message
-     */
-    ThrowableEx(const std::string& message) : Throwable(message) {}
-
-    /*!
-     * Constructor.  Takes a Context.
-     * \param c The Context
-     */
-    ThrowableEx(const Context& ctx) : Throwable(ctx) {}
-
-    /*!
-     * Constructor. Takes a Throwable and a Context
-     * \param t The throwable
-     * \param c The Context
-     */
-    ThrowableEx(const ThrowableEx& t, const Context& ctx) : Throwable(t, ctx) {}
-    ThrowableEx(const Throwable& t, const Context& ctx) : Throwable(t, ctx) {}
-
-    #if !CODA_OSS_except_Throwable_ISA_std_exception
-    const char* what() const noexcept override final  // derived classes override toString()
-    {
-        const Throwable* pThrowable = this;
-        return pThrowable->what();
-    }
-    #endif
-};
 using Throwable11 = ThrowableEx; // keep old name around for other projects
 }
 

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -77,9 +77,10 @@ CODA_OSS_disable_warning_push
 #pragma warning(disable: 4275) // non dll-interface class '...' used as base for dll-interface class '...'
 #endif
 class CODA_OSS_API Throwable : public std::exception
-CODA_OSS_disable_warning_pop
 {
-    void doGetBacktrace();
+CODA_OSS_disable_warning_pop
+
+  void doGetBacktrace();
     Throwable(const Context*, const Throwable* pT, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t);
 protected:
     Throwable(const Context*, const Throwable* pT = nullptr, const std::string* pMessage = nullptr, bool callGetBacktrace = false);

--- a/modules/c++/except/include/except/Throwable.h
+++ b/modules/c++/except/include/except/Throwable.h
@@ -20,9 +20,9 @@
  *
  */
 
+#pragma once
 #ifndef CODA_OSS_except_Throwable_h_INCLUDED_
 #define CODA_OSS_except_Throwable_h_INCLUDED_
-#pragma once
 
 #include <string>
 #include <vector>
@@ -71,14 +71,16 @@ namespace except
  * This class provides the base interface for exceptions and errors.
  */
 
-
+#ifndef SWIGPYTHON
 CODA_OSS_disable_warning_push
 #if _MSC_VER
 #pragma warning(disable: 4275) // non dll-interface class '...' used as base for dll-interface class '...'
 #endif
-class CODA_OSS_API Throwable : public std::exception
-{
+class CODA_OSS_API Throwable : public std::exception {
 CODA_OSS_disable_warning_pop
+#else
+class Throwable {
+#endif // SWIGPYTHON
 
   void doGetBacktrace();
     Throwable(const Context*, const Throwable* pT, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t);
@@ -190,7 +192,7 @@ public:
         return toString() + backtrace;
     }
 
-    const char* what() const noexcept final  // derived classes override toString()
+    const char* what() const noexcept override final  // derived classes override toString()
     {
         // adding this to toString() output could (significantly) alter existing display
         mWhat = toString(true /*includeBacktrace*/); // call any derived toString()

--- a/modules/c++/except/source/Throwable.cpp
+++ b/modules/c++/except/source/Throwable.cpp
@@ -34,8 +34,7 @@ void except::Throwable::doGetBacktrace()
     (void)except::getBacktrace(supported, mBacktrace);
 }
 
-template <typename TThrowable>
-except::Throwable::Throwable(const Context* pContext, const TThrowable* pThrowable, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t)
+except::Throwable::Throwable(const Context* pContext, const Throwable* pThrowable, const std::string* pMessage, bool callGetBacktrace, std::nullptr_t)
 {
     if (pThrowable != nullptr)
     {
@@ -62,7 +61,7 @@ except::Throwable::Throwable(const Context* pContext, const TThrowable* pThrowab
 
     // This will record a back-trace from where the Throwable object was instantiated.
     // That's not necessarily where the "throw" will occur, but it's often the case; Throwable
-    // instances ususally aren't passed around.  That is, hardly anybody does:
+    // instances usually aren't passed around.  That is, hardly anybody does:
     //    Exception e; // Throwable instance
     //    might_throw(e);
     // rather, the idiom is usually
@@ -73,10 +72,6 @@ except::Throwable::Throwable(const Context* pContext, const TThrowable* pThrowab
     }
 }
 except::Throwable::Throwable(const Context* pContext, const Throwable* pThrowable, const std::string* pMessage, bool callGetBacktrace)
-: Throwable(pContext, pThrowable, pMessage, callGetBacktrace, nullptr)
-{
-}
-except::Throwable::Throwable(const Context* pContext, const ThrowableEx* pThrowable, const std::string* pMessage, bool callGetBacktrace)
 : Throwable(pContext, pThrowable, pMessage, callGetBacktrace, nullptr)
 {
 }
@@ -92,9 +87,4 @@ except::Throwable::Throwable(except::Context c) : Throwable(&c)
 except::Throwable::Throwable(const except::Throwable& t, except::Context c) : Throwable(&c, &t)
 {
 }
-except::Throwable::Throwable(const except::ThrowableEx& t, except::Context c) : Throwable(&c, &t)
-{
-}
-except::Throwable::Throwable(const except::ThrowableEx& t) : Throwable(nullptr, &t)
-{
-}
+


### PR DESCRIPTION
`Throwable` always inherits from `std::exception`, `ThrowableEx` (and friends) have been removed.