### PR TITLE
Changes the default value for 'install_pydir'

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -1271,7 +1271,7 @@ def configure(self):
     env['install_libdir'] = Options.options.libdir if Options.options.libdir else join(Options.options.prefix, 'lib')
     env['install_bindir'] = Options.options.bindir if Options.options.bindir else join(Options.options.prefix, 'bin')
     env['install_sharedir'] = Options.options.sharedir if Options.options.sharedir else join(Options.options.prefix, 'share')
-    env['install_pydir'] = Options.options.pydir if Options.options.pydir else '${PYTHONDIR}'
+    env['install_pydir'] = Options.options.pydir if Options.options.pydir else join(Options.options.prefix, 'lib/python/site-packages')
 
     # Swig memory leak output
     if Options.options.swig_silent_leak:

--- a/modules/c++/net/wscript
+++ b/modules/c++/net/wscript
@@ -4,7 +4,7 @@ NAME            = 'net'
 MAINTAINER      = 'jmrandol@users.sourceforge.net'
 VERSION         = '1.0'
 MODULE_DEPS     = 'logging re mt io mem'
-USELIB          = 'NSL SOCKET'
+USELIB          = 'SOCKET'
 USE             = 'CURL'
 TEST_FILTER     = 'AckMulticastSender.cpp ' \
                   'AckMulticastSubscriber.cpp ' \

--- a/modules/drivers/xml/xerces/wscript
+++ b/modules/drivers/xml/xerces/wscript
@@ -106,8 +106,6 @@ def configure(conf):
                 conf.check_cc(function_name='ftime', header_name="sys/timeb.h", mandatory=False)
                 conf.check_cc(function_name='getaddrinfo', header_name="netdb.h", mandatory=False)
 
-                conf.check_cc(lib="nsl", mandatory=False, uselib_store='NSL')
-
                 conf.check_cc(header_name="unistd.h", mandatory=False)
                 conf.check_cc(header_name="sys/time.h", mandatory=False)
                 conf.check_cc(header_name="limits.h", mandatory=False)


### PR DESCRIPTION
When building changes I had made in coda I was getting an error something like `unable to create directory /test_utils`. With the help of Eric Williams and Charles Vink I tracked the problem down to the fact that build.py was relying on the PYTHONDIR variable being defined if `--pydir` was not specified during the configure stage. This fork removes that assumption and changes the default to `join(Options.options.prefix, 'lib/python/site-packages')`. This allows things to build without error without specifying `--pydir`.

I also found when building code under RHEL 8 I encountered an issue that the NSL libraries couldn't be found but are there. I found that removing the search works in both RHEL 7 and 8 so I'm proposing that change also.

I'm not sure how to test this change purely in coda-oss but I have tested it when building coda with this change.

@chvink 