### PR TITLE
add back transform_async() as Transform_par()

### DIFF
--- a/UnitTest/mt.cpp
+++ b/UnitTest/mt.cpp
@@ -1,6 +1,8 @@
 #include "pch.h"
 #include "CppUnitTest.h"
 
+#include <sys/ByteSwap.h>
+
 #include <mt/CriticalSection.h>
 #include <mt/ThreadPlanner.h>
 #include <mt/ThreadGroup.h>
@@ -11,6 +13,7 @@
 #include <mt/ThreadPoolException.h>
 #include <mt/GenerationThreadPool.h>
 #include <mt/ThreadedByteSwap.h>
+#include <mt/Algorithm.h>
 
 namespace mt
 {

--- a/modules/c++/mt/include/mt/Algorithm.h
+++ b/modules/c++/mt/include/mt/Algorithm.h
@@ -20,22 +20,73 @@
  *
  */
 
-#ifndef CODA_OSS_mt_Algorithm_h_INCLUDED_
-#define CODA_OSS_mt_Algorithm_h_INCLUDED_
 #pragma once
 
 #include <algorithm>
 #include <iterator>
 #include <future>
 
+#include "coda_oss/CPlusPlus.h"
+#if CODA_OSS_cpp17
+	// <execution> is broken with the older version of GCC we're using
+	#if (__GNUC__ >= 10) || _MSC_VER
+	#include <execution>
+	#define CODA_OSS_mt_Algorithm_has_execution 1
+	#endif
+#endif
+
 namespace mt
 {
-// There was a transform_async() utility here, but I removed it.
-//
-// First of all, C++11's std::async() is now (in 2023) thought of as maybe a
-// bit "half baked," and perhaps shouldn't be emulated.  Then, C++17 added
-// parallel algorithms which might be a better ... although we're still at C++14.
+// "Roll our own" `std::transform(execution::par)` using std::async()
+// https://en.cppreference.com/w/cpp/algorithm/transform
+
+// Our own `Transform_par_()` is built on `std::async()`; for that we need to control
+// a couple of settings.
+struct Transform_par_settings final
+{
+    Transform_par_settings() = default;
+
+    Transform_par_settings(ptrdiff_t cutoff) : cutoff_(cutoff) { }
+    Transform_par_settings(std::launch policy) : policy_(policy) { }
+    Transform_par_settings(ptrdiff_t cutoff, std::launch policy) : cutoff_(cutoff), policy_(policy) { }
+    Transform_par_settings(std::launch policy, ptrdiff_t cutoff) : Transform_par_settings(cutoff, policy) { }
+
+    // The value of "default_cutoff" was determined by testing; there is nothing
+    // special about it, feel free to change it.
+    static constexpr ptrdiff_t dimension = 128 * 8;
+    static constexpr ptrdiff_t default_cutoff = dimension * dimension;
+    ptrdiff_t cutoff_ =  default_cutoff;
+
+    // https://en.cppreference.com/w/cpp/thread/launch
+    std::launch policy_ = std::launch::async; // "the task is executed on a different thread, potentially by creating and launching it first"
+};
+
+template <typename InputIt, typename OutputIt, typename UnaryOperation>
+inline OutputIt Transform_par_(InputIt first1, InputIt last1, OutputIt d_first, UnaryOperation unary_op,
+    const Transform_par_settings& settings)
+{
+    // https://en.cppreference.com/w/cpp/thread/async
+    const auto len = std::distance(first1, last1);
+    if (len < settings.cutoff_)
+    {
+        return std::transform(first1, last1, d_first, unary_op);
+    }
+    
+    const auto mid1 = first1 + len / 2;
+    const auto d_mid = d_first + len / 2;
+    auto handle = std::async(settings.policy_, Transform_par_<InputIt, OutputIt, UnaryOperation>, mid1, last1, d_mid, unary_op, settings);
+    Transform_par_(first1, mid1, d_first, unary_op, settings);
+    return handle.get();
+}
+template <typename InputIt, typename OutputIt, typename UnaryOperation>
+inline OutputIt Transform_par(InputIt first1, InputIt last1, OutputIt d_first, UnaryOperation unary_op,
+    Transform_par_settings settings = Transform_par_settings{})
+{
+#if CODA_OSS_mt_Algorithm_has_execution
+    return std::transform(std::execution::par, first1, last1, d_first, unary_op);
+#else
+    return Transform_par_(first1, last1, d_first, unary_op, settings);
+#endif // CODA_OSS_mt_Algorithm_has_execution
 }
 
-#endif // CODA_OSS_mt_Algorithm_h_INCLUDED_
-
+}


### PR DESCRIPTION
Provide `mt::Transfor_par()` as a work-around for not having `std::transform(par, ...)` until C++17,