### PR TITLE
Change logging timestamp format

### DIFF
--- a/modules/c++/avx/include/avx/extractf.h
+++ b/modules/c++/avx/include/avx/extractf.h
@@ -4,6 +4,7 @@
  *
  * (C) Copyright 2004 - 2019, MDA Information Systems LLC
  * (C) Copyright 2021, Maxar Technologies, Inc.
+ * (C) Copyright 2025, Arka Group, L.P.
  *
  * config-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -26,6 +27,7 @@
 
 #include <config/compiler_extensions.h>
 
+#ifdef __AVX__
 #ifndef CODA_OSS_mm256_extractf_DEFINED_
     #define CODA_OSS_mm256_extractf_DEFINED_ 1
 
@@ -52,6 +54,7 @@
         }
     }
 
+#endif
 #endif
 
 #endif  // CODA_OSS_avx_extractf_h_INCLUDED_

--- a/modules/c++/sys/include/sys/Conf.h
+++ b/modules/c++/sys/include/sys/Conf.h
@@ -4,6 +4,7 @@
  *
  * (C) Copyright 2004 - 2014, MDA Information Systems LLC
  * (C) Copyright 2021, Maxar Technologies, Inc.
+ * (C) Copyright 2025, Arka Group, L.P.
  *
  * sys-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -33,7 +34,7 @@
 // POSIX is more-or-less "Unix"
 // https://linux.die.net/man/7/feature_test_macros
 // "If no feature test macros are explicitly defined, then the following feature test macros
-// are defined by default: ... _POSIX_SOURCE, and _POSIX_C_SOURCE=200809L. [...] 
+// are defined by default: ... _POSIX_SOURCE, and _POSIX_C_SOURCE=200809L. [...]
 // _POSIX_SOURCE Defining this obsolete macro ... is equivalent to defining _POSIX_C_SOURCE ..."
 #ifndef _WIN32
 #include <features.h>
@@ -159,7 +160,7 @@ namespace sys
 #define SYS_FUNC NativeLayer_func__
 
 #define Ctxt(MESSAGE) except::Context(__FILE__, __LINE__, SYS_FUNC, \
-        sys::TimeStamp().local(), MESSAGE)
+        sys::TimeStamp(true).local(), MESSAGE)
 
 namespace sys
 {

--- a/modules/c++/sys/include/sys/TimeStamp.h
+++ b/modules/c++/sys/include/sys/TimeStamp.h
@@ -1,8 +1,9 @@
 /* =========================================================================
- * This file is part of sys-c++ 
+ * This file is part of sys-c++
  * =========================================================================
- * 
+ *
  * (C) Copyright 2004 - 2014, MDA Information Systems LLC
+ * (C) Copyright 2025, Arka Group, L.P.
  *
  * sys-c++ is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -14,8 +15,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
  *
- * You should have received a copy of the GNU Lesser General Public 
- * License along with this program; If not, 
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
  * see <http://www.gnu.org/licenses/>.
  *
  */
@@ -33,7 +34,7 @@
 /*!
  *  \file  TimeStamp.h
  *  \brief Get a timestamp in a system-independent manner
- * 
+ *
  *  Provide the API for timestamps
  */
 
@@ -66,7 +67,10 @@ struct TimeStamp final
     std::string local() const
     {
         sys::LocalDateTime dt;
-        return dt.format(getFormat());
+        std::string base = dt.format(getFormat());
+
+        double fracSec = fmod(dt.getSecond(), 1);
+        return base + FmtX(".%03.0f", fracSec * 1000);
     }
 
     /*!
@@ -76,7 +80,10 @@ struct TimeStamp final
     std::string gmt() const
     {
         sys::UTCDateTime dt;
-        return dt.format(getFormat());
+        std::string base = dt.format(getFormat());
+
+        double fracSec = fmod(dt.getSecond(), 1);
+        return base + FmtX(".%03.0f", fracSec * 1000);
     }
 
 private:


### PR DESCRIPTION
Change logging timestamp format to include milliseconds and be consistent between Ctxt and non-Ctxt messages