### PR TITLE
Add function to set http headers in curl client

### DIFF
--- a/modules/c++/net/CMakeLists.txt
+++ b/modules/c++/net/CMakeLists.txt
@@ -18,4 +18,11 @@ if (TARGET re-c++)
         FILTER_LIST "AckMulticastSender.cpp" "AckMulticastSubscriber.cpp"
                     "MulticastSender.cpp" "MulticastSubscriber.cpp"
                     "SerializableTestClient.cpp")
+    
+    if (CURL_FOUND)
+        coda_add_tests(
+            MODULE_NAME ${MODULE_NAME}
+            DIRECTORY "unittests"
+            UNITTEST)
+    endif()
 endif()

--- a/modules/c++/net/include/net/CurlHandle.h
+++ b/modules/c++/net/include/net/CurlHandle.h
@@ -28,6 +28,7 @@
 #ifdef NET_CURL_SUPPORT
 #include <curl/curl.h>
 #include <string>
+#include <vector>
 
 namespace net
 {
@@ -100,6 +101,20 @@ public:
     void setProxyPort(size_t port);
 
     /*
+     * \func setHttpHeaders
+     * \brief Sets custom HTTP headers for the request.
+     * 
+     * \param headers Vector of header strings in the "Header: Value" format.
+     */
+    void setHttpHeaders(const std::vector<std::string>& headers);
+
+    /*
+     * \func setPutRequest
+     * \brief Configures the handle to make PUT request.
+     */
+    void setPutRequest();
+
+    /*
      *  \func perform
      *  \brief Performs the underlying CURL call. Before call this, at a
      *         minimum you must also call setURL and setWriteBuffer.
@@ -125,6 +140,7 @@ private:
                                size_t nmemb,
                                std::string* writerData);
     CURL* const mHandle;
+    curl_slist* mHeaders;
 };
 }
 

--- a/modules/c++/net/include/net/CurlHandle.h
+++ b/modules/c++/net/include/net/CurlHandle.h
@@ -115,6 +115,14 @@ public:
     void setPutRequest();
 
     /*
+     * \func getHeaders
+     * \brief Gets the current HTTP headers list.
+     * 
+     * \return Vector of header strings. Empty vector if no headers are set.
+     */
+    std::vector<std::string> getHeaders() const;
+
+    /*
      *  \func perform
      *  \brief Performs the underlying CURL call. Before call this, at a
      *         minimum you must also call setURL and setWriteBuffer.

--- a/modules/c++/net/source/CurlHandle.cpp
+++ b/modules/c++/net/source/CurlHandle.cpp
@@ -115,6 +115,18 @@ void CurlHandle::setPutRequest()
             "Setting PUT request");
 }
 
+std::vector<std::string> CurlHandle::getHeaders() const
+{
+    std::vector<std::string> result;
+    curl_slist* current = mHeaders;
+    while (current != nullptr)
+    {
+        result.push_back(std::string(current->data));
+        current = current->next;
+    }
+    return result;
+}
+
 void CurlHandle::perform()
 {
     verify(curl_easy_perform(mHandle), "curl_easy_perform()");

--- a/modules/c++/net/source/CurlHandle.cpp
+++ b/modules/c++/net/source/CurlHandle.cpp
@@ -29,7 +29,8 @@
 namespace net
 {
 CurlHandle::CurlHandle() :
-    mHandle(curl_easy_init())
+    mHandle(curl_easy_init()),
+    mHeaders(nullptr)
 {
     if (mHandle == nullptr)
     {
@@ -39,6 +40,10 @@ CurlHandle::CurlHandle() :
 
 CurlHandle::~CurlHandle()
 {
+    if (mHeaders != nullptr)
+    {
+        curl_slist_free_all(mHeaders);
+    }
     curl_easy_cleanup(mHandle);
 }
 
@@ -82,6 +87,32 @@ void CurlHandle::setProxyPort(size_t port)
 {
     verify(curl_easy_setopt(mHandle, CURLOPT_PROXYPORT, static_cast<long>(port)),
             "Setting proxy port");
+}
+
+void CurlHandle::setHttpHeaders(const std::vector<std::string>& headers)
+{
+    if (mHeaders != nullptr)
+    {
+        curl_slist_free_all(mHeaders);
+        mHeaders = nullptr;
+    }
+
+    for (const auto& header : headers)
+    {
+        mHeaders = curl_slist_append(mHeaders, header.c_str());
+    }
+
+    if (mHeaders != nullptr)
+    {
+        verify(curl_easy_setopt(mHandle, CURLOPT_HTTPHEADER, mHeaders),
+                "Setting HTTP headers");
+    }
+}
+
+void CurlHandle::setPutRequest()
+{
+    verify(curl_easy_setopt(mHandle, CURLOPT_CUSTOMREQUEST, "PUT"),
+            "Setting PUT request");
 }
 
 void CurlHandle::perform()

--- a/modules/c++/net/unittests/test_curl_handle.cpp
+++ b/modules/c++/net/unittests/test_curl_handle.cpp
@@ -1,0 +1,122 @@
+/* =========================================================================
+ * This file is part of net-c++
+ * =========================================================================
+ *
+ * (C) Copyright 2004 - 2017, MDA Information Systems LLC
+ *
+ * net-c++ is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; If not,
+ * see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <net/net_config.h>
+
+#ifdef NET_CURL_SUPPORT
+
+#include "TestCase.h"
+#include <net/CurlHandle.h>
+#include <vector>
+#include <string>
+
+TEST_CASE(testSetHttpHeaders)
+{
+    net::CurlHandle handle;
+    
+    // Test with empty headers - should not throw
+    std::vector<std::string> emptyHeaders;
+    handle.setHttpHeaders(emptyHeaders);
+    
+    // Test with single header - should not throw
+    std::vector<std::string> singleHeader{"Content-Type: application/json"};
+    handle.setHttpHeaders(singleHeader);
+    
+    // Test with multiple headers - should not throw
+    std::vector<std::string> multipleHeaders{
+        "Content-Type: application/json",
+        "Authorization: Bearer token123",
+        "User-Agent: TestClient/1.0"
+    };
+    handle.setHttpHeaders(multipleHeaders);
+    
+    // Test that headers can be replaced - should not throw
+    std::vector<std::string> newHeaders{"X-Custom-Header: value"};
+    handle.setHttpHeaders(newHeaders);
+    
+    TEST_SUCCESS;
+}
+
+// Test that setPutRequest doesn't throw
+TEST_CASE(testSetPutRequest)
+{
+    net::CurlHandle handle;
+    handle.setPutRequest();
+
+    TEST_SUCCESS;
+}
+
+// Test combining setPutRequest with setHttpHeaders - should not throw
+TEST_CASE(testSetPutRequestWithHeaders)
+{
+    net::CurlHandle handle;
+    std::vector<std::string> headers{
+        "Content-Type: text/plain",
+        "Content-Length: 0"
+    };
+    
+    handle.setHttpHeaders(headers);
+    handle.setPutRequest();
+    
+    TEST_SUCCESS;
+}
+
+// Test that multiple handles can be configured independently
+TEST_CASE(testMultipleHandlesIndependent)
+{
+    net::CurlHandle handle1;
+    net::CurlHandle handle2;
+    
+    std::vector<std::string> headers1{"X-Handle: 1"};
+    std::vector<std::string> headers2{"X-Handle: 2"};
+    
+    handle1.setHttpHeaders(headers1);
+    handle2.setHttpHeaders(headers2);
+    handle1.setPutRequest();
+    
+    TEST_SUCCESS;
+}
+
+// Test that calling setHttpHeaders multiple times properly replaces headers
+TEST_CASE(testSetHeadersMultipleTimes)
+{
+    net::CurlHandle handle;
+    std::vector<std::string> firstHeaders{"X-First: 1"};
+    handle.setHttpHeaders(firstHeaders);
+    
+    std::vector<std::string> secondHeaders{"X-Second: 2"};
+    handle.setHttpHeaders(secondHeaders);
+    
+    std::vector<std::string> thirdHeaders{"X-Third: 3", "X-Fourth: 4"};
+    handle.setHttpHeaders(thirdHeaders);
+    
+    TEST_SUCCESS;
+}
+
+TEST_MAIN(
+    TEST_CHECK(testSetHttpHeaders);
+    TEST_CHECK(testSetPutRequest);
+    TEST_CHECK(testSetPutRequestWithHeaders);
+    TEST_CHECK(testMultipleHandlesIndependent);
+    TEST_CHECK(testSetHeadersMultipleTimes);
+)
+#endif

--- a/modules/c++/net/unittests/test_curl_handle.cpp
+++ b/modules/c++/net/unittests/test_curl_handle.cpp
@@ -28,30 +28,56 @@
 #include <net/CurlHandle.h>
 #include <vector>
 #include <string>
+#include <algorithm>
+
+
+namespace
+{
+static bool headerExists(const std::vector<std::string>& headers, const std::string& header)
+{
+    return std::find(headers.begin(), headers.end(), header) != headers.end();
+}
+}
 
 TEST_CASE(testSetHttpHeaders)
 {
     net::CurlHandle handle;
     
-    // Test with empty headers - should not throw
+    // Test with empty headers - should result in empty vector
     std::vector<std::string> emptyHeaders;
     handle.setHttpHeaders(emptyHeaders);
+    std::vector<std::string> headers = handle.getHeaders();
+    TEST_ASSERT_TRUE(headers.empty());
     
-    // Test with single header - should not throw
+    // Test with single header
     std::vector<std::string> singleHeader{"Content-Type: application/json"};
     handle.setHttpHeaders(singleHeader);
+    headers = handle.getHeaders();
+    TEST_ASSERT_EQ(headers.size(), static_cast<size_t>(1));
+    TEST_ASSERT_TRUE(headerExists(headers, "Content-Type: application/json"));
     
-    // Test with multiple headers - should not throw
+    // Test with multiple headers
     std::vector<std::string> multipleHeaders{
         "Content-Type: application/json",
         "Authorization: Bearer token123",
         "User-Agent: TestClient/1.0"
     };
     handle.setHttpHeaders(multipleHeaders);
+    headers = handle.getHeaders();
+    TEST_ASSERT_EQ(headers.size(), static_cast<size_t>(3));
+    TEST_ASSERT_TRUE(headerExists(headers, "Content-Type: application/json"));
+    TEST_ASSERT_TRUE(headerExists(headers, "Authorization: Bearer token123"));
+    TEST_ASSERT_TRUE(headerExists(headers, "User-Agent: TestClient/1.0"));
     
-    // Test that headers can be replaced - should not throw
+    // Test that headers can be replaced
     std::vector<std::string> newHeaders{"X-Custom-Header: value"};
     handle.setHttpHeaders(newHeaders);
+    headers = handle.getHeaders();
+    TEST_ASSERT_EQ(headers.size(), static_cast<size_t>(1));
+    TEST_ASSERT_TRUE(headerExists(headers, "X-Custom-Header: value"));
+    // Old headers should not exist
+    TEST_ASSERT_FALSE(headerExists(headers, "Content-Type: application/json"));
+    TEST_ASSERT_FALSE(headerExists(headers, "Authorization: Bearer token123"));
     
     TEST_SUCCESS;
 }
@@ -65,7 +91,7 @@ TEST_CASE(testSetPutRequest)
     TEST_SUCCESS;
 }
 
-// Test combining setPutRequest with setHttpHeaders - should not throw
+// Test combining setPutRequest with setHttpHeaders
 TEST_CASE(testSetPutRequestWithHeaders)
 {
     net::CurlHandle handle;
@@ -75,9 +101,17 @@ TEST_CASE(testSetPutRequestWithHeaders)
     };
     
     handle.setHttpHeaders(headers);
+    std::vector<std::string> retrievedHeaders = handle.getHeaders();
+    TEST_ASSERT_EQ(retrievedHeaders.size(), 2);
+    TEST_ASSERT_TRUE(headerExists(retrievedHeaders, "Content-Type: text/plain"));
+    TEST_ASSERT_TRUE(headerExists(retrievedHeaders, "Content-Length: 0"));
+    
     handle.setPutRequest();
     
-    TEST_SUCCESS;
+    // Headers should still be set after setPutRequest
+    retrievedHeaders = handle.getHeaders();
+    TEST_ASSERT_EQ(retrievedHeaders.size(), 2);
+    
 }
 
 // Test that multiple handles can be configured independently
@@ -93,6 +127,18 @@ TEST_CASE(testMultipleHandlesIndependent)
     handle2.setHttpHeaders(headers2);
     handle1.setPutRequest();
     
+    // Verify handle1 headers
+    std::vector<std::string> h1Headers = handle1.getHeaders();
+    TEST_ASSERT_EQ(h1Headers.size(), 1);
+    TEST_ASSERT_TRUE(headerExists(h1Headers, "X-Handle: 1"));
+    TEST_ASSERT_FALSE(headerExists(h1Headers, "X-Handle: 2"));
+    
+    // Verify handle2 headers
+    std::vector<std::string> h2Headers = handle2.getHeaders();
+    TEST_ASSERT_EQ(h2Headers.size(), 1);
+    TEST_ASSERT_TRUE(headerExists(h2Headers, "X-Handle: 2"));
+    TEST_ASSERT_FALSE(headerExists(h2Headers, "X-Handle: 1"));
+    
     TEST_SUCCESS;
 }
 
@@ -100,16 +146,28 @@ TEST_CASE(testMultipleHandlesIndependent)
 TEST_CASE(testSetHeadersMultipleTimes)
 {
     net::CurlHandle handle;
+    
     std::vector<std::string> firstHeaders{"X-First: 1"};
     handle.setHttpHeaders(firstHeaders);
+    std::vector<std::string> headers = handle.getHeaders();
+    TEST_ASSERT_EQ(headers.size(), 1);
+    TEST_ASSERT_TRUE(headerExists(headers, "X-First: 1"));
     
     std::vector<std::string> secondHeaders{"X-Second: 2"};
     handle.setHttpHeaders(secondHeaders);
+    headers = handle.getHeaders();
+    TEST_ASSERT_EQ(headers.size(), 1);
+    TEST_ASSERT_TRUE(headerExists(headers, "X-Second: 2"));
+    TEST_ASSERT_FALSE(headerExists(headers, "X-First: 1"));
     
     std::vector<std::string> thirdHeaders{"X-Third: 3", "X-Fourth: 4"};
     handle.setHttpHeaders(thirdHeaders);
-    
-    TEST_SUCCESS;
+    headers = handle.getHeaders();
+    TEST_ASSERT_EQ(headers.size(), 2);
+    TEST_ASSERT_TRUE(headerExists(headers, "X-Third: 3"));
+    TEST_ASSERT_TRUE(headerExists(headers, "X-Fourth: 4"));
+    TEST_ASSERT_FALSE(headerExists(headers, "X-Second: 2"));
+    TEST_ASSERT_FALSE(headerExists(headers, "X-First: 1"));
 }
 
 TEST_MAIN(

--- a/modules/c++/net/unittests/test_curl_handle.cpp
+++ b/modules/c++/net/unittests/test_curl_handle.cpp
@@ -79,7 +79,6 @@ TEST_CASE(testSetHttpHeaders)
     TEST_ASSERT_FALSE(headerExists(headers, "Content-Type: application/json"));
     TEST_ASSERT_FALSE(headerExists(headers, "Authorization: Bearer token123"));
     
-    TEST_SUCCESS;
 }
 
 // Test that setPutRequest doesn't throw
@@ -111,7 +110,6 @@ TEST_CASE(testSetPutRequestWithHeaders)
     // Headers should still be set after setPutRequest
     retrievedHeaders = handle.getHeaders();
     TEST_ASSERT_EQ(retrievedHeaders.size(), 2);
-    
 }
 
 // Test that multiple handles can be configured independently
@@ -138,8 +136,6 @@ TEST_CASE(testMultipleHandlesIndependent)
     TEST_ASSERT_EQ(h2Headers.size(), 1);
     TEST_ASSERT_TRUE(headerExists(h2Headers, "X-Handle: 2"));
     TEST_ASSERT_FALSE(headerExists(h2Headers, "X-Handle: 1"));
-    
-    TEST_SUCCESS;
 }
 
 // Test that calling setHttpHeaders multiple times properly replaces headers


### PR DESCRIPTION
Recently high side AWS enabled Amazon EC2 Instance Metadata Service Version 2 (IMDSv2) for all instances which requires us to set a HTTP header when we make a request to the instance metadata endpoint.  This enables a way for us to set that header as well as adding a unit test around the two new methods