### PR TITLE
provide a simple implementation of std::experimental::simd

### DIFF
--- a/UnitTest/UnitTest.vcxproj
+++ b/UnitTest/UnitTest.vcxproj
@@ -325,6 +325,10 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="..\modules\c++\sys\unittests\test_ximd.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\modules\c++\types\unittests\test_complex.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/UnitTest/UnitTest.vcxproj.filters
+++ b/UnitTest/UnitTest.vcxproj.filters
@@ -258,6 +258,9 @@
     <ClCompile Include="..\modules\drivers\highfive\unittests\tests_high_five_base.cpp">
       <Filter>hdf5.lite</Filter>
     </ClCompile>
+    <ClCompile Include="..\modules\c++\sys\unittests\test_ximd.cpp">
+      <Filter>sys</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/UnitTest/sys.cpp
+++ b/UnitTest/sys.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "CppUnitTest.h"
 
+#include <coda_oss/numbers.h>
+
 #include <import/sys.h>
 #include <sys/Runnable.h>
 #include <sys/Thread.h>

--- a/UnitTest/sys.cpp
+++ b/UnitTest/sys.cpp
@@ -21,6 +21,7 @@
 #include <sys/DateTime.h>
 #include <sys/Conf.h>
 #include <sys/Path.h>
+#include <sys/Ximd.h>
 
 namespace sys
 {
@@ -54,6 +55,10 @@ TEST_CLASS(test_os){ public:
 
 TEST_CLASS(test_path){ public:
 #include "sys/unittests/test_path.cpp"
+};
+
+TEST_CLASS(test_ximd){ public:
+#include "sys/unittests/test_ximd.cpp"
 };
 
 }

--- a/modules/c++/coda-oss.vcxproj
+++ b/modules/c++/coda-oss.vcxproj
@@ -285,6 +285,7 @@
     <ClInclude Include="sys\include\sys\ThreadWin32.h" />
     <ClInclude Include="sys\include\sys\TimeStamp.h" />
     <ClInclude Include="sys\include\sys\UTCDateTime.h" />
+    <ClInclude Include="sys\include\sys\Ximd.h" />
     <ClInclude Include="tiff\include\tiff\Common.h" />
     <ClInclude Include="tiff\include\tiff\FileReader.h" />
     <ClInclude Include="tiff\include\tiff\FileWriter.h" />

--- a/modules/c++/coda-oss.vcxproj.filters
+++ b/modules/c++/coda-oss.vcxproj.filters
@@ -957,6 +957,9 @@
     <ClInclude Include="coda_oss\include\coda_oss\mdspan_.h">
       <Filter>coda_oss</Filter>
     </ClInclude>
+    <ClInclude Include="sys\include\sys\Ximd.h">
+      <Filter>sys</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -56,7 +56,7 @@ namespace CODA_OSS_Ximd_namespace
 {
 // Need a class for the "broadcast" constructor (not impelemented).
 // Also helps to avoid overloading `std::array`.
-template <typename T, int N = 4>
+template <typename T> //, int N = 4>
 struct Ximd final
 {
     static_assert(std::is_arithmetic<T>::value, "T must be arithmetic");
@@ -83,6 +83,11 @@ struct Ximd final
     {
         *this = other;
     }
+    template<typename U>
+    Ximd(const U* mem)
+    {
+        copy_from(mem);
+    }
 
     // https://en.cppreference.com/w/cpp/experimental/simd/simd/simd
     // this is the same as `U&& v` above; avoid enable_if gunk for now.
@@ -107,7 +112,22 @@ struct Ximd final
 
     static constexpr size_t size() noexcept
     {
+        constexpr int N = 4;
         return N;
+    }
+
+    template <typename U>
+    void copy_from(const U* mem)
+    {
+        *this = Ximd([&](size_t i) { return mem[i]; });
+    }
+    template <typename U>
+    void copy_to(U* mem) const
+    {
+        for (size_t i = 0; i < size(); i++)
+        {
+            mem[i] = (*this)[i];
+        }
     }
 
     Ximd& operator++() noexcept
@@ -126,11 +146,11 @@ struct Ximd final
     std::array<value_type, size()> value{};
 };
 
-template<typename T, int N>
-using fixed_size_ximd = Ximd<T, N>;
-
-template<typename T, int N>
-using native_ximd = Ximd<T>;
+//template<typename T, int N>
+//using fixed_size_ximd = Ximd<T, N>;
+//
+//template<typename T, int N>
+//using native_ximd = Ximd<T>;
 
 using ximd_mask = Ximd<bool>;
 
@@ -253,7 +273,6 @@ inline auto round(const Ximd<T>& v)
 {
     return Ximd<T>([&](size_t i) { return std::round(v[i]); });
 }
-
 
 } // CODA_OSS_Ximd_namespace
 

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -221,6 +221,18 @@ inline auto operator==(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noe
     return lhs == rhs_;
 }
 template <typename T>
+inline auto operator!=(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
+{
+    return ximd_mask([&](size_t i) { return lhs[i] != rhs[i]; });
+}
+template <typename T>
+inline auto operator!=(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noexcept
+{
+    Ximd<T> rhs_;
+    rhs_ = rhs;
+    return lhs != rhs_;
+}
+template <typename T>
 inline auto operator<(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
 {
     return ximd_mask([&](size_t i) { return lhs[i] < rhs[i]; });

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -56,7 +56,7 @@ namespace CODA_OSS_Ximd_namespace
 {
 // Need a class for the "broadcast" constructor (not impelemented).
 // Also helps to avoid overloading `std::array`.
-template <typename T> //, int N = 4>
+template <typename T, int N = 4>
 struct Ximd final
 {
     static_assert(std::is_arithmetic<T>::value, "T must be arithmetic");
@@ -112,7 +112,6 @@ struct Ximd final
 
     static constexpr size_t size() noexcept
     {
-        constexpr int N = 4;
         return N;
     }
 
@@ -143,7 +142,7 @@ struct Ximd final
     }
 
  private:
-    std::array<value_type, size()> value{};
+    std::array<value_type, N> value{};
 };
 
 //template<typename T, int N>

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -47,33 +47,31 @@
 #include <functional>
 #include <cmath>
 
-// By default, we'll put things in the `sys` namespace as everything
-// else here does; but a developer might want to change that.
-#ifndef CODA_OSS_Ximd_namespace
-#define CODA_OSS_Ximd_namespace sys
-#endif
-namespace CODA_OSS_Ximd_namespace
+namespace sys
 {
+namespace ximd
+{
+
 // Need a class for the "broadcast" constructor (not impelemented).
 // Also helps to avoid overloading `std::array`.
 template <typename T, int N = 4>
 struct Ximd final
 {
     static_assert(std::is_arithmetic<T>::value, "T must be arithmetic");
-    //static_assert(std::is_same<T, std::remove_cv<T>::type>::value, "no `const` for T");
+    // static_assert(std::is_same<T, std::remove_cv<T>::type>::value, "no `const` for T");
 
     using value_type = T;
     using reference = T&;
 
     Ximd() = default;
     // This is the same as the "generater" overload below ... avoid enable_if gunk for now.
-    //template<typename U>
-    //Ximd(U&& v) noexcept
+    // template<typename U>
+    // Ximd(U&& v) noexcept
     //{
     //    *this = Ximd([&](size_t) { return v; });
     //}
-    template<typename U>
-    Ximd& operator=(U&& v) noexcept // work-around missing ctor, above
+    template <typename U>
+    Ximd& operator=(U&& v) noexcept  // work-around missing ctor, above
     {
         *this = Ximd([&](size_t) { return v; });
         return *this;
@@ -83,7 +81,7 @@ struct Ximd final
     {
         *this = other;
     }
-    template<typename U>
+    template <typename U>
     Ximd(const U* mem)
     {
         copy_from(mem);
@@ -141,15 +139,15 @@ struct Ximd final
         return tmp;
     }
 
- private:
+private:
     std::array<value_type, N> value{};
 };
 
-//template<typename T, int N>
-//using fixed_size_ximd = Ximd<T, N>;
+// template<typename T, int N>
+// using fixed_size_ximd = Ximd<T, N>;
 //
-//template<typename T, int N>
-//using native_ximd = Ximd<T>;
+// template<typename T, int N>
+// using native_ximd = Ximd<T>;
 
 using ximd_mask = Ximd<bool>;
 
@@ -175,7 +173,7 @@ inline auto operator-(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noex
 {
     Ximd<T> rhs_;
     rhs_ = rhs;
-    return lhs-  rhs_;
+    return lhs - rhs_;
 }
 template <typename T>
 inline auto operator*(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
@@ -277,7 +275,7 @@ inline bool any_of(const ximd_mask& m)
 template <typename T>
 inline auto atan2(const Ximd<T>& real, const Ximd<T>& imag)
 {
-    return Ximd<T>([&](size_t i) { return std::atan2(imag[i], real[i]); });
+    return Ximd<T>([&](size_t i) { return std::atan2(real[i], imag[i]); });
 }
 template <typename T>
 inline auto round(const Ximd<T>& v)
@@ -285,6 +283,7 @@ inline auto round(const Ximd<T>& v)
     return Ximd<T>([&](size_t i) { return std::round(v[i]); });
 }
 
-} // CODA_OSS_Ximd_namespace
+} // ximd
+} // sys
 
 #endif

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -140,9 +140,23 @@ inline auto operator+(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
     return Ximd<T>([&](size_t i) { return lhs[i] + rhs[i]; });
 }
 template <typename T>
+inline auto operator+(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noexcept
+{
+    Ximd<T> rhs_;
+    rhs_ = rhs;
+    return lhs + rhs_;
+}
+template <typename T>
 inline auto operator-(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
 {
     return Ximd<T>([&](size_t i) { return lhs[i] - rhs[i]; });
+}
+template <typename T>
+inline auto operator-(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noexcept
+{
+    Ximd<T> rhs_;
+    rhs_ = rhs;
+    return lhs-  rhs_;
 }
 template <typename T>
 inline auto operator*(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
@@ -181,6 +195,13 @@ inline auto operator==(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
     return ximd_mask([&](size_t i) { return lhs[i] == rhs[i]; });
 }
 template <typename T>
+inline auto operator==(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noexcept
+{
+    Ximd<T> rhs_;
+    rhs_ = rhs;
+    return lhs == rhs_;
+}
+template <typename T>
 inline auto operator<(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
 {
     return ximd_mask([&](size_t i) { return lhs[i] < rhs[i]; });
@@ -196,6 +217,18 @@ template <typename T>
 inline auto operator<=(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
 {
     return ximd_mask([&](size_t i) { return lhs[i] <= rhs[i]; });
+}
+template <typename T>
+inline auto operator>(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
+{
+    return ximd_mask([&](size_t i) { return lhs[i] > rhs[i]; });
+}
+template <typename T>
+inline auto operator>(const Ximd<T>& lhs, typename Ximd<T>::value_type rhs) noexcept
+{
+    Ximd<T> rhs_;
+    rhs_ = rhs;
+    return lhs > rhs_;
 }
 
 inline bool any_of(const ximd_mask& m)

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -1,0 +1,190 @@
+/* =========================================================================
+ * This file is part of sys-c++ 
+ * =========================================================================
+ * 
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * © Copyright 2024, Maxar Technologies, Inc.
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public 
+ * License along with this program; If not, 
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once 
+
+/*!
+ *  \brief A simple ("poor man's) "implemtation" of std::experimental::simd
+ * for development/testing purposes.
+ *
+ * `std::experimental::simd` needs G++11 and C++20 and the "vectorclass"
+ * library needs C++17.  "Rolling our own" using `std::array` lets developers
+ * try out some things without needing actual SIMD code.
+ *
+ */
+
+#include "Dbg.h"
+
+// This is intended for development/testing purposes, so enable by default only for debug.
+#ifndef CODA_OSS_Ximd_ENABLED
+#define CODA_OSS_Ximd_ENABLED CODA_OSS_DEBUG
+#endif
+
+#if CODA_OSS_Ximd_ENABLED
+
+#include <array>
+
+// By default, we'll put things in the `sys` namespace as everything
+// else here does; but a developer might want to change that.
+#ifndef CODA_OSS_Ximd_namespace
+#define CODA_OSS_Ximd_namespace sys
+#endif
+namespace CODA_OSS_Ximd_namespace
+{
+constexpr size_t native_size = 4;
+
+// Need a class for the "broadcast" constructor.
+// Also helps to avoid overloading `std::array`.
+template <typename T>
+struct Ximd final
+{
+    using value_type = T;
+    using reference = T&;
+
+    Ximd() = default;
+    Ximd(const value_type& v) noexcept
+    {
+        *this = Ximd([&](size_t) { return v; });
+    }
+    template <typename U>
+    Ximd(const Ximd<U>& other) noexcept
+    {
+        *this = other;
+    }
+
+    // https://en.cppreference.com/w/cpp/experimental/simd/simd/simd
+    template <typename G>
+    explicit Ximd(G&& generator) noexcept
+    {
+        for (size_t i = 0; i < value.size(); i++)
+        {
+            value[i] = generator(i);
+        }
+    }
+
+    reference operator[](size_t pos) noexcept
+    {
+        return value[pos];
+    }
+    value_type operator[](size_t pos) const noexcept
+    {
+        return value[pos];
+    }
+
+    constexpr auto size() const noexcept
+    {
+        return value.size();
+    }
+
+    Ximd& operator++() noexcept
+    {
+        *this = Ximd([&](size_t i) { return ++value[i]; });
+        return *this;
+    }
+    Ximd operator++(int) noexcept
+    {
+        auto tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+
+ private:
+    std::array<value_type, native_size> value{};
+};
+
+using ximd_mask = Ximd<bool>;
+
+template <typename T>
+inline auto operator/(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
+{
+    return Ximd<T>([&](size_t i) { return lhs[i] / rhs[i]; });
+}
+
+template <typename T>
+inline auto operator*(const Ximd<T>& lhs, const Ximd<T>& rhs) noexcept
+{
+    return Ximd<T>([&](size_t i) { return lhs[i] * rhs[i]; });
+}
+
+template <typename T>
+inline auto operator-(const Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    return Ximd([&](size_t i) { return lhs[i] - rhs[i]; });
+}
+template <typename T>
+inline auto& operator-=(Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    lhs = Ximd<T>([&](size_t i) {
+                lhs[i] -= rhs[i];
+                return lhs[i];
+            });
+    return lhs;
+}
+
+template <typename T>
+inline auto& operator+=(Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    lhs = Ximd<T>([&](size_t i) {
+                lhs[i] += rhs[i];
+                return lhs[i];
+            });
+    return lhs;
+}
+
+template <typename T>
+inline auto operator+(const Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    return Ximd<T>([&](size_t i) { return lhs[i] + rhs[i]; });
+}
+
+template <typename T>
+inline auto operator==(const Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    return ximd_mask([&](size_t i) { return lhs[i] == rhs[i]; });
+}
+template <typename T>
+inline auto operator<(const Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    return ximd_mask([&](size_t i) { return lhs[i] < rhs[i]; });
+}
+template <typename T>
+inline auto operator<=(const Ximd<T>& lhs, const Ximd<T>& rhs)
+{
+    return ximd_mask([&](size_t i) { return lhs[i] <= rhs[i]; });
+}
+
+inline bool any_of(const ximd_mask& m)
+{
+    for (size_t i = 0; i < m.size(); i++)
+    {
+        if (m[i])
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // CODA_OSS_Ximd_namespace
+
+#endif

--- a/modules/c++/sys/include/sys/Ximd.h
+++ b/modules/c++/sys/include/sys/Ximd.h
@@ -60,7 +60,7 @@ template <typename T, int N = 4>
 struct Ximd final
 {
     static_assert(std::is_arithmetic<T>::value, "T must be arithmetic");
-    static_assert(std::is_same<T, std::remove_cv<T>::type>::value, "no `const` for T");
+    //static_assert(std::is_same<T, std::remove_cv<T>::type>::value, "no `const` for T");
 
     using value_type = T;
     using reference = T&;

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -88,6 +88,26 @@ static inline auto load(std::span<const zfloat> p)
     return make_zfloatv(generate_real, generate_imag);
 }
 
+template<typename T>
+static inline auto store(const sys::Ximd<T>& v)
+{
+    std::vector<typename sys::Ximd<T>::value_type> retval;
+    for (size_t i = 0; i < v.size(); i++)
+    {
+        retval.push_back(v[i]);
+    }
+    return retval;
+}
+static inline auto store(const zfloatv& v)
+{
+    std::vector<zfloat> retval;
+    for (size_t i = 0; i < size(v); i++)
+    {        
+        retval.emplace_back(real(v)[i], imag(v)[i]);
+    }
+    return retval;
+}
+
 TEST_CASE(testDefaultConstructor)
 {
     // sanity check implementation and utility routines
@@ -215,9 +235,10 @@ TEST_CASE(testGetPhase)
     for (auto&& zvaluev : valuesv)
     {
         const auto phase = getPhase(zvaluev, phase_delta());
-        for (size_t i = 0; i < phase.size(); i++)
+        const auto phase_ = store(phase);
+        for (auto&& ph : store(phase))
         {
-            actual.push_back(gsl::narrow_cast<uint8_t>(phase[i]));
+            actual.push_back(gsl::narrow_cast<uint8_t>(ph));
         }
     }
 
@@ -280,9 +301,8 @@ TEST_CASE(testLookup)
         const auto phase = getPhase(zvaluev, phase_delta());
         const auto phase_direction = lookup<AmplitudeTableSize>(phase, phase_directions);
 
-        for (size_t i = 0; i < size(phase_direction); i++)
+        for (auto&& pd : store(phase_direction))
         {
-            const auto pd = phase_directions[phase[i]];
             actual.push_back(pd);
         }
     }

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -1,0 +1,39 @@
+/* =========================================================================
+ * This file is part of sys-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * © Copyright 2024, Maxar Technologies, Inc.
+ *
+ * sys-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <sys/Ximd.h>
+
+#include "TestCase.h"
+
+TEST_CASE(testDefaultConstructor)
+{
+    sys::Ximd<int> v = 1;
+    for (size_t i = 0; i < v.size(); i++)
+    {
+        TEST_ASSERT_EQ(1, v[i]);
+    }
+}
+
+TEST_MAIN(
+    TEST_CHECK(testDefaultConstructor);
+)

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -157,14 +157,14 @@ static inline auto if_add(const floatv_mask& m, const floatv& lhs, typename floa
     const auto generate_add = [&](size_t i) {
         return m[i] ? lhs[i] + rhs : lhs[i];
     };
-    return floatv(generate_add);
+    return floatv::generate(generate_add);
 }
 static inline auto roundi(const floatv& v)  // match vcl::roundi()
 {
     const auto rounded = round(v);
     const auto generate_roundi = [&](size_t i)
     { return static_cast<typename intv::value_type>(rounded[i]); };
-    return intv(generate_roundi);
+    return intv::generate(generate_roundi);
 }
 static auto getPhase(const zfloatv& v, float phase_delta)
 {
@@ -439,7 +439,7 @@ static auto lookup(const intv& zindex, std::span<const float> magnitudes)
         }
         return NAN; // propogate "don't care"
     };
-    return floatv(generate);
+    return floatv::generate(generate);
 }
 
 static inline auto lower_bound_(std::span<const float> magnitudes, const floatv& v)

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -26,7 +26,12 @@
 #include <std/span>
 #include <std/numbers>
 
+// These are unittests, always enable unless explicitly disabled
+#ifndef CODA_OSS_Ximd_ENABLED
+#define CODA_OSS_Ximd_ENABLED 1
+#endif
 #include <sys/Ximd.h>
+
 #include <gsl/gsl.h>
 #include <sys/Span.h>
 
@@ -447,14 +452,7 @@ static inline auto lower_bound_(std::span<const float> magnitudes, const floatv&
 }
 static inline auto lower_bound(std::span<const float> magnitudes, const floatv& value)
 {
-    auto retval = lower_bound_(magnitudes, value);
-    for (size_t i = 0; i < value.size(); i++)
-    {
-        const auto it = std::lower_bound(magnitudes.begin(), magnitudes.end(), value[i]);
-        const auto result = gsl::narrow<int>(std::distance(magnitudes.begin(), it));
-        assert(retval[i] == result);
-    }
-    return retval;
+    return lower_bound_(magnitudes, value);
 }
 
 static auto nearest(std::span<const float> magnitudes, const floatv& value)
@@ -497,12 +495,6 @@ static auto find_nearest(std::span<const float> magnitudes, const floatv& phase_
     // the complex value onto the ray of candidate magnitudes at the selected phase.
     // i.e. dot product.
     const auto projection = (phase_direction_real * real(v)) + (phase_direction_imag * imag(v));
-    for (size_t i = 0; i < projection.size(); i++)
-    {
-        const auto p = (phase_direction_real[i] * real(v)[i]) + (phase_direction_imag[i] * imag(v)[i]);
-        assert(p == projection[i]);
-    }
-
     //assert(std::abs(projection - std::abs(v)) < 1e-5); // TODO ???
     return nearest(magnitudes, projection);
 }

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -133,7 +133,7 @@ TEST_CASE(testDefaultConstructor)
 }
 
 // Sample code from SIX; see **ComplexToAMP8IPHS8I.cpp**.
-static inline auto GetPhase(std::complex<double> v)
+static auto GetPhase(std::complex<double> v)
 {
     // There's an intentional conversion to zero when we cast 256 -> uint8. That wrap around
     // handles cases that are close to 2PI.
@@ -162,7 +162,7 @@ static inline auto roundi(const floatv& v)  // match vcl::roundi()
     { return static_cast<typename intv::value_type>(rounded[i]); };
     return intv(generate_roundi);
 }
-static inline auto getPhase(const zfloatv& v, float phase_delta)
+static auto getPhase(const zfloatv& v, float phase_delta)
 {
     // Phase is determined via arithmetic because it's equally spaced.
     // There's an intentional conversion to zero when we cast 256 -> uint8. That wrap around
@@ -172,10 +172,12 @@ static inline auto getPhase(const zfloatv& v, float phase_delta)
     phase = if_add(phase < 0.0f, phase, std::numbers::pi_v<float> * 2.0f); // Wrap from [0, 2PI]
     return roundi(phase / phase_delta);
 }
-
-static const auto& cxValues()
+static inline const auto& cxValues()
 {
-    static const std::vector<zfloat> retval{/*{0, 0},*/ {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}, {0, -1}, {1, -1}};
+    //static const std::vector<zfloat> retval{/*{0, 0},*/ {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}, {0, -1}, {1, -1}};
+    static const std::vector<zfloat> retval{{0.0, 0.0}, {1.0, 1.0}, {10.0, -10.0}, {-100.0, 100.0}, {-1000.0, -1000.0}, // sample data from SIX
+            {-1.0, -1.0}, {1.0, -1.0}, {-1.0, 1.0} // "pad" to multiple of floatv::size()
+    };
     return retval;
 }
 
@@ -276,7 +278,7 @@ static auto getPhaseDirections_()
     }
     return phase_directions;
 }
-static const auto& getPhaseDirections()
+static inline const auto& getPhaseDirections()
 {
     static const auto retval = getPhaseDirections_();
     return retval;
@@ -372,7 +374,7 @@ static auto make_magnitudes_()
     std::copy(result.begin(), result.end(), retval.begin());
     return retval;
 }
-static std::span<const float> magnitudes()
+static inline std::span<const float> magnitudes()
 {
     //! The sorted set of possible magnitudes order from small to large.
     static const auto cached_magnitudes = make_magnitudes_();
@@ -411,12 +413,12 @@ static uint8_t find_nearest(zfloat phase_direction, zfloat v)
 }
 
 template<typename TTest, typename TResult>
-static inline auto select(const TTest& test_, const TResult& t, const TResult& f)
+static inline auto select(const TTest& test, const TResult& t, const TResult& f)
 {
     TResult retval;
-    for (size_t i = 0; i < test_.size(); i++)
+    for (size_t i = 0; i < test.size(); i++)
     {
-        retval[i] = test_[i] ? t[i] : f[i];
+        retval[i] = test[i] ? t[i] : f[i];
     }
     return retval;
 }

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -433,7 +433,7 @@ static auto lookup(const intv& zindex, std::span<const float> magnitudes)
         const auto i_ = zindex[i];
         
         // The index may be out of range. This is expected because `i` might be "don't care."
-        if ((i_ >= 0) && (i_ < magnitudes.size()))
+        if ((i_ >= 0) && (i_ < ssize(magnitudes)))
         {
             return magnitudes[i_];
         }

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -21,19 +21,183 @@
  *
  */
 
+#include <complex>
+#include <vector>
+#include <std/span>
+#include <std/numbers>
+
 #include <sys/Ximd.h>
+#include <gsl/gsl.h>
+#include <sys/Span.h>
 
 #include "TestCase.h"
 
+using zfloat = std::complex<float>;
+
+using intv = sys::Ximd<int>;
+using floatv = sys::Ximd<float>;
+
+// Manage a SIMD complex as an array of two SIMDs
+using zfloatv = std::array<floatv, 2>;
+static inline auto& real(zfloatv& z) noexcept
+{
+    return z[0];
+}
+static inline const auto& real(const zfloatv& z) noexcept
+{
+    return z[0];
+}
+static inline auto& imag(zfloatv& z) noexcept
+{
+    return z[1];
+}
+static inline const auto& imag(const zfloatv& z) noexcept
+{
+    return z[1];
+}
+static inline size_t size(const zfloatv& z) noexcept
+{
+    auto retval = real(z).size();
+    assert(retval == imag(z).size());
+    return retval;
+}
+
+static inline auto arg(const zfloatv& z)
+{
+    // https://en.cppreference.com/w/cpp/numeric/complex/arg
+    // > `std::atan2(std::imag(z), std::real(z))`
+    return atan2(real(z), imag(z));  // arg()
+}
+
+template <typename TGeneratorReal, typename TGeneratorImag>
+static inline auto make_zfloatv(TGeneratorReal&& generate_real, TGeneratorImag&& generate_imag)
+{
+    zfloatv retval;
+    for (size_t i = 0; i < size(retval); i++)
+    {
+        real(retval)[i] = generate_real(i);
+        imag(retval)[i] = generate_imag(i);
+    }
+    return retval;
+}
+
+static inline auto load(std::span<const zfloat> p)
+{
+    const auto generate_real = [&](size_t i) { return p[i].real(); };
+    const auto generate_imag = [&](size_t i) { return p[i].imag(); };
+    return make_zfloatv(generate_real, generate_imag);
+}
+
 TEST_CASE(testDefaultConstructor)
 {
-    sys::Ximd<int> v = 1;
+    // sanity check implementation and utility routines
+    TEST_ASSERT_EQ(floatv::size(), size(zfloatv{}));
+
+    // intv v = 1;
+    intv v;
+    v = 1;
     for (size_t i = 0; i < v.size(); i++)
     {
         TEST_ASSERT_EQ(1, v[i]);
     }
 }
 
+// Sample code from SIX; see **ComplexToAMP8IPHS8I.cpp**.
+static inline auto GetPhase(std::complex<double> v)
+{
+    // There's an intentional conversion to zero when we cast 256 -> uint8. That wrap around
+    // handles cases that are close to 2PI.
+    double phase = std::arg(v);
+    if (phase < 0.0) phase += coda_oss::numbers::pi * 2.0; // Wrap from [0, 2PI]
+    return phase;
+}
+static uint8_t getPhase(zfloat v, float phase_delta)
+{
+    // Phase is determined via arithmetic because it's equally spaced.
+    const auto phase = GetPhase(v);
+    return gsl::narrow_cast<uint8_t>(std::round(phase / phase_delta));
+}
+
+static inline auto if_add(const sys::ximd_mask& m, const floatv lhs, typename floatv::value_type rhs)
+{
+    const auto generate_add = [&](size_t i) {
+        return m[i] ? lhs[i] + rhs : lhs[i];
+    };
+    return floatv(generate_add);
+}
+static inline auto roundi(const floatv& v)  // match vcl::roundi()
+{
+    const auto rounded = round(v);
+    const auto generate_roundi = [&](size_t i)
+    { return static_cast<typename intv::value_type>(rounded[i]); };
+    return intv(generate_roundi);
+}
+static inline auto getPhase(const zfloatv& v, float phase_delta)
+{
+    // Phase is determined via arithmetic because it's equally spaced.
+    // There's an intentional conversion to zero when we cast 256 -> uint8. That wrap around
+    // handles cases that are close to 2PI.
+    auto phase = arg(v);
+    //where(phase < 0.0f, phase) += std::numbers::pi_v<float> *2.0f; // Wrap from [0, 2PI]
+    phase = if_add(phase < 0.0f, phase, std::numbers::pi_v<float> * 2.0f); // Wrap from [0, 2PI]
+    return roundi(phase / phase_delta);
+}
+
+static const std::vector<zfloat>& cxValues()
+{
+    static const std::vector<zfloat> retval{/*{0, 0},*/ {1, 0}, {1, 1}, {0, 1}, {-1, 1}, {-1, 0}, {-1, -1}, {0, -1}, {1, -1}};
+    return retval;
+}
+
+static auto expected_getPhase_values(const std::string& testName, float phase_delta)
+{
+    auto&& values = cxValues();
+    TEST_ASSERT(values.size() % floatv::size() == 0);
+    std::vector<uint8_t> expected;
+    expected.reserve(values.size());
+    for (auto&& v : values)
+    {
+        expected.push_back(getPhase(v, phase_delta));
+    }
+    return expected;
+}
+
+TEST_CASE(testGetPhase)
+{
+    constexpr auto phase_delta = 0.01f;
+    static const auto expected = expected_getPhase_values(testName, phase_delta);
+
+    std::vector<zfloatv> valuesv;
+    constexpr auto sz = floatv::size();
+    auto&& values = cxValues();
+    auto const pValues = sys::make_span(values);
+    auto p = sys::make_span(pValues.data(), sz);
+    for (size_t i = 0; i < values.size() / sz; i++)
+    {
+        valuesv.push_back(load(p));
+        p = sys::make_span(p.data() + sz, p.size());
+    }
+
+    std::vector<uint8_t> actual;
+    for (auto&& zvaluev : valuesv)
+    {
+        const auto phase = getPhase(zvaluev, phase_delta);
+        for (size_t i = 0; i < phase.size(); i++)
+        {
+            actual.push_back(gsl::narrow_cast<uint8_t>(phase[i]));
+        }
+    }
+
+    TEST_ASSERT_EQ(actual.size(), expected.size());
+    for (size_t i = 0; i < actual.size(); i++)
+    {
+        TEST_ASSERT_EQ(actual[i], expected[i]);
+    }
+}
+
+
 TEST_MAIN(
     TEST_CHECK(testDefaultConstructor);
+
+    TEST_CHECK(testGetPhase);
 )

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -433,7 +433,7 @@ static auto lookup(const intv& zindex, std::span<const float> magnitudes)
         const auto i_ = zindex[i];
         
         // The index may be out of range. This is expected because `i` might be "don't care."
-        if ((i_ >= 0) && (i_ < ssize(magnitudes)))
+        if ((i_ >= 0) && (i_ < std::ssize(magnitudes)))
         {
             return magnitudes[i_];
         }

--- a/modules/c++/sys/unittests/test_ximd.cpp
+++ b/modules/c++/sys/unittests/test_ximd.cpp
@@ -39,8 +39,12 @@
 
 using zfloat = std::complex<float>;
 
-using intv = sys::Ximd<int>;
-using floatv = sys::Ximd<float>;
+template<typename T>
+using simd = sys::ximd::Ximd<T>;
+using intv = simd<int>;
+using floatv = simd<float>;
+using intv_mask = sys::ximd::ximd_mask;
+using floatv_mask = sys::ximd::ximd_mask;
 
 // Manage a SIMD complex as an array of two SIMDs
 using zfloatv = std::array<floatv, 2>;
@@ -71,7 +75,7 @@ static inline auto arg(const zfloatv& z)
 {
     // https://en.cppreference.com/w/cpp/numeric/complex/arg
     // > `std::atan2(std::imag(z), std::real(z))`
-    return atan2(real(z), imag(z));  // arg()
+    return atan2(imag(z), real(z));  // arg()
 }
 
 template <typename TGeneratorReal, typename TGeneratorImag>
@@ -89,7 +93,7 @@ static inline auto make_zfloatv(TGeneratorReal&& generate_real, TGeneratorImag&&
 template <typename T>
 static inline auto copy_from(std::span<const T> p)
 {
-    sys::Ximd<T> retval;
+    simd<T> retval;
     assert(p.size() == retval.size());
     retval.copy_from(p.data());
     return retval;
@@ -102,9 +106,9 @@ static inline auto copy_from(std::span<const zfloat> p)
 }
 
 template<typename T>
-static inline auto copy_to(const sys::Ximd<T>& v)
+static inline auto copy_to(const simd<T>& v)
 {
-    std::vector<typename sys::Ximd<T>::value_type> retval(v.size());
+    std::vector<typename simd<T>::value_type> retval(v.size());
     v.copy_to(retval.data());
     return retval;
 }
@@ -148,7 +152,7 @@ static uint8_t getPhase(zfloat v, float phase_delta)
     return gsl::narrow_cast<uint8_t>(std::round(phase / phase_delta));
 }
 
-static inline auto if_add(const sys::ximd_mask& m, const floatv& lhs, typename floatv::value_type rhs)
+static inline auto if_add(const floatv_mask& m, const floatv& lhs, typename floatv::value_type rhs)
 {
     const auto generate_add = [&](size_t i) {
         return m[i] ? lhs[i] + rhs : lhs[i];


### PR DESCRIPTION
[std::experimental::simd}(https://en.cppreference.com/w/cpp/experimental/simd) is currently targeted for C++26 🤞🏻.

In the meantime, it's fairly easy to hook up a simple version by using `std::array<T, 4>`; and thanks to auto-vectorization, performance isn't abysmal.
