### PR TITLE
Make fixed polys more user friendly

### DIFF
--- a/modules/c++/math.poly/include/math/poly/Fixed1D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed1D.h
@@ -65,7 +65,7 @@ public:
         // Initialize coefficents;
         for (size_t i = 0; i < _Order+1; i++)
         {
-            mCoef[i] = _T(0.0);
+            mCoef[i] = _T{};
         }
     }
 
@@ -175,7 +175,7 @@ public:
      */
     _T operator() (double at) const
     {
-        _T rv(0.0);
+        _T rv{};
         double atPower = 1;
 
         for (size_t i = 0; i <= _Order; i++)
@@ -192,7 +192,7 @@ public:
      */
     _T integrate(double start, double end) const
     {
-        _T rv(0.0);
+        _T rv{};
         double div;
         double newCoef;
         double endAtPower = end;

--- a/modules/c++/math.poly/include/math/poly/Fixed1D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed1D.h
@@ -23,6 +23,8 @@
 #ifndef __MATH_POLY_FIXED_1D_H__
 #define __MATH_POLY_FIXED_1D_H__
 
+#include <array>
+
 #include <import/except.h>
 #include <import/sys.h>
 #include <math/poly/OneD.h>
@@ -51,7 +53,7 @@ namespace poly
 template <size_t _Order, typename _T=double> class Fixed1D
 {
 protected:
-    _T mCoef[_Order+1];
+    std::array<_T, _Order+1> mCoef;
 public:
 
    /*!
@@ -63,7 +65,7 @@ public:
         // Initialize coefficents;
         for (size_t i = 0; i < _Order+1; i++)
         {
-            mCoef[i] = 0;
+            mCoef[i] = _T(0.0);
         }
     }
 
@@ -81,6 +83,41 @@ public:
         }
     }
 
+    /*!
+    * Construct from C array
+    */
+    Fixed1D(const _T* coeffs, const size_t nCoeff)
+    {
+        size_t sizeC = std::min<size_t>(nCoeff, _Order);
+        for (size_t i = 0; i <= sizeC; i++)
+        {
+            mCoef[i] = coeffs[i];
+        }
+    }
+
+    /*!
+    * Construct from std::array
+    */
+    template<size_t O> Fixed1D(const std::array<_T, O>& coeffs)
+    {
+        size_t sizeC = std::min<size_t>(O, _Order);
+        for (size_t i = 0; i <= sizeC; i++)
+        {
+            mCoef[i] = coeffs[i];
+        }
+    }
+
+    /*!
+    * Construct from std::vector
+    */
+    Fixed1D(const std::vector<_T>& coeffs)
+    {
+        size_t sizeC = std::min<size_t>(coeffs.size()-1, _Order);
+        for (size_t i = 0; i <= sizeC; i++)
+        {
+            mCoef[i] = coeffs[i];
+        }
+    }
     /*!
      *  Unlike the non-fixed size poly, this constructor
      *  will truncate higher orders.  This allows us to do something like
@@ -138,7 +175,7 @@ public:
      */
     _T operator() (double at) const
     {
-        double rv(0);
+        _T rv(0.0);
         double atPower = 1;
 
         for (size_t i = 0; i <= _Order; i++)
@@ -155,7 +192,7 @@ public:
      */
     _T integrate(double start, double end) const
     {
-        _T rv(0);
+        _T rv(0.0);
         double div;
         double newCoef;
         double endAtPower = end;
@@ -169,7 +206,6 @@ public:
             rv -= newCoef * startAtPower;
             endAtPower *= end;
             startAtPower *= start;
-
         }
         return rv;
     }
@@ -214,6 +250,15 @@ public:
 
         return mCoef[i];
 
+    }
+    inline const std::array<_T, _Order+1>& coeffs() const
+    {
+        return mCoef;
+    }
+
+    inline std::array<_T, _Order+1>& coeffs()
+    {
+        return mCoef;
     }
 
 

--- a/modules/c++/math.poly/include/math/poly/Fixed2D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed2D.h
@@ -107,7 +107,7 @@ public:
 
     inline _T operator()(double atX, double atY) const
     {
-        _T rv(0);
+        _T rv{};
         double atXPower(1);
 
         for (size_t i = 0; i <= _OrderX; i++)
@@ -120,7 +120,7 @@ public:
     }
     _T integrate(double startX, double endX, double startY, double endY) const
     {
-        _T rv(0);
+        _T rv{};
         double div(0);
         double endAtPower = endX;
         double startAtPower = startX;

--- a/modules/c++/math.poly/include/math/poly/Fixed2D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed2D.h
@@ -23,6 +23,7 @@
 #ifndef __MATH_POLY_FIXED_2D_H__
 #define __MATH_POLY_FIXED_2D_H__
 
+#include <array>
 #include <math/poly/Fixed1D.h>
 #include <math/poly/TwoD.h>
 #include <math/poly/Utils.h>
@@ -40,7 +41,7 @@ namespace poly
 template<size_t _OrderX, size_t _OrderY, typename _T=double> class Fixed2D
 {
 protected:
-    Fixed1D<_OrderY, _T> mCoef[_OrderX+1];
+    std::array<Fixed1D<_OrderY, _T>, _OrderX+1> mCoef;
 public:
     Fixed2D() {}
 
@@ -93,6 +94,16 @@ public:
 
     size_t orderX() const { return _OrderX; }
     size_t orderY() const { return _OrderY; }
+
+    inline const std::array<Fixed1D<_OrderY, _T>, _OrderX+1>& coeffs() const
+    {
+        return mCoef;
+    }
+
+    inline std::array<Fixed1D<_OrderY, _T>, _OrderX+1>& coeffs()
+    {
+        return mCoef;
+    }
 
     inline _T operator()(double atX, double atY) const
     {


### PR DESCRIPTION
Make the coefficients of the `Fixed1D` and `Fixed2D` polynomials `std::array<T, Order>` instead of `T[Order]` so that the coefficients can be returned. Added a few constructors to the `Fixed1D` type.