### PR TITLE
Add explicit implementations of polynomial velocity and acceleration

### DIFF
--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -168,7 +168,9 @@ jobs:
   build-waf:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-22.04]
+        os: [
+            # BROKEN: windows-latest, 
+            ubuntu-22.04]
         python-version: ['3.7']
         debugging: ['--enable-debugging', '']
     name: ${{ matrix.os }}-${{ matrix.python-version }}-waf${{ matrix.debugging }}

--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -168,7 +168,7 @@ jobs:
   build-waf:
     strategy:
       matrix:
-        os: [windows-2019, ubuntu-22.04]
+        os: [ubuntu-22.04]
         python-version: ['3.7']
         debugging: ['--enable-debugging', '']
     name: ${{ matrix.os }}-${{ matrix.python-version }}-waf${{ matrix.debugging }}
@@ -187,12 +187,6 @@ jobs:
         pip install numpy
         mkdir install${{ matrix.os }}Waf-Github
         python waf configure --prefix="$PWD/install${{ matrix.os }}Waf-Github" --enable-swig ${{ matrix.debugging }}
-    - name: configure_without_swig
-      if: ${{ matrix.os == 'windows-2019' }}
-      run: |
-        pip install numpy
-        mkdir install${{ matrix.os }}Waf-Github
-        python waf configure --prefix="$PWD/install${{ matrix.os }}Waf-Github" ${{ matrix.debugging }}
     - name: build
       run: |
         python waf build

--- a/.github/workflows/build_unittest.yml
+++ b/.github/workflows/build_unittest.yml
@@ -168,7 +168,7 @@ jobs:
   build-waf:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [windows-latest, ubuntu-22.04]
         python-version: ['3.7']
         debugging: ['--enable-debugging', '']
     name: ${{ matrix.os }}-${{ matrix.python-version }}-waf${{ matrix.debugging }}
@@ -187,6 +187,12 @@ jobs:
         pip install numpy
         mkdir install${{ matrix.os }}Waf-Github
         python waf configure --prefix="$PWD/install${{ matrix.os }}Waf-Github" --enable-swig ${{ matrix.debugging }}
+    - name: configure_without_swig
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        pip install numpy
+        mkdir install${{ matrix.os }}Waf-Github
+        python waf configure --prefix="$PWD/install${{ matrix.os }}Waf-Github" ${{ matrix.debugging }}
     - name: build
       run: |
         python waf build

--- a/modules/c++/math.poly/include/math/poly/Fixed1D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed1D.h
@@ -187,6 +187,36 @@ public:
     }
 
     /*!
+     *  Evaluate the 1st derivative of our polynomial at 'at'
+     */
+    _T velocity(double at) const
+    {
+        _T rv{};
+        double atPower = 1;
+        for (size_t i = 1; i <= _Order; i++)
+        {
+            rv += static_cast<double>(i) * mCoef[i]*atPower;
+            atPower *= at;
+        }
+        return rv;
+    }
+
+    /*!
+     *  Evaluate the 2nd derivative of our polynomial at 'at'
+     */
+    _T acceleration(double at) const
+    {
+        _T rv{};
+        double atPower = 1;
+        for (size_t i = 2; i <= _Order; i++)
+        {
+            rv += static_cast<double>((i - 1) * i) * mCoef[i]*atPower;
+            atPower *= at;
+        }
+        return rv;
+    }
+
+    /*!
      *  Integrate between start and end
      *
      */

--- a/modules/c++/math.poly/include/math/poly/Fixed1D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed1D.h
@@ -137,8 +137,8 @@ public:
         }
     }
 
-    inline size_t order() const { return _Order; }
-    inline size_t size() const { return _Order + 1; }
+    constexpr inline size_t order() const { return _Order; }
+    constexpr inline size_t size() const { return _Order + 1; }
 
     /*!
      *

--- a/modules/c++/math.poly/include/math/poly/Fixed2D.h
+++ b/modules/c++/math.poly/include/math/poly/Fixed2D.h
@@ -95,8 +95,10 @@ public:
         return *this;
     }
 
-    size_t orderX() const { return _OrderX; }
-    size_t orderY() const { return _OrderY; }
+    constexpr size_t orderX() const { return _OrderX; }
+    constexpr size_t orderY() const { return _OrderY; }
+    constexpr size_t sizeX() const { return _OrderX + 1; }
+    constexpr size_t sizeY() const { return _OrderY + 1; }
 
     inline const std::array<Fixed1D<_OrderY, _T>, _OrderX+1>& coeffs() const
     {

--- a/modules/c++/math.poly/include/math/poly/OneD.hpp
+++ b/modules/c++/math.poly/include/math/poly/OneD.hpp
@@ -155,17 +155,32 @@ OneD< math::linear::VectorN<3, double> >::derivative() const
 
 template<typename _T>
 _T
-OneD<_T>::velocity(double x) const
+OneD<_T>::velocity(double at) const
 {
-    return derivative()(x);
+    _T ret{};
+   double atPwr = 1.0;
+   const auto sz = mCoef.size();
+   for (size_t i = 1 ; i < sz; i++)
+   {
+      ret += static_cast<double>(i) * mCoef[i]*atPwr;
+      atPwr *= at;
+   }
+   return ret;
 }
 
 template<typename _T>
 _T
-OneD<_T>::acceleration(double x) const
+OneD<_T>::acceleration(double at) const
 {
-    return derivative().derivative()(x);
-
+    _T ret{};
+   double atPwr = 1.0;
+   const auto sz = mCoef.size();
+   for (size_t i = 2 ; i < sz; i++)
+   {
+      ret += static_cast<double>(i * (i - 1)) * mCoef[i]*atPwr;
+      atPwr *= at;
+   }
+   return ret;
 }
 
 template<typename _T>

--- a/modules/c++/math.poly/unittests/test_1d_poly.cpp
+++ b/modules/c++/math.poly/unittests/test_1d_poly.cpp
@@ -146,9 +146,83 @@ TEST_CASE(testTransformInput)
     }
 }
 
+TEST_CASE(testVelocity)
+{
+    std::vector<double> values;
+    getRandValues(values);
+
+    // Constant poly should have 0 velocity
+    math::poly::OneD<double> poly(getRandPoly(0));
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.velocity(val), 0.0);
+    }
+
+    // Linear poly should have constant velocity
+    poly = getRandPoly(1);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.velocity(val), poly[1]);
+    }
+
+    // Check quadratic and cubic against the derivative
+    poly = getRandPoly(2);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.velocity(val), poly.derivative()(val));
+    }
+
+    poly = getRandPoly(3);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.velocity(val), poly.derivative()(val));
+    }
+}
+
+TEST_CASE(testAcceleration)
+{
+    std::vector<double> values;
+    getRandValues(values);
+
+    // Constant and linear polys should have 0 acceleration
+    math::poly::OneD<double> poly(getRandPoly(0));
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.acceleration(val), 0.0);
+    }
+
+    poly = getRandPoly(1);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.acceleration(val), 0);
+    }
+
+    // Quadratic poly should have constant acceleration
+    poly = getRandPoly(2);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.acceleration(val), 2 * poly[2]);
+    }
+    
+    // Check cubic and quartic against the 2nd derivative
+    poly = getRandPoly(3);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.acceleration(val), poly.derivative().derivative()(val));
+    }
+
+    poly = getRandPoly(4);
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(poly.acceleration(val), poly.derivative().derivative()(val));
+    }
+}
+
 TEST_MAIN(
     TEST_CHECK(testScaleVariable);
     TEST_CHECK(testTruncateTo);
     TEST_CHECK(testTruncateToNonZeros);
     TEST_CHECK(testTransformInput);
-    )
+    TEST_CHECK(testVelocity);
+    TEST_CHECK(testAcceleration);
+)

--- a/modules/c++/math.poly/unittests/test_fixed_1d_poly.cpp
+++ b/modules/c++/math.poly/unittests/test_fixed_1d_poly.cpp
@@ -26,8 +26,8 @@
 #include <math/poly/Fixed1D.h>
 #include "TestCase.h"
 
-static const size_t ORDER = 5;
-typedef math::poly::Fixed1D<ORDER, double> TestFixed1D;
+template<size_t ORDER>
+using Fixed1D = math::poly::Fixed1D<ORDER, double>;
 
 double getRand()
 {
@@ -37,9 +37,10 @@ double getRand()
     return (50.0 * rand() / RAND_MAX - 25.0);
 }
 
-TestFixed1D getRandPoly()
+template<size_t ORDER>
+Fixed1D<ORDER> getRandPoly()
 {
-    TestFixed1D poly;
+    Fixed1D<ORDER> poly;
     for (size_t ii = 0; ii <= ORDER; ++ii)
     {
         poly[ii] = getRand();
@@ -62,11 +63,11 @@ TEST_CASE(testScaleVariable)
     std::vector<double> value;
     getRandValues(value);
 
-    TestFixed1D poly(getRandPoly());
+    auto poly(getRandPoly<5>());
 
     // transformedPoly = poly(x * scale, y * scale)
     const double scale(13.34);
-    TestFixed1D transformedPoly = poly.scaleVariable(scale);
+    auto transformedPoly = poly.scaleVariable(scale);
 
     for (size_t ii = 0; ii < value.size(); ++ii)
     {
@@ -80,6 +81,80 @@ TEST_CASE(testScaleVariable)
     }
 }
 
+TEST_CASE(testVelocity)
+{
+    std::vector<double> values;
+    getRandValues(values);
+
+    // 0 poly should have 0 velocity
+    auto constPoly(getRandPoly<0>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(constPoly.velocity(val), 0.0);
+    }
+
+    // 1 poly should have 0 velocity
+    auto linearPoly(getRandPoly<1>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(linearPoly.velocity(val), linearPoly[1]);
+    }
+
+    // Check quadratic and cubic against the derivative
+    auto quadraticPoly(getRandPoly<2>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(quadraticPoly.velocity(val), quadraticPoly.derivative()(val));
+    }
+
+    auto cubicPoly(getRandPoly<3>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(cubicPoly.velocity(val), cubicPoly.derivative()(val));
+    }
+}
+
+TEST_CASE(testAcceleration)
+{
+    std::vector<double> values;
+    getRandValues(values);
+
+    // 0 and 1 polys should have 0 acceleration
+    auto constPoly(getRandPoly<0>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(constPoly.acceleration(val), 0.0);
+    }
+
+    auto linearPoly(getRandPoly<1>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(linearPoly.acceleration(val), 0.0);
+    }
+
+    // Quadratic poly should have 0 acceleration
+    auto quadraticPoly(getRandPoly<2>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(quadraticPoly.acceleration(val), 2 * quadraticPoly[2]);
+    }
+    
+    // Check cubic and quartic against the 2nd derivative
+    auto cubicPoly(getRandPoly<3>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(cubicPoly.acceleration(val), cubicPoly.derivative().derivative()(val));
+    }
+
+    auto quarticPoly(getRandPoly<4>());
+    for (const auto& val: values)
+    {
+        TEST_ASSERT_EQ(quarticPoly.acceleration(val), quarticPoly.derivative().derivative()(val));
+    }
+}
+
 TEST_MAIN(
     TEST_CHECK(testScaleVariable);
+    TEST_CHECK(testVelocity);
+    TEST_CHECK(testAcceleration);
 )

--- a/modules/c++/math.poly/unittests/test_fixed_1d_poly.cpp
+++ b/modules/c++/math.poly/unittests/test_fixed_1d_poly.cpp
@@ -86,14 +86,14 @@ TEST_CASE(testVelocity)
     std::vector<double> values;
     getRandValues(values);
 
-    // 0 poly should have 0 velocity
+    // Constant poly should have 0 velocity
     auto constPoly(getRandPoly<0>());
     for (const auto& val: values)
     {
         TEST_ASSERT_EQ(constPoly.velocity(val), 0.0);
     }
 
-    // 1 poly should have 0 velocity
+    // Linear poly should have constant velocity
     auto linearPoly(getRandPoly<1>());
     for (const auto& val: values)
     {
@@ -119,7 +119,7 @@ TEST_CASE(testAcceleration)
     std::vector<double> values;
     getRandValues(values);
 
-    // 0 and 1 polys should have 0 acceleration
+    // Constant and linear polys should have 0 acceleration
     auto constPoly(getRandPoly<0>());
     for (const auto& val: values)
     {
@@ -132,7 +132,7 @@ TEST_CASE(testAcceleration)
         TEST_ASSERT_EQ(linearPoly.acceleration(val), 0.0);
     }
 
-    // Quadratic poly should have 0 acceleration
+    // Quadratic poly should have constant acceleration
     auto quadraticPoly(getRandPoly<2>());
     for (const auto& val: values)
     {


### PR DESCRIPTION
My initial goal here was to add `velocity` and `acceleration` functions to the `Fixed1D` polynomial which were similar to the `OneD` versions. After looking closer at the [current implementation](https://github.com/mdaus/coda-oss/blob/036b17d68e937ebf45189cbb7728e82e2877eef3/modules/c%2B%2B/math.poly/include/math/poly/OneD.hpp#L156-L161) I thought it would probably be more performant to directly evaluate the velocity and acceleration from the existing coefficients instead of creating a new polynomial (or two in the case of the acceleration) and then evaluating that. 

I refactored the two functions in `OneD` poly and added them to the `Fixed1D`, then made a simple micro-benchmark test which checked the new  values matched the old then called each version a bunch of times and reported the total execution time of the loop (compiled with `-DCMAKE_BUILD_TYPE=Release` and `volatile` keyword on the loop calculation to prevent the compiler from optimizing out the value). 

Results with `OneD<double>` seem quite good
```
N_Trial = 10000, Poly Order = 5
------------ Old Stuff ------------
     Velocity: 650876 nanoseconds
 Acceleration: 1239871 nanoseconds
------------ New Stuff ------------
     Velocity: 41146 nanoseconds (~16x faster)
 Acceleration: 49426 nanoseconds (~25x faster)
```
Results with `Fixed1D<5, double>` are less convincing
```
N_Trial = 10000, Poly Order = 5
------------ Old Stuff ------------
     Velocity: 2652 nanoseconds
 Acceleration: 5187 nanoseconds
------------ New Stuff ------------
     Velocity: 2628 nanoseconds
 Acceleration: 2619 nanoseconds
```
* Since the `Fixed1D` is backed by a `std::array` the compiler can do a lot more work for us. Still with the `acceleration` method we get about double the performance. 
