### PR TITLE
Allowed derived classes of SwapBuffer

### DIFF
--- a/modules/c++/mem/include/mem/SwapBuffer.h
+++ b/modules/c++/mem/include/mem/SwapBuffer.h
@@ -47,7 +47,7 @@ namespace mem
  *        returned from the get* methods, which would segfault when 
  *        the ScopedAlignedArrays go out of scope.
  */
-struct SwapBuffer final
+struct SwapBuffer
 {
     /*!
      *  Allocate the buffers to the size needed --
@@ -120,7 +120,7 @@ struct SwapBuffer final
     }
 
     //! Swap the buffers
-    void swap() 
+    virtual void swap()
     {
         std::swap(mValid, mScratch);
     }


### PR DESCRIPTION
Allow derived classes that offer additional functionality (such as locking)