### PR TITLE
Only need to actually create/destroy Xerces once

### DIFF
--- a/modules/c++/xml.lite/include/xml/lite/UtilitiesXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/UtilitiesXerces.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <mutex>
 #include <type_traits>
+#include <memory>
 
 #include "config/compiler_extensions.h"
 #include "config/Exports.h"
@@ -420,8 +421,9 @@ struct CODA_OSS_API XercesContext final
     void destroy();
     
 private:
-    static std::mutex mMutex;
-    bool mIsDestroyed = false;
+    struct Impl;
+    static std::shared_ptr<Impl> getInstance();
+    std::shared_ptr<Impl> mpImpl;
 };
 }
 }

--- a/modules/c++/xml.lite/include/xml/lite/UtilitiesXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/UtilitiesXerces.h
@@ -409,17 +409,19 @@ struct XercesErrorHandler final : public XercesErrorHandlerInterface_T
  */
 struct CODA_OSS_API XercesContext final
 {
-    //! Constructor
     XercesContext();
-    
-    //! Destructor
     ~XercesContext();
+
+    XercesContext(const XercesContext&) = delete;
+    XercesContext& operator=(const XercesContext&) = delete;
+    XercesContext(XercesContext&&) = delete;
+    XercesContext& operator=(XercesContext&&) = delete;
 
     void destroy();
     
 private:
     static std::mutex mMutex;
-    bool mIsDestroyed;
+    bool mIsDestroyed = false;
 };
 }
 }

--- a/modules/c++/xml.lite/include/xml/lite/ValidatorXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/ValidatorXerces.h
@@ -89,12 +89,8 @@ private:
  *
  * This class is the Xercesc schema validator
  */
-class CODA_OSS_API ValidatorXerces : public ValidatorInterface
+struct CODA_OSS_API ValidatorXerces : public ValidatorInterface
 {
-    XercesContext mCtxt;    //! this must be the first member listed
-
-public:
-
     /*! 
      *  Constructor
      *  \param schemaPaths  Vector of both paths and singular schemas
@@ -133,6 +129,8 @@ public:
     static std::vector<coda_oss::filesystem::path> loadSchemas(const std::vector<coda_oss::filesystem::path>& schemaPaths, bool recursive=true);
 
 private:
+    XercesContext mCtxt;
+
     bool validate_(const coda_oss::u8string& xml, 
                    const std::string& xmlID,
                    std::vector<ValidationInfo>& errors) const;

--- a/modules/c++/xml.lite/include/xml/lite/ValidatorXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/ValidatorXerces.h
@@ -104,10 +104,10 @@ public:
      *                      input
      */
     ValidatorXerces(const std::vector<std::string>& schemaPaths, 
-                    logging::Logger* log,
+                    logging::Logger* log = nullptr,
                     bool recursive = true);
-    ValidatorXerces(const std::vector<coda_oss::filesystem::path>&, // fs::path -> mLegacyStringConversion = false
-                    logging::Logger* log,
+    ValidatorXerces(const std::vector<coda_oss::filesystem::path>&,
+                    logging::Logger* log = nullptr,
                     bool recursive = true);
 
     ValidatorXerces(const ValidatorXerces&) = delete;

--- a/modules/c++/xml.lite/include/xml/lite/XMLReaderXerces.h
+++ b/modules/c++/xml.lite/include/xml/lite/XMLReaderXerces.h
@@ -61,7 +61,7 @@ namespace lite
  */
 class CODA_OSS_API XMLReaderXerces final : public XMLReaderInterface
 {
-    XercesContext mCtxt;    //! this must be the first member listed
+    XercesContext mCtxt;
     std::unique_ptr<SAX2XMLReader>        mNative;
     std::unique_ptr<XercesContentHandler> mDriverContentHandler;
     std::unique_ptr<XercesErrorHandler>   mErrorHandler;

--- a/modules/c++/xml.lite/source/UtilitiesXerces.cpp
+++ b/modules/c++/xml.lite/source/UtilitiesXerces.cpp
@@ -186,8 +186,7 @@ fatalError(const SAXParseException &exception)
     throw except::Error(Ctxt(xex.getMessage()));
 }
 
-XercesContext::XercesContext() :
-    mIsDestroyed(false)
+XercesContext::XercesContext()
 {
     //! XMLPlatformUtils::Initialize is not thread safe!
     try

--- a/modules/c++/xml.lite/source/UtilitiesXerces.cpp
+++ b/modules/c++/xml.lite/source/UtilitiesXerces.cpp
@@ -28,8 +28,6 @@ namespace xml
 {
 namespace lite
 {
-std::mutex XercesContext::mMutex;
-
 XercesLocalString::XercesLocalString(XMLCh* xmlStr) :
     mLocal(xmlStr)
 {
@@ -186,7 +184,16 @@ fatalError(const SAXParseException &exception)
     throw except::Error(Ctxt(xex.getMessage()));
 }
 
-XercesContext::XercesContext()
+/*!
+ *  \class XercesContext::Impl
+ *  \brief This class safely creates and destroys Xerces
+ */
+struct XercesContext::Impl final
+{
+    static std::mutex mMutex;
+    bool mIsDestroyed = false;
+
+Impl()
 {
     //! XMLPlatformUtils::Initialize is not thread safe!
     try
@@ -202,7 +209,7 @@ XercesContext::XercesContext()
     }
 }
 
-XercesContext::~XercesContext()
+~Impl()
 {
     try
     {
@@ -213,7 +220,7 @@ XercesContext::~XercesContext()
     }
 }
 
-void XercesContext::destroy()
+void destroy()
 {
     // wrapping it here saves the mutex lock
     if (!mIsDestroyed)
@@ -234,7 +241,28 @@ void XercesContext::destroy()
         }
     }
 }
+};
+std::mutex XercesContext::Impl::mMutex;
+
+std::shared_ptr<XercesContext::Impl> XercesContext::getInstance()
+{
+    // The one and only instance; call  XMLPlatformUtils::Initialize() and XMLPlatformUtils::Terminate() just once.
+    static auto  impl = std::make_shared<XercesContext::Impl>();
+    return impl; // increment reference count
 }
+XercesContext::XercesContext() : mpImpl(getInstance()) // increment reference count
+{
 }
+XercesContext::~XercesContext()
+{
+    destroy();
+}
+void XercesContext::destroy()
+{
+    mpImpl.reset();
+}
+
+} // lite
+} // xml
 
 #endif

--- a/modules/c++/xml.lite/source/ValidatorXerces.cpp
+++ b/modules/c++/xml.lite/source/ValidatorXerces.cpp
@@ -165,9 +165,12 @@ ValidatorXerces::ValidatorXerces(
                                      xercesc::Grammar::SchemaGrammarType,
                                      true))
         {
-            std::ostringstream oss;
-            oss << "Error: Failure to load schema " << schema;
-            log->warn(Ctxt(oss));
+            if (log != nullptr)
+            {
+                std::ostringstream oss;
+                oss << "Error: Failure to load schema " << schema;
+                log->warn(Ctxt(oss));
+            }
         }
     }
 

--- a/modules/c++/xml.lite/unittests/test_xmlparser.cpp
+++ b/modules/c++/xml.lite/unittests/test_xmlparser.cpp
@@ -463,8 +463,8 @@ static void testValidateXmlFile_(const std::string& testName, const std::string&
     static const auto xsd = find_unittest_file("doc.xsd");
     const auto path = find_unittest_file(xmlFile);
 
-    const std::vector<std::filesystem::path> schemaPaths{xsd.parent_path()}; // fs::path -> new string-conversion code
-    const xml::lite::Validator validator(schemaPaths, nullptr /*log*/);
+    const std::vector<std::filesystem::path> schemaPaths{xsd.parent_path()};
+    const xml::lite::Validator validator(schemaPaths);
 
     io::FileInputStream fis(path);
     std::vector<xml::lite::ValidationInfo> errors;


### PR DESCRIPTION
Change the implementation of *XercesContext* to use a `std::shared_ptr`; this way Xerces is really only initialized/destroyed once.