### PR TITLE
Windows Build enhancements

### DIFF
--- a/modules/c++/include/TestCase.h
+++ b/modules/c++/include/TestCase.h
@@ -215,7 +215,7 @@ inline int main(TFunc f)
 #define CODA_OSS_test_ne_(X1, X2) (((X1) != (X2)) && ((X2) != (X1))) // X1 != X2 means X2 != X1
 #define CODA_OSS_test_ne(X1, X2) (CODA_OSS_test_ne_(X1, X2) && !CODA_OSS_test_eq_(X1, X2))
 #define CODA_OSS_test_eq(X1, X2) (CODA_OSS_test_eq_(X1, X2) && !CODA_OSS_test_ne_(X1, X2))
-#define TEST_ASSERT_EQ(X1, X2) if (!CODA_OSS_test_eq((X1), (X2))) { CODA_OSS_test_diePrintf_eq_(X1, X2); }
+#define TEST_ASSERT_EQ(X1, X2) do { bool expr(CODA_OSS_test_eq((X1), (X2))); if (!expr) { CODA_OSS_test_diePrintf_eq_(X1, X2); } } while (0);
 #define TEST_ASSERT_EQ_MSG(msg, X1, X2) if (!CODA_OSS_test_eq((X1), (X2))) { CODA_OSS_test_diePrintf_eq_msg_(msg, X1, X2); }
 #define TEST_ASSERT_EQ_STR(X1, X2) TEST_ASSERT_EQ(std::string(X1), std::string(X2))
 #define TEST_ASSERT_NOT_EQ(X1, X2) if (!CODA_OSS_test_ne((X1), (X2))) { CODA_OSS_test_diePrintf_not_eq_(X1, X2); }

--- a/modules/c++/sys/source/OSWin32.cpp
+++ b/modules/c++/sys/source/OSWin32.cpp
@@ -357,6 +357,7 @@ void sys::OSWin32::getAvailableCPUs(std::vector<int>& /*physicalCPUs*/,
 sys::SIMDInstructionSet sys::OSWin32::getSIMDInstructionSet() const
 {
     // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-isprocessorfeaturepresent
+#if _MSC_VER >= 1920
     if (IsProcessorFeaturePresent(PF_AVX512F_INSTRUCTIONS_AVAILABLE))
     {
         return SIMDInstructionSet::AVX512F;
@@ -365,6 +366,7 @@ sys::SIMDInstructionSet sys::OSWin32::getSIMDInstructionSet() const
     {
         return SIMDInstructionSet::AVX2;
     }
+#endif
     if (IsProcessorFeaturePresent(PF_XMMI64_INSTRUCTIONS_AVAILABLE))
     {
         return SIMDInstructionSet::SSE2;


### PR DESCRIPTION
- Fix AVX compilation errors on older MS compilers
- Fix `C4127: Conditional Expression is Constant` error on newer MS Compilers