### PR TITLE
Updates for newer MSVC in github

### DIFF
--- a/modules/c++/gsl/include/gsl/assert
+++ b/modules/c++/gsl/include/gsl/assert
@@ -46,14 +46,15 @@
 // Hopefully temporary until suppression standardization occurs
 //
 #if defined(__clang__)
-#define GSL_SUPPRESS(x) [[gsl::suppress("x")]]
-#else
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && _MSC_VER >= 1950
+// Visual Studio versions after 2022 (_MSC_VER > 1944) support the justification message.
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
 #define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
 #else
 #define GSL_SUPPRESS(x)
-#endif // _MSC_VER
-#endif // __clang__
+#endif // defined(__clang__)
 
 #define GSL_STRINGIFY_DETAIL(x) #x
 #define GSL_STRINGIFY(x) GSL_STRINGIFY_DETAIL(x)

--- a/modules/c++/gsl/include/gsl/byte
+++ b/modules/c++/gsl/include/gsl/byte
@@ -18,18 +18,19 @@
 #define GSL_BYTE_H
 
 //
-// make suppress attributes work for some compilers
+// make suppress attributes parse for some compilers
 // Hopefully temporary until suppression standardization occurs
 //
 #if defined(__clang__)
-#define GSL_SUPPRESS(x) [[gsl::suppress("x")]]
-#else
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && _MSC_VER >= 1950
+// Visual Studio versions after 2022 (_MSC_VER > 1944) support the justification message.
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
 #define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
 #else
 #define GSL_SUPPRESS(x)
-#endif // _MSC_VER
-#endif // __clang__
+#endif // defined(__clang__)
 
 #include <type_traits>
 

--- a/modules/drivers/gsl/GSL-4.0.0/include/gsl/assert
+++ b/modules/drivers/gsl/GSL-4.0.0/include/gsl/assert
@@ -46,14 +46,15 @@
 // Hopefully temporary until suppression standardization occurs
 //
 #if defined(__clang__)
-#define GSL_SUPPRESS(x) [[gsl::suppress("x")]]
-#else
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && _MSC_VER >= 1950
+// Visual Studio versions after 2022 (_MSC_VER > 1944) support the justification message.
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
 #define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
 #else
 #define GSL_SUPPRESS(x)
-#endif // _MSC_VER
-#endif // __clang__
+#endif // defined(__clang__)
 
 #define GSL_STRINGIFY_DETAIL(x) #x
 #define GSL_STRINGIFY(x) GSL_STRINGIFY_DETAIL(x)

--- a/modules/drivers/gsl/GSL-4.0.0/include/gsl/byte
+++ b/modules/drivers/gsl/GSL-4.0.0/include/gsl/byte
@@ -18,18 +18,19 @@
 #define GSL_BYTE_H
 
 //
-// make suppress attributes work for some compilers
+// make suppress attributes parse for some compilers
 // Hopefully temporary until suppression standardization occurs
 //
 #if defined(__clang__)
-#define GSL_SUPPRESS(x) [[gsl::suppress("x")]]
-#else
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && _MSC_VER >= 1950
+// Visual Studio versions after 2022 (_MSC_VER > 1944) support the justification message.
+#define GSL_SUPPRESS(x) [[gsl::suppress(#x)]]
+#elif defined(_MSC_VER) && !defined(__INTEL_COMPILER) && !defined(__NVCC__)
 #define GSL_SUPPRESS(x) [[gsl::suppress(x)]]
 #else
 #define GSL_SUPPRESS(x)
-#endif // _MSC_VER
-#endif // __clang__
+#endif // defined(__clang__)
 
 #include <type_traits>
 


### PR DESCRIPTION
Updating GSL_SUPPRESS manually from the latest Microsoft code to fix compile errors seen when upgrading from "MSVC 19.44.35225.0" to "MSVC 19.51.36248.0" in github runner

Code block copied from https://github.com/microsoft/GSL/blob/main/include/gsl/assert#L44C1-L57C29